### PR TITLE
client: bundle Windows launcher, .env config, and compaction/isolation fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env (gitignored) and fill in your values. The Windows launcher
+# scripts/claude-ds4.cmd loads this file at startup.
+
+# --- ds4 client (Windows launcher) ---
+
+# Point the launcher at your Mac's ds4 server so Claude Code reaches it. Without
+# it the launcher warns and falls back to http://localhost:8000, which does not
+# reach the Mac. Does not change the model or auth token.
+# Format: http://<host>:<port> — e.g. DS4_ANTHROPIC_BASE_URL=http://<mac-lan-ip>:8000
+DS4_ANTHROPIC_BASE_URL=http://localhost:8000
+
+# Override the auth token sent to ds4. ds4 does not authenticate, so any non-empty
+# value works; omit to use the built-in default. Does not affect the base URL.
+# Format: any non-empty string — e.g. DS4_API_KEY=dsv4-local
+DS4_API_KEY=dsv4-local

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 *.bak
+.env

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Standard layout (mirrors the agents-repo convention):
 | [docs/history.md](docs/history.md) | Completed work with why — incidents (write storm, sleep freeze) and decisions |
 | [docs/infrastructure.md](docs/infrastructure.md) | SSOT for hosts, network, ports, paths |
 | [scripts/ds4-start.sh](scripts/ds4-start.sh) | Canonical Mac start script |
+| [scripts/claude-ds4.cmd](scripts/claude-ds4.cmd) | Windows client launcher — loads `.env`, sets ds4 env, isolates the VS Code process, launches VS Code |
+| [.env.example](.env.example) | Template for the gitignored `.env` — Windows client `DS4_ANTHROPIC_BASE_URL` (Mac IP) and `DS4_API_KEY` |
 
 ## Quick start
 
@@ -32,8 +34,14 @@ git -C ~/git/ds4 pull                 # update the antirez/ds4 build clone if ne
 ~/git/ds4-ops/scripts/ds4-start.sh
 ```
 
-**Windows (client):** set the env in [docs/ops.md](docs/ops.md#client-windows),
-then run `claude`.
+**Windows (client):** put the Mac's IP in a gitignored `.env` (first time only), then run the
+bundled launcher (loads `.env`, sets the ds4 env, isolates the VS Code process, opens VS Code):
+```bat
+copy .env.example .env
+rem edit .env: DS4_ANTHROPIC_BASE_URL=http://<mac-ip>:8000
+scripts\claude-ds4.cmd .
+```
+See [docs/ops.md](docs/ops.md#client-windows) for details and the terminal alternative.
 
 ## Configuration at a glance
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,8 +30,19 @@ Mechanics and exact values: [tuning.md](tuning.md).
 - **Hybrid (router)** — to send planning to *real* Anthropic Opus while implementation stays
   on ds4, a proxy (claude-code-router) is required. `ANTHROPIC_BASE_URL` is process-global,
   so env vars alone can rewrite the model name but cannot split the destination. The router
-  is an extra always-on service and a critical-path dependency; take it only if ds4's
-  thinking-on quality is judged insufficient for planning.
+  is an extra always-on service and a critical-path dependency. It also **cannot preserve a
+  fixed-price subscription**: Anthropic's 2026-02 legal-and-compliance terms bar OAuth tokens
+  outside official clients, and server-side enforcement (2026-04) blocks OAuth-passthrough
+  proxies (the known tools — LiteLLM header-forwarding, anthropic-max-router, meridian — were
+  non-functional for this as of 2026-04). A
+  router therefore bills the Anthropic leg as **metered API**, not subscription — take it only
+  if metered planning is acceptable and ds4's thinking-on quality is judged insufficient.
+
+Running native (subscription) Claude Code and ds4 side by side on one machine is a *process*
+concern, not a routing one, and does not need a router: a bare `ANTHROPIC_BASE_URL` with a
+credential already replaces the subscription, and VS Code shares one environment across all
+windows of a user-data-dir. The two are kept apart by launching the ds4 window in an isolated
+VS Code process (`--user-data-dir`). Procedure: [ops.md](ops.md#client-windows).
 
 ## Context window is a structural mismatch
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -35,7 +35,8 @@ Then launch VS Code with the ds4 backend via the bundled wrapper:
 scripts\claude-ds4.cmd .
 ```
 The wrapper loads `.env`, then sets the ds4 env (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`,
-the `deepseek-v4-flash` model aliases, and `CLAUDE_CODE_AUTO_COMPACT_WINDOW=393216` /
+the `deepseek-v4-flash` model aliases (the haiku tier uses the non-thinking `deepseek-chat`),
+and `CLAUDE_CODE_AUTO_COMPACT_WINDOW=393216` /
 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75`), then launches VS Code. If `DS4_ANTHROPIC_BASE_URL` is set
 in neither `.env` nor the shell, the wrapper warns and falls back to `localhost` (a placeholder
 that will not reach the Mac). A value set in the shell takes precedence over `.env`. `DS4_API_KEY`

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -24,17 +24,45 @@ kill "$(pgrep -f ds4-server)"
 
 ## Client (Windows)
 
-Set per-session env, then launch Claude Code:
-```powershell
-$env:ANTHROPIC_BASE_URL = "http://<mac-ip>:8000"
-$env:ANTHROPIC_AUTH_TOKEN = "dummy"
-$env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = "393216"
-$env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "75"
-claude
+First time only, create the repo-root `.env` from the template and put the Mac's LAN IP in it
+(the IP is never committed — `.env` is gitignored):
+```bat
+copy .env.example .env
+rem then edit .env: DS4_ANTHROPIC_BASE_URL=http://<mac-ip>:8000
 ```
+Then launch VS Code with the ds4 backend via the bundled wrapper:
+```bat
+scripts\claude-ds4.cmd .
+```
+The wrapper loads `.env`, then sets the ds4 env (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`,
+the `deepseek-v4-flash` model aliases, and `CLAUDE_CODE_AUTO_COMPACT_WINDOW=393216` /
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75`), then launches VS Code. If `DS4_ANTHROPIC_BASE_URL` is set
+in neither `.env` nor the shell, the wrapper warns and falls back to `localhost` (a placeholder
+that will not reach the Mac). A value set in the shell takes precedence over `.env`. `DS4_API_KEY`
+overrides the auth token; ds4 does not authenticate, so any non-empty value works.
+
+**Isolation from native (subscription) VS Code:** the wrapper passes
+`--user-data-dir "%LOCALAPPDATA%\vscode-ds4"`, starting a *separate* VS Code process. VS Code
+shares one process — and thus one environment — across every window under the same
+user-data-dir, so without this flag the ds4 env bleeds into native subscription windows. The
+separate profile keeps the ds4 session and native `code` / `codes` sessions independent on the
+same machine. Extensions are shared (`--user-data-dir` isolates settings/state, not
+`~/.vscode/extensions`), so the Claude Code extension is already available in the ds4 profile.
+Do not add ds4 env vars to native sessions: a bare `ANTHROPIC_BASE_URL` plus a credential
+replaces the subscription (see
+[architecture.md](architecture.md#two-strategies-chosen-by-whether-real-opus-is-wanted)).
+Caveat: if a ds4 window is already open, close it before changing `DS4_ANTHROPIC_BASE_URL` —
+VS Code reuses the running process for that profile and keeps the old environment.
+
+Terminal alternative (no VS Code): set the same env vars the wrapper does
+(see [scripts/claude-ds4.cmd](../scripts/claude-ds4.cmd) for the full list) and run `claude`.
 
 Optional per-tier thinking split: also set the `ANTHROPIC_DEFAULT_*_MODEL` vars from
 [tuning.md](tuning.md#per-tier-thinking-split-without-a-router-optional).
+
+**Verify connectivity:** after launch, run `/context` and confirm CC reports a window near
+393216 (not 200K / 1M). Grow the conversation and confirm auto-compaction fires *before* ds4
+returns `400 context_length_exceeded`.
 
 ## Monitoring (Mac)
 

--- a/scripts/claude-ds4.cmd
+++ b/scripts/claude-ds4.cmd
@@ -1,0 +1,60 @@
+@echo off
+setlocal
+
+rem ds4 client launcher (Windows). Sets the ds4 backend env, isolates the VS Code
+rem process so the env does not bleed into native subscription windows, then launches
+rem VS Code. Rationale: docs/architecture.md; procedure: docs/ops.md#client-windows.
+
+rem Load the repo-root .env (gitignored) so the real Mac LAN IP is never committed.
+rem Format: KEY=value, one per line, # comment lines allowed. A value already set in
+rem the shell takes precedence over .env. See .env.example for the supported keys.
+set "DS4_ENV_FILE=%~dp0..\.env"
+if exist "%DS4_ENV_FILE%" (
+    for /f "usebackq eol=# tokens=1,* delims==" %%A in ("%DS4_ENV_FILE%") do (
+        if not defined %%A set "%%A=%%B"
+    )
+)
+
+rem Clear any real Anthropic API key so the ds4 server is used instead
+set ANTHROPIC_API_KEY=
+
+rem ds4 server base URL. The real Mac LAN IP is NOT committed (public repo): put
+rem DS4_ANTHROPIC_BASE_URL=http://<mac-ip>:8000 in the repo-root .env (or set it in the
+rem shell). The default below is a placeholder (localhost) and will not reach the Mac.
+if defined DS4_ANTHROPIC_BASE_URL (
+    set ANTHROPIC_BASE_URL=%DS4_ANTHROPIC_BASE_URL%
+) else (
+    echo [claude-ds4] WARNING: DS4_ANTHROPIC_BASE_URL not set; using placeholder default http://localhost:8000 ^(will not reach the Mac ds4 server^).
+    set ANTHROPIC_BASE_URL=http://localhost:8000
+)
+
+rem ds4 server auth token. ds4 does not authenticate, so any non-empty value works
+rem (override with DS4_API_KEY env var).
+if defined DS4_API_KEY (
+    set ANTHROPIC_AUTH_TOKEN=%DS4_API_KEY%
+) else (
+    set ANTHROPIC_AUTH_TOKEN=dsv4-local
+)
+
+set ANTHROPIC_MODEL=deepseek-v4-flash
+set ANTHROPIC_CUSTOM_MODEL_OPTION=deepseek-v4-flash
+set ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=DeepSeek V4 Flash local ds4
+set ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION=ds4.c local GGUF
+set ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-flash
+set ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash
+set ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-flash
+set CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash
+
+set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+set CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1
+set CLAUDE_STREAM_IDLE_TIMEOUT_MS=600000
+
+rem Align auto-compaction with ds4's real ceiling so it fires before ds4 rejects the
+rem conversation with 400 context_length_exceeded. Values: docs/tuning.md.
+set CLAUDE_CODE_AUTO_COMPACT_WINDOW=393216
+set CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75
+
+rem Launch VS Code in an isolated process. A distinct --user-data-dir starts a separate
+rem VS Code instance; VS Code otherwise shares one process (and one environment) across
+rem all windows of a user-data-dir, which would leak the ds4 env into native windows.
+code --user-data-dir "%LOCALAPPDATA%\vscode-ds4" %*

--- a/scripts/claude-ds4.cmd
+++ b/scripts/claude-ds4.cmd
@@ -41,7 +41,9 @@ set ANTHROPIC_CUSTOM_MODEL_OPTION=deepseek-v4-flash
 set ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=DeepSeek V4 Flash local ds4
 set ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION=ds4.c local GGUF
 set ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-flash
-set ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash
+rem Haiku is the lightweight/mechanical tier (titles, quick background tasks); map it to the
+rem non-thinking alias so it stays fast and cheap. Thinking-control model names: docs/tuning.md.
+set ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-chat
 set ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-flash
 set CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash
 


### PR DESCRIPTION
## Summary

Brings the Windows ds4 client under repo management and fixes two client-side gaps found while setting it up.

- **Launcher migration**: `scripts/claude-ds4.cmd` (from an out-of-repo copy). Loads a gitignored repo-root `.env` for `DS4_ANTHROPIC_BASE_URL` (Mac LAN IP) and `DS4_API_KEY`; shell-set values take precedence. `.env.example` template added; real IP never committed.
- **Compaction alignment**: sets `CLAUDE_CODE_AUTO_COMPACT_WINDOW=393216` / `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75` so auto-compaction fires before ds4 returns `400 context_length_exceeded`.
- **VS Code process isolation**: `--user-data-dir "%LOCALAPPDATA%\vscode-ds4"` starts a separate VS Code process so the ds4 env stops bleeding into native (subscription) windows.
- **Docs**: corrected the architecture.md hybrid/router note (subscription-preserving 1-session hybrid is not achievable); updated ops.md client section and README.

Closes #2

<!-- issue-close-pr-of: 2 -->