### PR TITLE
feat(proxy): add ds4 reverse proxy with TLS termination, prompt normalization, and token auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,9 @@
 # Format: https://<host>:<port> — e.g. DS4_ANTHROPIC_BASE_URL=https://<mac-lan-ip>:8443
 DS4_ANTHROPIC_BASE_URL=https://localhost:8443
 
-# Points Node.js at the mkcert local CA so it trusts the proxy certificate.
-# Get the path from: mkcert -CAROOT (on the Mac), then append /rootCA.pem.
-# Format: absolute path — e.g. DS4_CA_CERT=/Users/<you>/Library/Application Support/mkcert/rootCA.pem
+# Points Node.js at your local mkcert root CA so it trusts the proxy certificate.
+# Use the same root CA that signed the proxy cert; get its path from mkcert -CAROOT, then append /rootCA.pem.
+# Format: absolute path — e.g. DS4_CA_CERT=C:\Users\<you>\AppData\Local\mkcert\rootCA.pem
 DS4_CA_CERT=
 
 # Override the auth token sent to the proxy. The proxy verifies this token; must

--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,31 @@
 # Copy to .env (gitignored) and fill in your values. The Windows launcher
-# scripts/code-ds4.cmd loads this file at startup.
+# scripts/code-ds4.cmd and the Mac proxy scripts/ds4-proxy.sh load this file at startup.
 
 # --- ds4 client (Windows launcher) ---
 
-# Point the launcher at your Mac's ds4 server so Claude Code reaches it. Without
-# it the launcher warns and falls back to http://localhost:8000, which does not
+# Point the launcher at your Mac's ds4 proxy so Claude Code reaches it. Without
+# it the launcher warns and falls back to https://localhost:8443, which does not
 # reach the Mac. Does not change the model or auth token.
-# Format: http://<host>:<port> — e.g. DS4_ANTHROPIC_BASE_URL=http://<mac-lan-ip>:8000
-DS4_ANTHROPIC_BASE_URL=http://localhost:8000
+# Format: https://<host>:<port> — e.g. DS4_ANTHROPIC_BASE_URL=https://<mac-lan-ip>:8443
+DS4_ANTHROPIC_BASE_URL=https://localhost:8443
 
-# Override the auth token sent to ds4. ds4 does not authenticate, so any non-empty
-# value works; omit to use the built-in default. Does not affect the base URL.
+# Points Node.js at the mkcert local CA so it trusts the proxy certificate.
+# Get the path from: mkcert -CAROOT (on the Mac), then append /rootCA.pem.
+# Format: absolute path — e.g. DS4_CA_CERT=/Users/<you>/Library/Application Support/mkcert/rootCA.pem
+DS4_CA_CERT=
+
+# Override the auth token sent to the proxy. The proxy verifies this token; must
+# match DS4_PROXY_AUTH_TOKEN on the Mac. Does not affect the base URL.
 # Format: any non-empty string — e.g. DS4_API_KEY=dsv4-local
 DS4_API_KEY=dsv4-local
+
+# --- ds4 proxy (Mac server side) ---
+
+# HTTPS port the proxy listens on. Must match the port in DS4_ANTHROPIC_BASE_URL.
+# Format: integer — e.g. DS4_PROXY_PORT=8443
+DS4_PROXY_PORT=8443
+
+# Token the proxy requires from every client request. Generate with: /create-key
+# Must match the DS4_API_KEY value in the Windows-side .env.
+# Format: any non-empty string — e.g. DS4_PROXY_AUTH_TOKEN=<generated-secret>
+DS4_PROXY_AUTH_TOKEN=

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,3 +63,35 @@ than push ds4 past its ceiling.
 
 - **MTP / speculative decoding** — upstream calls it experimental with at most a slight speedup.
 - **Distributed inference** — speeds prefill but slows decode and needs a second machine; wrong shape for interactive agent use.
+
+## Reverse proxy layer
+
+A Python asyncio reverse proxy (`proxy/`) sits between Claude Code (HTTPS client) and ds4 (plain HTTP on 127.0.0.1:8000). It serves three goals that cannot be achieved by env-var wiring alone.
+
+### Why TLS termination
+
+`ANTHROPIC_BASE_URL` is the only wiring point between Claude Code and ds4. Without TLS the full conversation — including prompts, tool calls, and model outputs — travels over plain HTTP on the local network. A self-signed mkcert certificate and `NODE_EXTRA_CA_CERTS` give full TLS without `NODE_TLS_REJECT_UNAUTHORIZED=0`. Procedures: [ops.md](ops.md).
+
+### Why prompt normalization
+
+Claude Code injects volatile content into every system prompt: working directory, git status, platform, OS version, shell, auto-memory path, and `<system-reminder>` blocks. This volatile prefix changes on every request and breaks KV cache prefix continuity — the model must re-prefill from scratch each turn. The proxy normalizes four properties before forwarding to ds4:
+
+| Rule | What it does | Why |
+|---|---|---|
+| `move_dynamic_sections` | Removes volatile system-prompt lines and appends them to the first user message | System prompt prefix stays stable; KV cache hits on every subsequent turn |
+| `normalize_date` | Collapses `Today's date is YYYY-MM-DDTHH:MM:SSZ` to `YYYY-MM-DD` | Time component changes every second; bare date is stable for one calendar day |
+| `strip_system_reminders` | Removes `<system-reminder>…</system-reminder>` blocks | Session-scoped injections differ across turns; stripping them stabilises the prefix |
+| `sort_tools` | Sorts the `tools` array by name | Tool order can vary; deterministic order gives the same prompt bytes across requests |
+
+Each rule is a pure function; all four are applied in order via `apply_all()`. The pipeline is transparent for non-`/v1/messages` paths and non-JSON bodies.
+
+### Why token auth
+
+ds4 has no authentication. The proxy adds an HMAC-based token gate (constant-time comparison via `hmac.compare_digest`) so that only Claude Code with the correct `DS4_API_KEY` can reach ds4. This matters because the proxy is exposed to the LAN via HTTPS rather than `0.0.0.0` plain HTTP; auth prevents use by other devices on the network.
+
+### Design choices
+
+- **Pure asyncio, no framework** — SSE must flow through without buffering (`CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1`). Standard `asyncio` gives direct control over chunk relay.
+- **httpx for upstream forwarding** — async, streaming, fits the asyncio model.
+- **`--host 127.0.0.1` for ds4** — once the proxy handles LAN termination, ds4 no longer needs to listen on `0.0.0.0`. The proxy is the sole LAN-visible endpoint.
+- **Tee logging** — optional request/response body logging for debugging; off by default, controlled by env var. Logs are pre- and post-normalization bodies; auth tokens are never written.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,3 +95,15 @@ ds4 has no authentication. The proxy adds an HMAC-based token gate (constant-tim
 - **httpx for upstream forwarding** — async, streaming, fits the asyncio model.
 - **`--host 127.0.0.1` for ds4** — once the proxy handles LAN termination, ds4 no longer needs to listen on `0.0.0.0`. The proxy is the sole LAN-visible endpoint.
 - **Tee logging** — optional request/response body logging for debugging; off by default, controlled by env var. Logs are pre- and post-normalization bodies; auth tokens are never written.
+
+### Repository placement — may split out later
+
+`proxy/` currently lives inside ds4-ops rather than in its own repository. The coupling justifies co-location today: it shares the repo-root `.env` (its auth token must match the client's `DS4_API_KEY`, its listen port must match the client's base URL), the ops/tuning/infrastructure docs describe proxy, server, and client as one system, and it has no second consumer. The normalization rules are ds4-specific — they stabilise *this* model's KV-cache prefix — so the package is not yet a general-purpose library.
+
+`proxy/` is nonetheless a self-contained Python package (its own `pyproject.toml` / `uv.lock`), so extraction stays cheap and can preserve history via `git filter-repo`. Split it into its own repository when any of these triggers fires:
+
+1. A second consumer wants the proxy (another backend, or a client other than this ds4 setup).
+2. The proxy needs an independent release / deploy / version lifecycle.
+3. The normalization rules generalise beyond ds4.
+
+Until then it stays here as a deliberate hold, not drift.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -22,8 +22,9 @@ SSOT for hosts, network, ports, and paths. Other docs reference this — do not 
 
 | Item | Value |
 |---|---|
-| Server listen | `0.0.0.0:8000` (LAN, no auth — trusted network only) |
-| Client base URL | `http://<mac-ip>:8000` (fill in the Mac's LAN IP) |
+| Server listen | `127.0.0.1:8000` (loopback only — proxy is the LAN endpoint) |
+| Proxy listen | `0.0.0.0:8443` (HTTPS, TLS terminated, mkcert cert) |
+| Client base URL | `https://<mac-ip>:8443` (fill in the Mac's LAN IP) |
 | Protocols served | `/v1/messages` (Anthropic), `/v1/chat/completions`, `/v1/completions`, `/v1/responses` (OpenAI), `/v1/models` |
 
 ## Paths (Mac)
@@ -31,4 +32,6 @@ SSOT for hosts, network, ports, and paths. Other docs reference this — do not 
 | Item | Value |
 |---|---|
 | Start script | `~/git/ds4-ops/scripts/ds4-server.sh` |
+| Proxy start script | `~/git/ds4-ops/scripts/ds4-proxy.sh` |
+| Proxy TLS cert/key | `~/.config/ds4-proxy/cert.pem` / `key.pem` (mkcert-generated) |
 | KV disk cache | `~/Library/Caches/ds4-server/kv` (persistent, Time Machine-excluded by macOS default) |

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -9,13 +9,16 @@ The proxy is the sole LAN-visible endpoint (TLS termination + prompt normalizati
 auth); ds4-server itself listens on loopback. Rationale:
 [architecture.md](architecture.md#reverse-proxy-layer).
 
-One-time mkcert setup (issues a locally-trusted TLS cert for the proxy):
-```sh
-brew install mkcert
-mkcert -install                              # install the local CA into the system trust store
-mkdir -p ~/.config/ds4-proxy
-mkcert -cert-file ~/.config/ds4-proxy/cert.pem -key-file ~/.config/ds4-proxy/key.pem localhost <mac-lan-ip>
-```
+One-time TLS setup. The proxy's cert must be trusted by the Windows client, so sign it with the
+**same mkcert root CA the client already uses** — do not create a separate root CA on the Mac.
+Sharing one root means the client trusts the proxy by pointing `DS4_CA_CERT` at that existing
+root; nothing new has to be distributed and trusted.
+
+1. On the Windows client, issue a leaf cert/key for the proxy from the existing root CA. The
+   root CA private key never leaves the client.
+2. Copy only the generated cert/key to the Mac as `~/.config/ds4-proxy/cert.pem` and `key.pem`.
+
+Exact mkcert flags and cert locations are environment-specific — see mkcert's own docs.
 
 Add the shared auth token to the server-side `.env` (repo root, gitignored):
 ```sh

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -3,6 +3,34 @@
 Day-to-day procedures. Parameter rationale is in [tuning.md](tuning.md); hosts/ports in
 [infrastructure.md](infrastructure.md).
 
+## Run the proxy (Mac)
+
+The proxy is the sole LAN-visible endpoint (TLS termination + prompt normalization + token
+auth); ds4-server itself listens on loopback. Rationale:
+[architecture.md](architecture.md#reverse-proxy-layer).
+
+One-time mkcert setup (issues a locally-trusted TLS cert for the proxy):
+```sh
+brew install mkcert
+mkcert -install                              # install the local CA into the system trust store
+mkdir -p ~/.config/ds4-proxy
+mkcert -cert-file ~/.config/ds4-proxy/cert.pem -key-file ~/.config/ds4-proxy/key.pem localhost <mac-lan-ip>
+```
+
+Add the shared auth token to the server-side `.env` (repo root, gitignored):
+```sh
+# .env: DS4_PROXY_AUTH_TOKEN=<generated-secret>   (generate with /create-key)
+```
+
+Start the proxy (foreground; refuses to start if `DS4_PROXY_AUTH_TOKEN` is unset):
+```sh
+~/git/ds4-ops/scripts/ds4-proxy.sh
+```
+
+Client-side (Windows): set `DS4_CA_CERT` to `<mkcert -CAROOT>/rootCA.pem` in the repo-root
+`.env` so Node trusts the proxy certificate, and set `DS4_API_KEY` to the same value as
+`DS4_PROXY_AUTH_TOKEN`.
+
 ## Run the server (Mac)
 
 ```sh
@@ -28,7 +56,8 @@ First time only, create the repo-root `.env` from the template and put the Mac's
 (the IP is never committed — `.env` is gitignored):
 ```bat
 copy .env.example .env
-rem then edit .env: DS4_ANTHROPIC_BASE_URL=http://<mac-ip>:8000
+rem then edit .env: DS4_ANTHROPIC_BASE_URL=https://<mac-ip>:8443
+rem and DS4_CA_CERT=<mkcert -CAROOT>\rootCA.pem (so Node trusts the proxy cert)
 ```
 Then launch VS Code with the ds4 backend via the bundled wrapper:
 ```bat
@@ -36,11 +65,15 @@ scripts\code-ds4.cmd .
 ```
 The wrapper loads `.env`, then sets the ds4 env (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`,
 the `deepseek-v4-flash` model aliases (the haiku tier uses the non-thinking `deepseek-chat`),
+`NODE_EXTRA_CA_CERTS` from `DS4_CA_CERT`,
 and `CLAUDE_CODE_AUTO_COMPACT_WINDOW=393216` /
-`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75`), then launches VS Code. If `DS4_ANTHROPIC_BASE_URL` is set
-in neither `.env` nor the shell, the wrapper warns and falls back to `localhost` (a placeholder
-that will not reach the Mac). A value set in the shell takes precedence over `.env`. `DS4_API_KEY`
-overrides the auth token; ds4 does not authenticate, so any non-empty value works.
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75`), then launches VS Code. The base URL now points at the
+proxy (`https://<mac-ip>:8443`), not ds4 directly. If `DS4_ANTHROPIC_BASE_URL` is set
+in neither `.env` nor the shell, the wrapper warns and falls back to `https://localhost:8443`
+(a placeholder that will not reach the Mac). A value set in the shell takes precedence over
+`.env`. `DS4_API_KEY` overrides the auth token; the proxy verifies it, so it must match
+`DS4_PROXY_AUTH_TOKEN` on the Mac. `DS4_CA_CERT` must point at `<mkcert -CAROOT>/rootCA.pem`
+so Node trusts the proxy certificate (if unset the wrapper warns and TLS will not be trusted).
 
 **Isolation from native (subscription) VS Code:** the wrapper passes
 `--user-data-dir "%LOCALAPPDATA%\vscode-ds4"`, starting a *separate* VS Code process. VS Code

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -16,7 +16,7 @@ incidents that produced these values in [history.md](history.md).
 | `--kv-cache-cold-max-tokens` | `90000` | Largest single cold-save snapshot; big enough to cache a typical CC initial context in one write, below `--ctx`. |
 | `--kv-cache-continued-interval-tokens` | `25000` | **The write-amplification lever.** Each continued checkpoint rewrites the whole live prefix (not a delta), doubled f16→f32. The default 10000 caused a 137 GB write storm; 25000 more than halved the churn. |
 | `--warm-weights` | on | Page in the whole model at startup. RSS ~90.9 GB is expected, not a leak. |
-| `--host 0.0.0.0` | — | LAN-reachable, **no auth**. Trusted network only. |
+| `--host 127.0.0.1` | — | Loopback only; the proxy (scripts/ds4-proxy.sh) is the LAN endpoint. |
 
 ## Memory budget (128 GB)
 
@@ -56,8 +56,8 @@ HIGH + `--quality` is the better trade.
 
 | Var | Value | Why |
 |---|---|---|
-| `ANTHROPIC_BASE_URL` | `http://<mac-ip>:8000` | Route CC to ds4. |
-| `ANTHROPIC_AUTH_TOKEN` | any non-empty | ds4 does not authenticate; a dummy satisfies the client. |
+| `ANTHROPIC_BASE_URL` | `https://<mac-ip>:8443` | Route CC to the ds4 proxy (TLS). |
+| `ANTHROPIC_AUTH_TOKEN` | must match `DS4_PROXY_AUTH_TOKEN` | The proxy now enforces auth; the token must match the proxy's secret. |
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `393216` | Tell CC ds4's real ceiling (CC otherwise assumes the model's nominal 200K/1M window and never compacts in time). Keep in sync with `--ctx`. |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `75` | Compact at ~75% (~245K by CC's count). Absorbs the tokenizer mismatch — ds4/DeepSeek counts more tokens than CC/Claude for the same text, so CC must compact well before its own ceiling to keep ds4's count under 393216. |
 
@@ -75,3 +75,16 @@ Claude Code's alias-resolution vars (they also propagate to sub-agent `model:` f
 Caveat: whether CC accepts a non-Anthropic alias target on a custom endpoint is the one thing
 to verify empirically (grep the ds4 log for `THINKING` per request). If CC rejects it, fall
 back to a router.
+
+## Proxy env vars (Mac)
+
+Read by `scripts/ds4-proxy.sh` (from the repo-root `.env`). Design: [architecture.md](architecture.md#reverse-proxy-layer).
+
+| Var | Value | Why |
+|---|---|---|
+| `DS4_PROXY_PORT` | `8443` (default) | HTTPS listen port. Must match the port in the client's `ANTHROPIC_BASE_URL`. |
+| `DS4_PROXY_UPSTREAM` | `http://127.0.0.1:8000` (default) | The ds4 backend the proxy forwards to. |
+| `DS4_PROXY_AUTH_TOKEN` | required | Token every client request must present; must match the client's `DS4_API_KEY`. The proxy refuses to start if unset. |
+| `DS4_PROXY_CERT` / `DS4_PROXY_KEY` | `~/.config/ds4-proxy/cert.pem` / `key.pem` (defaults) | mkcert-generated TLS cert/key for the HTTPS listener. |
+| `DS4_PROXY_TEE` | `off` (default) / `on` | When `on`, logs pre- and post-normalization request bodies for debugging. |
+| `DS4_PROXY_LOG_DIR` | `~/Library/Caches/ds4-proxy/log` (default) | Where tee logs are written when `DS4_PROXY_TEE=on`. |

--- a/proxy/auth.py
+++ b/proxy/auth.py
@@ -1,0 +1,52 @@
+"""Bearer / API-key authentication for the ds4 reverse proxy."""
+
+import hmac
+
+
+def _get_header(headers: dict, name: str) -> str | None:
+    """Case-insensitive header lookup."""
+    for key, value in headers.items():
+        if key.lower() == name:
+            return value
+    return None
+
+
+def _constant_time_eq(a: str, b: str) -> bool:
+    """Constant-time string comparison using hmac.compare_digest.
+
+    compare_digest guards against timing side channels that a plain ``==``
+    would leak. Both operands are encoded to bytes first.
+    """
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
+
+
+def verify_auth(headers: dict, expected_token: str) -> bool:
+    """Return True iff the request presents the expected token.
+
+    Accepts the token from either:
+      * Authorization: Bearer <token>
+      * x-api-key: <token>
+
+    An empty expected token or an empty presented token always fails, so a
+    misconfigured/blank secret can never authenticate.
+    """
+    if not expected_token:
+        return False
+
+    # Collect every credential the request presents, then accept if ANY of
+    # them matches. A wrong Bearer token must not veto a correct x-api-key.
+    candidates: list[str] = []
+
+    authorization = _get_header(headers, "authorization")
+    if authorization is not None and authorization.startswith("Bearer "):
+        candidates.append(authorization[len("Bearer "):])
+
+    api_key = _get_header(headers, "x-api-key")
+    if api_key is not None:
+        candidates.append(api_key)
+
+    for presented in candidates:
+        if presented and _constant_time_eq(presented, expected_token):
+            return True
+
+    return False

--- a/proxy/config.py
+++ b/proxy/config.py
@@ -1,0 +1,59 @@
+"""Environment-driven configuration for the ds4 reverse proxy.
+
+load_config() reads every DS4_PROXY_* variable, applies defaults, expands ``~``
+in filesystem paths, and returns a frozen ProxyConfig. DS4_PROXY_AUTH_TOKEN is
+mandatory: an unset/empty value aborts the process with a clear message, so the
+proxy can never start without an authentication secret.
+"""
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    port: int
+    upstream: str
+    cert: Path
+    key: Path
+    auth_token: str
+    tee: bool
+    log_dir: Path
+
+
+def load_config() -> ProxyConfig:
+    """Build a ProxyConfig from the DS4_PROXY_* environment variables."""
+    port = int(os.environ.get("DS4_PROXY_PORT", "8443"))
+    upstream = os.environ.get("DS4_PROXY_UPSTREAM", "http://127.0.0.1:8000")
+
+    cert = Path(
+        os.environ.get("DS4_PROXY_CERT", "~/.config/ds4-proxy/cert.pem")
+    ).expanduser()
+    key = Path(
+        os.environ.get("DS4_PROXY_KEY", "~/.config/ds4-proxy/key.pem")
+    ).expanduser()
+
+    auth_token = os.environ.get("DS4_PROXY_AUTH_TOKEN", "")
+    if not auth_token:
+        sys.exit(
+            "[ds4-proxy] DS4_PROXY_AUTH_TOKEN is not set — refusing to start. "
+            "Set it in the repo-root .env."
+        )
+
+    tee = os.environ.get("DS4_PROXY_TEE", "off") == "on"
+
+    log_dir = Path(
+        os.environ.get("DS4_PROXY_LOG_DIR", "~/Library/Caches/ds4-proxy/log")
+    ).expanduser()
+
+    return ProxyConfig(
+        port=port,
+        upstream=upstream,
+        cert=cert,
+        key=key,
+        auth_token=auth_token,
+        tee=tee,
+        log_dir=log_dir,
+    )

--- a/proxy/http_io.py
+++ b/proxy/http_io.py
@@ -1,0 +1,112 @@
+"""HTTP framing helpers for the ds4 reverse proxy.
+
+Two concerns:
+  * read_request_body        - drain a request body from an asyncio stream,
+                               honoring Content-Length and chunked transfer
+                               encoding.
+  * sanitize_response_headers - strip hop-by-hop headers before relaying an
+                               upstream response to the client, and force
+                               "Connection: close".
+"""
+
+import asyncio
+
+# RFC 7230 section 6.1 hop-by-hop headers. These are meaningful only for a
+# single transport-level connection and must never be forwarded by a proxy.
+HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def _get_header(headers: dict, name: str) -> str | None:
+    """Case-insensitive header lookup."""
+    for key, value in headers.items():
+        if key.lower() == name:
+            return value
+    return None
+
+
+async def read_request_body(reader: asyncio.StreamReader, headers: dict) -> bytes:
+    """Read a request body from ``reader``.
+
+    Resolution order:
+      1. Content-Length  -> read exactly that many bytes.
+      2. Transfer-Encoding contains "chunked" -> decode the chunked body.
+      3. Otherwise -> return b"".
+    """
+    content_length = _get_header(headers, "content-length")
+    if content_length is not None:
+        return await reader.readexactly(int(content_length))
+
+    transfer_encoding = _get_header(headers, "transfer-encoding")
+    if transfer_encoding is not None and "chunked" in transfer_encoding.lower():
+        return await _read_chunked(reader)
+
+    return b""
+
+
+async def _read_chunked(reader: asyncio.StreamReader) -> bytes:
+    """Decode a chunked transfer-encoded body into its concatenated payload."""
+    chunks: list[bytes] = []
+    while True:
+        size_line = await reader.readline()
+        if not size_line:
+            # EOF before any chunk data — stream closed mid-message.
+            raise asyncio.IncompleteReadError(b'', None)
+        # A chunk-size line may carry extensions after a ';'; ignore them.
+        size_token = size_line.split(b";", 1)[0].strip()
+        if not size_token:
+            # Blank line before the first size (defensive) -> keep reading.
+            continue
+        chunk_size = int(size_token, 16)
+        if chunk_size == 0:
+            # Last chunk. Drain all trailer header lines up to and including
+            # the terminating blank line (CRLF-only line), per RFC 7230 §4.1.2.
+            while True:
+                line = await reader.readline()
+                if line in (b'\r\n', b'\n', b''):
+                    break
+            break
+        data = await reader.readexactly(chunk_size)
+        chunks.append(data)
+        # Each chunk's data is followed by a CRLF that is not part of the body.
+        await reader.readexactly(2)
+    return b"".join(chunks)
+
+
+def sanitize_response_headers(upstream_headers: list[tuple]) -> list[tuple]:
+    """Strip hop-by-hop headers (case-insensitive) and force Connection: close.
+
+    In addition to the standard HOP_BY_HOP set, RFC 7230 section 6.1 requires
+    that any header name listed in the Connection header's value is itself
+    treated as hop-by-hop and stripped (e.g. ``Connection: X-Debug`` marks
+    ``X-Debug`` as connection-specific).
+
+    Returns the surviving end-to-end headers followed by a single
+    ("Connection", "close") entry. An empty input yields exactly
+    [("Connection", "close")].
+    """
+    # Collect names nominated as hop-by-hop by any Connection header value.
+    nominated: set[str] = set()
+    for name, value in upstream_headers:
+        if name.lower() == "connection":
+            for token in value.split(","):
+                token = token.strip().lower()
+                if token:
+                    nominated.add(token)
+
+    result: list[tuple] = []
+    for name, value in upstream_headers:
+        lname = name.lower()
+        if lname in HOP_BY_HOP or lname in nominated:
+            continue
+        result.append((name, value))
+    result.append(("Connection", "close"))
+    return result

--- a/proxy/normalize.py
+++ b/proxy/normalize.py
@@ -1,0 +1,204 @@
+"""Request-body normalization rules for the ds4 reverse proxy.
+
+Four pure normalization rules plus apply_all() that composes them in
+deterministic A->B->C->D order:
+
+  A. move_dynamic_sections   - lift volatile system-prompt lines into the
+                               first user message so the cached system prompt
+                               stays stable across requests.
+  B. normalize_date          - collapse a timestamped "Today's date" line to
+                               a bare YYYY-MM-DD.
+  C. strip_system_reminders  - drop <system-reminder>...</system-reminder>.
+  D. sort_tools              - sort the tools array by name for determinism.
+
+All functions take a request body dict and return a new dict; the input is
+never mutated.
+"""
+
+import copy
+import re
+
+# Patterns that identify dynamic/volatile sections in the system prompt.
+# Each match is removed from the system prompt and appended to the first
+# user message. Order here is not significant; every match is moved.
+DYNAMIC_PATTERNS = [
+    re.compile(r'^Working directory:.*$', re.MULTILINE),
+    re.compile(r'^Is directory a git repo:.*$', re.MULTILINE),
+    re.compile(r'^Platform:.*$', re.MULTILINE),
+    re.compile(r'^OS Version:.*$', re.MULTILINE),
+    re.compile(r'^Shell:.*$', re.MULTILINE),
+    # gitStatus is a multi-line block: from the "gitStatus:" line up to (but
+    # not including) the first blank line, or the end of the string. DOTALL
+    # lets ".*?" span the trailing status lines, and the lazy quantifier plus
+    # the (blank-line | end) boundary stops the block from greedily eating
+    # stable text that follows a blank line after the status listing.
+    re.compile(r'^gitStatus:.*?(?=\n[ \t]*\n|\Z)', re.MULTILINE | re.DOTALL),
+    # Claude Code auto-memory injection: the line that names the project-specific
+    # memory directory. The path is machine-specific and breaks the KV cache
+    # prefix across different client machines or project renames.
+    re.compile(r'^You have a persistent, file-based memory system at .*$', re.MULTILINE),
+]
+
+_DATE_LINE = re.compile(
+    r"(Today's date is )(\d{4}-\d{2}-\d{2})(?:[T ][0-9:.\-+Z]*)?",
+)
+
+_SYSTEM_REMINDER = re.compile(
+    r'<system-reminder>.*?</system-reminder>',
+    re.DOTALL,
+)
+# Orphan close tags left behind when the open tag was already consumed as part
+# of a nested reminder (e.g. <system-reminder>a<system-reminder>b</system-reminder>
+# strips the inner pair, leaving </system-reminder> without a partner).
+_ORPHAN_CLOSE = re.compile(r'</system-reminder>')
+
+
+def _extract_from_text(text: str) -> tuple[str, list[str]]:
+    """Return (cleaned_text, [extracted_section, ...]) for one text blob."""
+    extracted: list[str] = []
+    cleaned = text
+    for pat in DYNAMIC_PATTERNS:
+        matches = pat.findall(cleaned)
+        if not matches:
+            continue
+        for m in matches:
+            extracted.append(m.strip())
+        cleaned = pat.sub('', cleaned)
+    # Collapse the blank lines left behind by removed sections.
+    cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
+    return cleaned, extracted
+
+
+def move_dynamic_sections(body: dict) -> dict:
+    """Remove dynamic sections from the system prompt and append them to the
+    first user message.
+
+    Supports two system-prompt shapes:
+      * a plain string
+      * a list of content blocks [{"type": "text", "text": ...}, ...]
+    """
+    body = copy.deepcopy(body)
+    system = body.get('system')
+    if system is None:
+        return body
+
+    extracted: list[str] = []
+
+    if isinstance(system, str):
+        cleaned, found = _extract_from_text(system)
+        extracted.extend(found)
+        body['system'] = cleaned
+    elif isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and 'text' in block:
+                cleaned, found = _extract_from_text(block['text'])
+                extracted.extend(found)
+                block['text'] = cleaned
+        body['system'] = system
+    else:
+        return body
+
+    if not extracted:
+        return body
+
+    appendix = '\n'.join(extracted)
+    messages = body.get('messages')
+    if not messages:
+        # No user message to attach to; the system prompt is still cleaned.
+        return body
+
+    # Find the first user message and append the extracted sections.
+    for msg in messages:
+        if msg.get('role') != 'user':
+            continue
+        content = msg.get('content')
+        if isinstance(content, str):
+            msg['content'] = content.rstrip() + '\n' + appendix
+        elif isinstance(content, list):
+            content.append({'type': 'text', 'text': appendix})
+        else:
+            msg['content'] = appendix
+        break
+    return body
+
+
+def _normalize_date_in_text(text: str) -> str:
+    return _DATE_LINE.sub(r'\1\2', text)
+
+
+def normalize_date(body: dict) -> dict:
+    """Normalize 'Today's date is ...' occurrences to a bare YYYY-MM-DD.
+
+    A malformed date part (no YYYY-MM-DD prefix) does not match and the line
+    is left untouched (safe side).
+    """
+    body = copy.deepcopy(body)
+    system = body.get('system')
+    if isinstance(system, str):
+        body['system'] = _normalize_date_in_text(system)
+    elif isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and 'text' in block:
+                block['text'] = _normalize_date_in_text(block['text'])
+    return body
+
+
+def _strip_reminders_in_text(text: str) -> str:
+    text = _SYSTEM_REMINDER.sub('', text)
+    return _ORPHAN_CLOSE.sub('', text)
+
+
+def strip_system_reminders(body: dict) -> dict:
+    """Remove every <system-reminder>...</system-reminder> block (DOTALL)."""
+    body = copy.deepcopy(body)
+    system = body.get('system')
+    if isinstance(system, str):
+        body['system'] = _strip_reminders_in_text(system)
+    elif isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and 'text' in block:
+                block['text'] = _strip_reminders_in_text(block['text'])
+
+    messages = body.get('messages')
+    if isinstance(messages, list):
+        for msg in messages:
+            content = msg.get('content')
+            if isinstance(content, str):
+                msg['content'] = _strip_reminders_in_text(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if 'text' in block:
+                        block['text'] = _strip_reminders_in_text(block['text'])
+                    elif isinstance(block.get('content'), str):
+                        # tool_result blocks carry their payload in "content",
+                        # not "text" — strip reminders there too.
+                        block['content'] = _strip_reminders_in_text(block['content'])
+                    elif isinstance(block.get('content'), list):
+                        # tool_result with list-shaped content (nested blocks).
+                        for sub in block['content']:
+                            if isinstance(sub, dict) and 'text' in sub:
+                                sub['text'] = _strip_reminders_in_text(sub['text'])
+    return body
+
+
+def sort_tools(body: dict) -> dict:
+    """Sort the tools list by name for deterministic prompt-cache keys.
+
+    No-op when there is no 'tools' key. Idempotent.
+    """
+    body = copy.deepcopy(body)
+    tools = body.get('tools')
+    if isinstance(tools, list):
+        body['tools'] = sorted(tools, key=lambda t: t.get('name', ''))
+    return body
+
+
+def apply_all(body: dict) -> dict:
+    """Apply all normalization rules in order A->B->C->D."""
+    body = move_dynamic_sections(body)
+    body = normalize_date(body)
+    body = strip_system_reminders(body)
+    body = sort_tools(body)
+    return body

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -1,0 +1,206 @@
+"""asyncio TLS reverse proxy for ds4.
+
+Terminates TLS from Claude Code, authenticates the request against a shared
+token, normalizes the /v1/messages body for a stable prompt-cache prefix, then
+forwards to the plain-HTTP ds4 backend and relays the (possibly streamed)
+response back. One handler runs per client connection.
+"""
+
+import asyncio
+import json
+import ssl
+import sys
+from datetime import datetime, timezone
+
+import httpx
+
+from proxy import auth, http_io, normalize
+from proxy.config import load_config
+from proxy.tee import TeeLogger
+
+MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MB; return 413 if exceeded
+
+
+def _get_header(headers: dict, name: str) -> str | None:
+    """Case-insensitive header lookup."""
+    lname = name.lower()
+    for key, value in headers.items():
+        if key.lower() == lname:
+            return value
+    return None
+
+
+async def _read_request_head(
+    reader: asyncio.StreamReader,
+) -> tuple[str, str, str, dict]:
+    """Read the request line and headers.
+
+    Returns (method, path, version, headers). Raises EOFError on a closed
+    connection and ValueError on a malformed request line.
+    """
+    request_line = await reader.readline()
+    if not request_line:
+        raise EOFError("connection closed before request line")
+
+    parts = request_line.decode("latin-1").rstrip("\r\n").split(" ")
+    if len(parts) != 3:
+        raise ValueError(f"malformed request line: {request_line!r}")
+    method, path, version = parts
+
+    headers: dict = {}
+    while True:
+        line = await reader.readline()
+        if line in (b"\r\n", b"\n", b""):
+            break
+        name, sep, value = line.decode("latin-1").rstrip("\r\n").partition(":")
+        if not sep:
+            continue
+        headers[name.strip()] = value.strip()
+
+    return method, path, version, headers
+
+
+def _build_upstream_headers(req_headers: dict, body: bytes) -> dict:
+    """Strip hop-by-hop + Content-Length, then set a fresh Content-Length."""
+    result: dict = {}
+    for name, value in req_headers.items():
+        lname = name.lower()
+        if lname in http_io.HOP_BY_HOP or lname == "content-length":
+            continue
+        result[name] = value
+    if body:
+        result["Content-Length"] = str(len(body))
+    return result
+
+
+def _send_error(writer: asyncio.StreamWriter, status: int, phrase: str) -> None:
+    """Write a bodyless HTTP/1.1 error response with Connection: close."""
+    response = (
+        f"HTTP/1.1 {status} {phrase}\r\n"
+        "Connection: close\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n"
+    )
+    writer.write(response.encode("latin-1"))
+
+
+async def _handle(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    config,
+    client: httpx.AsyncClient,
+    tee: TeeLogger,
+) -> None:
+    """Per-connection request handler."""
+    try:
+        try:
+            method, path, _version, req_headers = await _read_request_head(reader)
+        except (EOFError, ValueError):
+            return
+
+        # Authenticate before reading the body, so unauthorized requests do no
+        # upstream work.
+        if not auth.verify_auth(req_headers, config.auth_token):
+            _send_error(writer, 401, "Unauthorized")
+            await writer.drain()
+            return
+
+        # Reject oversize bodies up front when the client advertises the size.
+        content_length = _get_header(req_headers, "content-length")
+        if content_length is not None:
+            try:
+                if int(content_length) > MAX_BODY_BYTES:
+                    _send_error(writer, 413, "Content Too Large")
+                    await writer.drain()
+                    return
+            except ValueError:
+                pass
+
+        body = await http_io.read_request_body(reader, req_headers)
+
+        # Guard against a lying/absent Content-Length (e.g. chunked bodies).
+        if len(body) > MAX_BODY_BYTES:
+            _send_error(writer, 413, "Content Too Large")
+            await writer.drain()
+            return
+
+        if method == "POST" and path == "/v1/messages":
+            body = _normalize_body(body, tee)
+
+        upstream_url = config.upstream.rstrip("/") + path
+        headers = _build_upstream_headers(req_headers, body)
+
+        try:
+            async with client.stream(
+                method, upstream_url, content=body, headers=headers
+            ) as resp:
+                writer.write(
+                    f"HTTP/1.1 {resp.status_code} {resp.reason_phrase}\r\n".encode(
+                        "latin-1"
+                    )
+                )
+                for name, value in http_io.sanitize_response_headers(
+                    list(resp.headers.items())
+                ):
+                    writer.write(f"{name}: {value}\r\n".encode("latin-1"))
+                writer.write(b"\r\n")
+                await writer.drain()
+                async for chunk in resp.aiter_raw():
+                    writer.write(chunk)
+                    await writer.drain()
+        except httpx.RequestError:
+            _send_error(writer, 502, "Bad Gateway")
+            await writer.drain()
+    finally:
+        writer.close()
+
+
+def _normalize_body(body: bytes, tee: TeeLogger) -> bytes:
+    """Normalize a /v1/messages JSON body; pass through on non-JSON.
+
+    On any JSON decode failure the original bytes are forwarded unchanged, so a
+    non-JSON POST is never dropped.
+    """
+    try:
+        body_dict = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return body
+
+    normalized = normalize.apply_all(body_dict)
+    if tee.enabled:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        tee.log(timestamp, body_dict, normalized)
+    return json.dumps(
+        normalized, ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+
+
+async def main() -> None:
+    config = load_config()
+    tee = TeeLogger(enabled=config.tee, log_dir=config.log_dir)
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    try:
+        ctx.load_cert_chain(config.cert, config.key)
+    except (FileNotFoundError, ssl.SSLError) as exc:
+        sys.exit(
+            f"[ds4-proxy] failed to load TLS cert/key "
+            f"({config.cert} / {config.key}): {exc}"
+        )
+
+    async with httpx.AsyncClient(timeout=None) as client:
+        server = await asyncio.start_server(
+            lambda r, w: _handle(r, w, config, client, tee),
+            host="0.0.0.0",
+            port=config.port,
+            ssl=ctx,
+        )
+        print(
+            f"[ds4-proxy] listening on 0.0.0.0:{config.port} → {config.upstream}"
+        )
+        async with server:
+            await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/proxy/tee.py
+++ b/proxy/tee.py
@@ -1,0 +1,47 @@
+"""Optional body-only request logging for the ds4 reverse proxy.
+
+TeeLogger writes the pre- and post-normalization request bodies to disk when
+DS4_PROXY_TEE=on, so a normalization rule can be debugged by diffing what the
+client sent against what was forwarded upstream. Auth headers are never part of
+the body, so nothing sensitive is logged and no scrubbing is needed.
+"""
+
+import json
+import threading
+from pathlib import Path
+
+
+class TeeLogger:
+    def __init__(self, enabled: bool, log_dir: Path) -> None:
+        self._enabled = enabled
+        self._log_dir = log_dir
+        self._seq = 0
+        self._lock = threading.Lock()
+        if enabled:
+            log_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def log(self, timestamp: str, pre: dict, post: dict) -> None:
+        """Write pre/post request bodies as a numbered pair of JSON files.
+
+        No-op when logging is disabled. The per-instance sequence counter is
+        incremented under a lock so concurrent connections never collide.
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            seq = self._seq
+            self._seq += 1
+        stem = f"{timestamp}-{seq:05d}"
+        self._write(f"{stem}-pre.json", pre)
+        self._write(f"{stem}-post.json", post)
+
+    def _write(self, name: str, body: dict) -> None:
+        path = self._log_dir / name
+        path.write_text(
+            json.dumps(body, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "ds4-proxy"
+version = "0.1.0"
+description = "ds4 reverse proxy: request normalization, HTTP framing, and auth"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["."]

--- a/scripts/code-ds4.cmd
+++ b/scripts/code-ds4.cmd
@@ -18,22 +18,31 @@ if exist "%DS4_ENV_FILE%" (
 rem Clear any real Anthropic API key so the ds4 server is used instead
 set ANTHROPIC_API_KEY=
 
-rem ds4 server base URL. The real Mac LAN IP is NOT committed (public repo): put
-rem DS4_ANTHROPIC_BASE_URL=http://<mac-ip>:8000 in the repo-root .env (or set it in the
-rem shell). The default below is a placeholder (localhost) and will not reach the Mac.
+rem ds4 proxy base URL. The real Mac LAN IP is NOT committed (public repo): put
+rem DS4_ANTHROPIC_BASE_URL=https://<mac-lan-ip>:8443 in the repo-root .env (or set it in the
+rem shell). The default below is a placeholder (localhost, proxy port) and will not reach the Mac.
 if defined DS4_ANTHROPIC_BASE_URL (
     set ANTHROPIC_BASE_URL=%DS4_ANTHROPIC_BASE_URL%
 ) else (
-    echo [code-ds4] WARNING: DS4_ANTHROPIC_BASE_URL not set; using placeholder default http://localhost:8000 ^(will not reach the Mac ds4 server^).
-    set ANTHROPIC_BASE_URL=http://localhost:8000
+    echo [code-ds4] WARNING: DS4_ANTHROPIC_BASE_URL not set; using placeholder default https://localhost:8443 ^(will not reach the Mac ds4 proxy^).
+    set ANTHROPIC_BASE_URL=https://localhost:8443
 )
 
-rem ds4 server auth token. ds4 does not authenticate, so any non-empty value works
-rem (override with DS4_API_KEY env var).
+rem ds4 proxy auth token. The proxy verifies this token; set it to the same value as
+rem DS4_PROXY_AUTH_TOKEN on the Mac (override with DS4_API_KEY env var).
 if defined DS4_API_KEY (
     set ANTHROPIC_AUTH_TOKEN=%DS4_API_KEY%
 ) else (
     set ANTHROPIC_AUTH_TOKEN=dsv4-local
+)
+
+rem mkcert local CA root so Node trusts the proxy TLS certificate. Set DS4_CA_CERT to
+rem the path printed by "mkcert -CAROOT"/rootCA.pem. NODE_TLS_REJECT_UNAUTHORIZED=0 is
+rem NOT used.
+if defined DS4_CA_CERT (
+    set NODE_EXTRA_CA_CERTS=%DS4_CA_CERT%
+) else (
+    echo [code-ds4] WARNING: DS4_CA_CERT not set; TLS certificate will not be trusted.
 )
 
 set ANTHROPIC_MODEL=deepseek-v4-flash

--- a/scripts/ds4-proxy.sh
+++ b/scripts/ds4-proxy.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Starts the ds4 reverse proxy (TLS termination + prompt normalization + token auth).
+# The proxy sits in front of ds4-server and is the sole LAN-visible endpoint.
+# ds4-server itself listens on 127.0.0.1:8000 after this change.
+# See docs/architecture.md#reverse-proxy-layer for the full rationale.
+set -eu
+
+# Load .env from the repo root (gitignored). DS4_PROXY_AUTH_TOKEN is required.
+DOTENV_FILE="$HOME/git/ds4-ops/.env"
+# shellcheck source=scripts/lib/load-dotenv.sh
+. "$(dirname "$0")/lib/load-dotenv.sh"
+
+# Fail early if auth token is missing (config.py also checks, but fail here too).
+if [ -z "${DS4_PROXY_AUTH_TOKEN:-}" ]; then
+    echo "[ds4-proxy] DS4_PROXY_AUTH_TOKEN is not set in .env — refusing to start" >&2
+    exit 1
+fi
+
+cd "$HOME/git/ds4-ops"
+exec uv run python -m proxy.server

--- a/scripts/ds4-server.sh
+++ b/scripts/ds4-server.sh
@@ -20,4 +20,4 @@ exec caffeinate -ism ./ds4-server \
   --kv-cache-cold-max-tokens 90000 \
   --kv-cache-continued-interval-tokens 25000 \
   --warm-weights \
-  --host 0.0.0.0
+  --host 127.0.0.1          # proxy (scripts/ds4-proxy.sh) is the LAN endpoint

--- a/scripts/lib/load-dotenv.sh
+++ b/scripts/lib/load-dotenv.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Sourced by ds4-proxy.sh. Loads KEY=VALUE pairs from DOTENV_FILE (must be set
+# by caller). Shell-existing values take precedence (matches code-ds4.cmd semantics).
+# Lines starting with # and blank lines are skipped.
+
+# Return 0 if the environment variable named by $1 is already set (matches the
+# "shell value wins" semantics: an exported value is what the child would see).
+_dotenv_is_set() {
+    printenv "$1" >/dev/null 2>&1
+}
+
+if [ -f "$DOTENV_FILE" ]; then
+    while IFS= read -r _dotenv_line || [ -n "$_dotenv_line" ]; do
+        case "$_dotenv_line" in
+            '#'*) continue ;;
+            '') continue ;;
+        esac
+        # Split on the first '=' only.
+        _dotenv_key=${_dotenv_line%%=*}
+        _dotenv_val=${_dotenv_line#*=}
+        # A blank key, or a line with no '=' at all, is not a KEY=VALUE pair.
+        if [ -z "$_dotenv_key" ] || [ "$_dotenv_key" = "$_dotenv_line" ]; then
+            continue
+        fi
+        # Export only when the variable is not already set in the environment.
+        if ! _dotenv_is_set "$_dotenv_key"; then
+            export "$_dotenv_key=$_dotenv_val"
+        fi
+    done < "$DOTENV_FILE"
+    unset _dotenv_line _dotenv_key _dotenv_val
+fi

--- a/tests/feature-13-ds4-proxy/test_auth.py
+++ b/tests/feature-13-ds4-proxy/test_auth.py
@@ -1,0 +1,125 @@
+# Tests: proxy/auth.py
+# Tags: scope:issue-specific
+#
+# L3 gap (what this test suite does NOT catch — explicitly deferred):
+# - Real asyncio TLS handshake behavior with mkcert certificates
+# - End-to-end auth header validation through the full proxy handler pipeline
+# - Security idempotency (repeated starts, duplicate CA/env entries: deferred
+#     to post-/write-code environment-level tests)
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+
+import pytest
+
+from proxy import auth
+
+
+# ===========================================================================
+# proxy/auth.py — verify_auth
+# ===========================================================================
+
+TOKEN = "s3cr3t-token-value"
+
+
+def test_28_verify_auth_bearer_correct():
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    assert auth.verify_auth(headers, TOKEN) is True
+
+
+def test_29_verify_auth_x_api_key_correct():
+    headers = {"x-api-key": TOKEN}
+    assert auth.verify_auth(headers, TOKEN) is True
+
+
+def test_30_verify_auth_wrong_token():
+    headers = {"Authorization": "Bearer wrong-token"}
+    assert auth.verify_auth(headers, TOKEN) is False
+
+
+def test_31_verify_auth_no_headers():
+    assert auth.verify_auth({}, TOKEN) is False
+
+
+def test_32_verify_auth_uses_compare_digest(monkeypatch):
+    # Verify hmac.compare_digest is actually invoked at runtime (not merely
+    # present in the source): patch the module-level reference auth.py uses and
+    # record the calls.
+    calls = []
+    import hmac as hmac_mod
+    original = hmac_mod.compare_digest
+
+    def recording(a, b):
+        calls.append((a, b))
+        return original(a, b)
+
+    monkeypatch.setattr(hmac_mod, "compare_digest", recording)
+    result = auth.verify_auth({"authorization": "Bearer secret"}, "secret")
+    assert result is True
+    assert len(calls) >= 1, "hmac.compare_digest was not called"
+
+
+def test_33_verify_auth_empty_token_fails():
+    # Even when the expected token is empty, an empty presented token fails.
+    headers = {"x-api-key": ""}
+    assert auth.verify_auth(headers, "") is False
+
+
+def test_34_verify_auth_missing_bearer_prefix():
+    headers = {"Authorization": TOKEN}  # no "Bearer " prefix
+    assert auth.verify_auth(headers, TOKEN) is False
+
+
+# --- C10: auth edge cases --------------------------------------------------
+
+def test_34a_authorization_header_lookup_case_insensitive():
+    # Lower-cased header name must still be found (case-insensitive lookup).
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    assert auth.verify_auth(headers, TOKEN) is True
+
+
+def test_34b_token_with_surrounding_whitespace_rejected():
+    # A trailing space makes the presented token differ from the expected one;
+    # the comparison is strict, so this must NOT match.
+    headers = {"Authorization": f"Bearer {TOKEN} "}
+    assert auth.verify_auth(headers, TOKEN) is False
+
+
+def test_34c_lowercase_bearer_prefix_rejected():
+    # Only the exact "Bearer " prefix is accepted; "bearer " does not match.
+    headers = {"Authorization": f"bearer {TOKEN}"}
+    assert auth.verify_auth(headers, TOKEN) is False
+
+
+def test_34d_wrong_bearer_but_correct_x_api_key_succeeds():
+    # A wrong Bearer token must not veto a correct x-api-key: the request
+    # presents a valid credential via x-api-key, so auth succeeds.
+    headers = {"Authorization": "Bearer wrong-token", "x-api-key": TOKEN}
+    assert auth.verify_auth(headers, TOKEN) is True
+
+
+def test_34e_verify_auth_returns_bool_not_string():
+    # The return type is always bool — never a string that could embed the token.
+    result = auth.verify_auth({"Authorization": "Bearer wrong"}, TOKEN)
+    assert result is False
+    assert isinstance(result, bool)
+
+
+def test_34f_empty_bearer_value_rejected():
+    # "Bearer " with nothing after the prefix: presented token is empty string,
+    # which is rejected even if the expected token is also empty (guard fires).
+    headers = {"Authorization": "Bearer "}
+    assert auth.verify_auth(headers, TOKEN) is False
+
+
+def test_34g_empty_x_api_key_rejected():
+    # x-api-key with empty value should fail regardless of expected token.
+    headers = {"x-api-key": ""}
+    assert auth.verify_auth(headers, TOKEN) is False
+
+
+def test_34h_x_api_key_mixedcase_accepted():
+    # verify_auth uses case-insensitive header lookup (_get_header).
+    # Mixed-case variants of x-api-key must be found and accepted.
+    assert auth.verify_auth({"X-API-Key": TOKEN}, TOKEN) is True
+    assert auth.verify_auth({"X-Api-Key": TOKEN}, TOKEN) is True
+    assert auth.verify_auth({"X-API-KEY": TOKEN}, TOKEN) is True

--- a/tests/feature-13-ds4-proxy/test_http_io.py
+++ b/tests/feature-13-ds4-proxy/test_http_io.py
@@ -1,0 +1,392 @@
+# Tests: proxy/http_io.py
+# Tags: scope:issue-specific
+#
+# L3 gap (what this test suite does NOT catch — explicitly deferred):
+# - Real asyncio TLS handshake behavior with mkcert certificates
+# - Actual SSE streaming under CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1
+# - End-to-end chunked transfer between real client and upstream ds4 server
+# - Proxy handler integration (server.py not yet written; auth→normalize→
+#     forward→sanitize pipeline tested post-/write-code as L2 integration tests)
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+
+import asyncio
+
+import pytest
+
+from proxy import http_io
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_read_body(data: bytes, headers: dict) -> bytes:
+    """Build a real asyncio.StreamReader, feed it ``data``, and read the body.
+
+    The StreamReader is created inside the running loop because, since Python
+    3.14, StreamReader() requires an already-running event loop (the implicit
+    get_event_loop() fallback in the main thread was removed).
+    """
+    async def _inner() -> bytes:
+        reader = asyncio.StreamReader()
+        reader.feed_data(data)
+        reader.feed_eof()
+        return await http_io.read_request_body(reader, headers)
+
+    return asyncio.run(_inner())
+
+
+# ===========================================================================
+# proxy/http_io.py — read_request_body
+# ===========================================================================
+
+def test_18_read_request_body_content_length():
+    body = _run_read_body(b"0123456789EXTRA", {"Content-Length": "10"})
+    assert body == b"0123456789"
+
+
+def test_19_read_request_body_chunked():
+    # "Wiki" (4) + "pedia" (5), then terminating "0" chunk.
+    payload = b"4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "chunked"})
+    assert body == b"Wikipedia"
+
+
+def test_20_read_request_body_no_te_no_cl():
+    body = _run_read_body(b"", {})
+    assert body == b""
+
+
+def test_20b_non_chunked_transfer_encoding_returns_empty():
+    # TE values other than "chunked" are not recognized by this proxy;
+    # they fall through to the default empty-body return (b""). Correct
+    # because Claude Code does not send non-chunked TE.
+    body = _run_read_body(b"notchunked-data", {"Transfer-Encoding": "compress"})
+    assert body == b""
+
+
+def test_20c_multi_token_te_gzip_chunked_is_detected():
+    # "gzip, chunked" contains "chunked" — the proxy must detect this as a
+    # chunked body (substring match covers multi-coding header values).
+    payload = b"5\r\nhello\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "gzip, chunked"})
+    assert body == b"hello"
+
+
+def test_20d_te_substring_notchunked_treated_as_chunked():
+    # The current implementation uses `"chunked" in te.lower()` (substring).
+    # "notchunked" contains "chunked" as a substring, so the code treats it as
+    # a chunked body.  This test documents the known permissive behavior.
+    # "notchunked" is not a valid RFC 7230 TE coding, so this edge case cannot
+    # arise from well-formed HTTP clients.
+    payload = b"5\r\nhello\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "notchunked"})
+    assert body == b"hello"
+
+
+def test_20e_te_identity_safe_boundary_returns_empty():
+    # Safe-boundary assertion: "identity" does not contain "chunked", so the
+    # proxy must NOT attempt to read a chunked body.  The request body is left
+    # unread (returns b"") — this is the safe fallback that prevents a crafted
+    # TE header from causing the proxy to hang waiting for chunk framing.
+    body = _run_read_body(b"some-data", {"Transfer-Encoding": "identity"})
+    assert body == b""
+
+
+def test_20f_te_chunkedx_treated_as_chunked_permissive():
+    # "chunkedx" contains "chunked" as a prefix substring → permissive match.
+    # Documents the same substring behavior as test_20d (notchunked).
+    payload = b"5\r\nhello\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "chunkedx"})
+    assert body == b"hello"
+
+
+def test_20g_te_xchunked_treated_as_chunked_permissive():
+    # "xchunked" contains "chunked" as a suffix substring → permissive match.
+    payload = b"5\r\nhello\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "xchunked"})
+    assert body == b"hello"
+
+
+async def test_21q_malformed_chunk_crlf_followed_by_valid_zero_chunk_permissive():
+    # When the 2-byte CRLF terminator after chunk data is replaced by non-CRLF
+    # bytes (here b"!!") but a valid zero-chunk terminator follows, _read_chunked
+    # silently consumes the invalid framing bytes and returns the chunk payload.
+    # This documents the permissive behavior: framing bytes are consumed but not
+    # validated.  "5\r\nhello!!0\r\n\r\n" → reads "hello", consumes "!!", then
+    # sees "0\r\n\r\n" as the terminator.
+    stream = b"5\r\nhello!!0\r\n\r\n"
+    reader = asyncio.StreamReader()
+    reader.feed_data(stream)
+    reader.feed_eof()
+    result = await http_io.read_request_body(reader, {"Transfer-Encoding": "chunked"})
+    assert result == b"hello"
+
+
+def test_21_read_request_body_chunked_terminator():
+    payload = b"5\r\nhello\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "chunked"})
+    assert body == b"hello"
+    assert b"0" not in body
+
+
+# --- C6: read_request_body error cases -------------------------------------
+
+def test_21a_content_length_larger_than_data():
+    # Current behavior: readexactly() cannot satisfy the declared length and
+    # raises IncompleteReadError; the bytes actually available are exposed on
+    # the exception's .partial attribute.
+    with pytest.raises(asyncio.IncompleteReadError) as exc_info:
+        _run_read_body(b"hello", {"Content-Length": "10"})
+    assert exc_info.value.partial == b"hello"
+
+
+def test_21b_chunked_malformed_size_line():
+    # Current behavior: a non-hex chunk-size token makes int(token, 16) raise
+    # ValueError. The proxy does not catch it — the error propagates.
+    with pytest.raises(ValueError):
+        _run_read_body(b"zz\r\nhello\r\n0\r\n\r\n", {"Transfer-Encoding": "chunked"})
+
+
+def test_21e_non_numeric_content_length_raises():
+    # A non-numeric Content-Length value makes int() raise ValueError.
+    with pytest.raises(ValueError):
+        _run_read_body(b"hello", {"Content-Length": "abc"})
+
+
+def test_21f_zero_content_length_returns_empty():
+    body = _run_read_body(b"ignored", {"Content-Length": "0"})
+    assert body == b""
+
+
+def test_21g_truncated_chunk():
+    # "5\r\nhel\r\n" declares 5 bytes but only 3 are provided before EOF.
+    # _read_chunked calls readexactly(5) which raises IncompleteReadError.
+    with pytest.raises(asyncio.IncompleteReadError):
+        _run_read_body(b"5\r\nhel\r\n", {"Transfer-Encoding": "chunked"})
+
+
+def test_21h_huge_content_length():
+    # A very large Content-Length with only a few bytes fed — readexactly()
+    # raises IncompleteReadError; the partial attribute holds the available bytes.
+    with pytest.raises(asyncio.IncompleteReadError) as exc_info:
+        _run_read_body(b"abc", {"Content-Length": "999999999999"})
+    assert exc_info.value.partial == b"abc"
+
+
+# --- C7: mixed-case TE and chunk extension ---------------------------------
+
+def test_21c_chunked_mixed_case_transfer_encoding():
+    # "Chunked" (mixed case) must still be detected as chunked.
+    payload = b"5\r\nhello\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "Chunked"})
+    assert body == b"hello"
+
+
+def test_21d_chunked_size_line_with_extension():
+    # "5;name=value" -> 5 bytes read, extension ignored.
+    payload = b"5;name=value\r\nhello\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "chunked"})
+    assert body == b"hello"
+
+
+def test_21j_content_length_wins_over_chunked_te():
+    # RFC 7230 §3.3.3: when both headers are present on a REQUEST, the proxy
+    # uses Content-Length (first match in read_request_body). This is the
+    # implemented priority. Feed exactly 5 bytes + trailing chunked data.
+    # Content-Length=5 means the first 5 bytes are consumed, not the chunked body.
+    #
+    # RFC 7230 §3.3.3 recommends treating CL+TE:chunked as a request-smuggling
+    # risk (reject the message or prefer TE:chunked over CL). The proxy
+    # intentionally keeps CL-wins because the only client is Claude Code, which
+    # never sends ambiguous framing. A rejection path is not implemented — this
+    # is a documented known deviation for this internal-only proxy.
+    # Policy guard: if CL-wins ever changes, update this test to match the new behavior.
+    payload = b"hello5\r\nworld\r\n0\r\n\r\n"
+    body = _run_read_body(payload, {"Content-Length": "5", "Transfer-Encoding": "chunked"})
+    assert body == b"hello"
+
+
+def test_21k_negative_content_length_raises():
+    with pytest.raises((ValueError, asyncio.IncompleteReadError)):
+        _run_read_body(b"hello", {"Content-Length": "-1"})
+
+
+def test_21l_chunked_with_single_trailer():
+    # The implementation drains ALL trailer lines after the zero-size chunk in a
+    # loop until it encounters a blank line. Verify the payload arrives correctly
+    # with a single trailer header + blank line terminator.
+    payload = b"5\r\nhello\r\n0\r\nX-Trailer: value\r\n\r\n"
+    body = _run_read_body(payload, {"Transfer-Encoding": "chunked"})
+    assert body == b"hello"
+
+
+async def test_21m_chunked_multiple_trailers_stream_exhausted():
+    # The implementation drains ALL trailer lines until a blank line. Verify
+    # that two trailer headers are consumed and the stream is fully exhausted.
+    payload = b"5\r\nhello\r\n0\r\nX-Foo: bar\r\nX-Baz: qux\r\n\r\n"
+    reader = asyncio.StreamReader()
+    reader.feed_data(payload)
+    reader.feed_eof()
+    body = await http_io.read_request_body(reader, {"Transfer-Encoding": "chunked"})
+    assert body == b"hello"
+    assert reader.at_eof()
+    # Buffer should be empty — stream fully consumed including trailers.
+    assert len(reader._buffer) == 0
+
+
+async def test_21n_chunked_eof_before_size_line_raises():
+    # _read_chunked must raise IncompleteReadError when the stream closes
+    # before any chunk-size line arrives (otherwise the readline loop spins
+    # forever on b'' EOF returns).
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    with pytest.raises(asyncio.IncompleteReadError):
+        await http_io.read_request_body(reader, {"Transfer-Encoding": "chunked"})
+
+
+async def test_21o_cl_wins_over_te_stream_remainder_not_consumed():
+    # RFC 7230 §3.3.2 / §3.3.3: when Content-Length and Transfer-Encoding are
+    # both present, Content-Length wins.  The chunked-encoded suffix that
+    # follows the CL body must remain in the stream so it cannot be silently
+    # forwarded as a second request body (request-smuggling boundary check).
+    cl_body = b"hello"
+    chunk_suffix = b"5\r\nworld\r\n0\r\n\r\n"
+    reader = asyncio.StreamReader()
+    reader.feed_data(cl_body + chunk_suffix)
+    reader.feed_eof()
+    headers = {
+        "Content-Length": str(len(cl_body)),
+        "Transfer-Encoding": "chunked",
+    }
+    result = await http_io.read_request_body(reader, headers)
+    assert result == cl_body
+    # The chunked suffix must still be in the stream buffer — it was NOT consumed.
+    remainder = await reader.read(len(chunk_suffix))
+    assert remainder == chunk_suffix
+
+
+async def test_21p_malformed_chunk_crlf_terminator_raises():
+    # _read_chunked calls readexactly(2) after each chunk's data to consume the
+    # CRLF framing, but does NOT validate those bytes are \r\n.  When the
+    # terminator is not \r\n (e.g. b"!!" replaces it), the 2 wrong bytes are
+    # consumed silently and the next chunk-size line cannot be parsed as hex,
+    # raising ValueError.  This test documents the current behavior.
+    # Frame: "5\r\nhello!!" — "!!" is the malformed CRLF, then no valid size
+    # line follows before EOF.
+    malformed = b"5\r\nhello!!"
+    reader = asyncio.StreamReader()
+    reader.feed_data(malformed)
+    reader.feed_eof()
+    with pytest.raises((ValueError, asyncio.IncompleteReadError)):
+        await http_io.read_request_body(reader, {"Transfer-Encoding": "chunked"})
+
+
+# ===========================================================================
+# proxy/http_io.py — sanitize_response_headers
+# ===========================================================================
+
+def test_22_sanitize_strips_te_and_connection():
+    headers = [
+        ("Content-Type", "application/json"),
+        ("Transfer-Encoding", "chunked"),
+        ("Connection", "keep-alive"),
+    ]
+    out = http_io.sanitize_response_headers(headers)
+    names = [n.lower() for n, _ in out]
+    assert "transfer-encoding" not in names
+    # Only the appended Connection: close remains.
+    assert names.count("connection") == 1
+    assert ("Connection", "close") in out
+
+
+def test_23_sanitize_strips_all_hop_by_hop():
+    headers = [
+        ("Connection", "x"),
+        ("Keep-Alive", "x"),
+        ("Proxy-Authenticate", "x"),
+        ("Proxy-Authorization", "x"),
+        ("TE", "x"),
+        ("Trailers", "x"),
+        ("Transfer-Encoding", "x"),
+        ("Upgrade", "x"),
+        ("Content-Type", "text/plain"),
+    ]
+    out = http_io.sanitize_response_headers(headers)
+    names = [n.lower() for n, _ in out]
+    for hop in http_io.HOP_BY_HOP:
+        # The only surviving "connection" is the appended close.
+        if hop == "connection":
+            continue
+        assert hop not in names
+    assert ("Content-Type", "text/plain") in out
+
+
+def test_24_sanitize_adds_connection_close():
+    out = http_io.sanitize_response_headers([("Content-Type", "text/plain")])
+    assert ("Connection", "close") in out
+
+
+def test_25_sanitize_preserves_non_hop_by_hop():
+    headers = [
+        ("Content-Type", "application/json"),
+        ("X-Request-Id", "abc-123"),
+    ]
+    out = http_io.sanitize_response_headers(headers)
+    assert ("Content-Type", "application/json") in out
+    assert ("X-Request-Id", "abc-123") in out
+
+
+def test_26_sanitize_empty_input():
+    out = http_io.sanitize_response_headers([])
+    assert out == [("Connection", "close")]
+
+
+def test_27_sanitize_case_insensitive_strip():
+    headers = [
+        ("TRANSFER-ENCODING", "chunked"),
+        ("CoNnEcTiOn", "keep-alive"),
+        ("UPGRADE", "h2c"),
+        ("Content-Type", "text/plain"),
+    ]
+    out = http_io.sanitize_response_headers(headers)
+    names = [n.lower() for n, _ in out]
+    assert "transfer-encoding" not in names
+    assert "upgrade" not in names
+    assert names.count("connection") == 1
+    assert ("Content-Type", "text/plain") in out
+
+
+def test_27a_sanitize_strips_connection_nominated_header():
+    # RFC 7230 6.1: a header named in the Connection value is hop-by-hop too.
+    headers = [
+        ("Connection", "X-Debug"),
+        ("X-Debug", "secret"),
+        ("Content-Type", "text/event-stream"),
+    ]
+    out = http_io.sanitize_response_headers(headers)
+    names = [n.lower() for n, _ in out]
+    assert "x-debug" not in names
+    assert ("Content-Type", "text/event-stream") in out
+    assert ("Connection", "close") in out
+
+
+def test_27b_sanitize_strips_multiple_connection_headers_with_csv_nominations():
+    # Two separate Connection tuples each nominating different headers via
+    # comma-separated values — all nominated headers must be stripped.
+    headers = [
+        ("Connection", "X-Debug, X-Trace"),
+        ("Connection", "X-Request-Id"),
+        ("X-Debug", "1"),
+        ("X-Trace", "2"),
+        ("X-Request-Id", "3"),
+        ("Content-Type", "text/plain"),
+    ]
+    out = http_io.sanitize_response_headers(headers)
+    names = [n.lower() for n, _ in out]
+    assert "x-debug" not in names
+    assert "x-trace" not in names
+    assert "x-request-id" not in names
+    assert ("Content-Type", "text/plain") in out
+    assert ("Connection", "close") in out

--- a/tests/feature-13-ds4-proxy/test_integration.py
+++ b/tests/feature-13-ds4-proxy/test_integration.py
@@ -1,0 +1,68 @@
+# Tests: proxy/normalize.py, proxy/http_io.py, proxy/auth.py
+# Tags: scope:issue-specific
+#
+# L3 gap (what this test suite does NOT catch — explicitly deferred):
+# - Real asyncio TLS handshake behavior with mkcert certificates
+# - Actual SSE streaming under CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1
+# - End-to-end chunked transfer between real client and upstream ds4 server
+# - Proxy handler integration (server.py not yet written; auth→normalize→
+#     forward→sanitize pipeline tested post-/write-code as L2 integration tests)
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+
+import pytest
+
+from proxy import auth, normalize
+
+
+# ===========================================================================
+# Proxy-level integration: verify_auth + apply_all per-request flow
+# ===========================================================================
+
+_INTEGRATION_TOKEN = "integration-test-token"
+
+
+def test_proxy_integration_auth_and_normalize():
+    """Chain verify_auth + apply_all to simulate the per-request server flow.
+
+    Checks:
+      1. verify_auth returns True for the correct token.
+      2. apply_all removes the dynamic section from system.
+      3. The dynamic section appears in the first user message.
+      4. The date is normalized (timestamp -> date only).
+      5. The system-reminder is stripped.
+    """
+    # Step 1: authentication
+    headers = {"Authorization": f"Bearer {_INTEGRATION_TOKEN}"}
+    assert auth.verify_auth(headers, _INTEGRATION_TOKEN) is True
+
+    # Step 2: normalization
+    body = {
+        "system": (
+            "You are helpful.\n"
+            "Working directory: C:\\git\\ds4-ops\n"
+            "Today's date is 2026-07-11T09:36:00Z\n"
+            "<system-reminder>hidden context</system-reminder>\n"
+        ),
+        "messages": [{"role": "user", "content": "run tests"}],
+        "tools": [{"name": "Write"}, {"name": "Bash"}],
+    }
+    out = normalize.apply_all(body)
+
+    # Dynamic section removed from system, placed in first user message.
+    assert "Working directory:" not in out["system"]
+    assert "Working directory: C:\\git\\ds4-ops" in out["messages"][0]["content"]
+
+    # Date normalized.
+    assert "Today's date is 2026-07-11" in out["system"]
+    assert "T09:36:00Z" not in out["system"]
+
+    # System-reminder stripped.
+    assert "system-reminder" not in out["system"]
+    assert "hidden context" not in out["system"]
+
+
+# (L3 gaps documented in file header)
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/feature-13-ds4-proxy/test_normalize_dynamic.py
+++ b/tests/feature-13-ds4-proxy/test_normalize_dynamic.py
@@ -1,0 +1,481 @@
+# Tests: proxy/normalize.py
+# Tags: scope:issue-specific
+#
+# L3 gap (what this test suite does NOT catch — explicitly deferred):
+# - Real asyncio TLS handshake behavior with mkcert certificates
+# - Actual SSE streaming under CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1
+# - End-to-end chunked transfer between real client and upstream ds4 server
+# - Proxy handler integration (server.py not yet written; auth→normalize→
+#     forward→sanitize pipeline tested post-/write-code as L2 integration tests)
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+
+import copy
+
+import pytest
+
+from proxy import normalize
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SYSTEM_WITH_CWD = (
+    "You are a helpful assistant.\n"
+    "Working directory: C:\\git\\ds4-ops\n"
+    "Be concise.\n"
+)
+
+
+# ===========================================================================
+# proxy/normalize.py — move_dynamic_sections (table-driven, C1 + C2)
+# ===========================================================================
+
+# Each case: (name, input_body, expected_removed_from_system, expected_in_user)
+#   * expected_removed_from_system: substrings that must NOT survive in system
+#   * expected_in_user: substrings that must appear in the first user message
+# Every entry in normalize.DYNAMIC_PATTERNS is covered by at least one case.
+_PREAMBLE = "You are a helpful assistant.\n"
+_USER_MSG = [{"role": "user", "content": "hello"}]
+
+MOVE_DYNAMIC_CASES = [
+    (
+        "working_directory",
+        {
+            "system": _PREAMBLE + "Working directory: C:\\git\\ds4-ops\n",
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["Working directory:"],
+        ["Working directory: C:\\git\\ds4-ops"],
+    ),
+    (
+        "is_directory_a_git_repo",
+        {
+            "system": _PREAMBLE + "Is directory a git repo: Yes\n",
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["Is directory a git repo:"],
+        ["Is directory a git repo: Yes"],
+    ),
+    (
+        "platform",
+        {
+            "system": _PREAMBLE + "Platform: win32\n",
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["Platform:"],
+        ["Platform: win32"],
+    ),
+    (
+        "os_version",
+        {
+            "system": _PREAMBLE + "OS Version: Windows 11 Home 10.0.26200\n",
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["OS Version:"],
+        ["OS Version: Windows 11 Home 10.0.26200"],
+    ),
+    (
+        "shell",
+        {
+            "system": _PREAMBLE + "Shell: PowerShell (primary)\n",
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["Shell:"],
+        ["Shell: PowerShell (primary)"],
+    ),
+    (
+        "auto_memory_path",
+        {
+            "system": _PREAMBLE + "You have a persistent, file-based memory system at `C:\\Users\\nire\\.claude\\projects\\ds4\\memory\\`.\n",
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["You have a persistent, file-based memory system at"],
+        ["You have a persistent, file-based memory system at `C:\\Users\\nire\\.claude\\projects\\ds4\\memory\\`."],
+    ),
+    (
+        "gitstatus_block_at_end",
+        {
+            "system": (
+                _PREAMBLE
+                + "gitStatus: This is the git status.\n"
+                + " M proxy/normalize.py\n"
+                + "?? tests/new.py\n"
+            ),
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["gitStatus:", " M proxy/normalize.py", "?? tests/new.py"],
+        ["gitStatus: This is the git status.", " M proxy/normalize.py"],
+    ),
+    (
+        "gitstatus_block_preserves_trailing_text",
+        # C4: a blank line terminates the gitStatus block; text after the
+        # blank line is STABLE and must remain in the system prompt, not be
+        # swallowed by the greedy DOTALL regex.
+        {
+            "system": (
+                _PREAMBLE
+                + "gitStatus: This is the git status.\n"
+                + " M proxy/normalize.py\n"
+                + "\n"
+                + "IMPORTANT: this context may or may not be relevant.\n"
+            ),
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        ["gitStatus:", " M proxy/normalize.py"],
+        ["gitStatus: This is the git status."],
+    ),
+    (
+        "multiple_sections",
+        {
+            "system": (
+                _PREAMBLE
+                + "Working directory: C:\\git\\ds4-ops\n"
+                + "Is directory a git repo: Yes\n"
+                + "Platform: win32\n"
+                + "OS Version: Windows 11\n"
+                + "Shell: PowerShell\n"
+                + "gitStatus: status.\n"
+                + " M a.py\n"
+            ),
+            "messages": copy.deepcopy(_USER_MSG),
+        },
+        [
+            "Working directory:",
+            "Is directory a git repo:",
+            "Platform:",
+            "OS Version:",
+            "Shell:",
+            "gitStatus:",
+        ],
+        [
+            "Working directory: C:\\git\\ds4-ops",
+            "Is directory a git repo: Yes",
+            "Platform: win32",
+            "OS Version: Windows 11",
+            "Shell: PowerShell",
+            "gitStatus: status.",
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, body, removed_from_system, in_user",
+    MOVE_DYNAMIC_CASES,
+    ids=[c[0] for c in MOVE_DYNAMIC_CASES],
+)
+def test_01_move_dynamic_sections_table(name, body, removed_from_system, in_user):
+    out = normalize.move_dynamic_sections(body)
+    system = out["system"]
+    for needle in removed_from_system:
+        assert needle not in system, f"[{name}] {needle!r} should be removed from system"
+    # The static preamble always survives.
+    assert "You are a helpful assistant." in system
+    user_content = out["messages"][0]["content"]
+    for needle in in_user:
+        assert needle in user_content, f"[{name}] {needle!r} should be moved into user"
+
+
+def test_01b_every_dynamic_pattern_has_a_case():
+    """Guard: every compiled DYNAMIC_PATTERN is exercised by a table case.
+
+    We match each pattern against the concatenated system prompts of all
+    cases; an unexercised pattern signals a coverage gap in the table.
+    """
+    all_systems = "\n".join(c[1]["system"] for c in MOVE_DYNAMIC_CASES)
+    for pat in normalize.DYNAMIC_PATTERNS:
+        assert pat.search(all_systems), f"pattern {pat.pattern!r} has no test case"
+
+
+def test_02_move_dynamic_sections_content_block_list():
+    body = {
+        "system": [
+            {"type": "text", "text": SYSTEM_WITH_CWD},
+        ],
+        "messages": [{"role": "user", "content": "hi there"}],
+    }
+    out = normalize.move_dynamic_sections(body)
+    assert "Working directory:" not in out["system"][0]["text"]
+    assert "Working directory: C:\\git\\ds4-ops" in out["messages"][0]["content"]
+
+
+def test_03_move_dynamic_sections_no_dynamic():
+    body = {
+        "system": "You are a helpful assistant.\nBe concise.\n",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    out = normalize.move_dynamic_sections(body)
+    assert out["system"] == body["system"]
+    assert out["messages"][0]["content"] == "hello"
+
+
+def test_04_move_dynamic_sections_no_messages_key():
+    # C3: with no messages to attach to, the dynamic content is discarded
+    # (there is no user message target), but the system prompt is STILL
+    # cleaned and the call must not crash. This documents that behavior:
+    # the dynamic content is not silently *kept* in system — it is stripped.
+    #
+    # The dynamic section WAS extracted from system (verified below: "Working
+    # directory:" is absent). With no user message to receive it, the content
+    # is DISCARDED — not stored elsewhere, not accumulated. This is by design:
+    # the proxy opts for cache stability over dynamic-content preservation when
+    # there is no target message slot.
+    body = {"system": SYSTEM_WITH_CWD}
+    out = normalize.move_dynamic_sections(body)
+    # System is cleaned even though there was nowhere to move the content to.
+    assert "Working directory:" not in out["system"]
+    assert "You are a helpful assistant." in out["system"]
+    # No messages key was invented, and nothing crashed.
+    assert "messages" not in out
+    # by design: dynamic content is discarded when there is no user message target
+    assert "Working directory: C:\\git\\ds4-ops" not in out["system"]
+
+
+def test_04b_gitstatus_does_not_eat_text_after_blank_line():
+    # C4 (dedicated): the greedy DOTALL gitStatus regex must NOT consume
+    # stable text that follows a blank line after the status listing.
+    stable = "IMPORTANT: this context may or may not be relevant to your tasks."
+    system = (
+        "You are helpful.\n"
+        "gitStatus: This is the git status.\n"
+        " M proxy/normalize.py\n"
+        "?? tests/new.py\n"
+        "\n"
+        f"{stable}\n"
+    )
+    body = {"system": system, "messages": [{"role": "user", "content": "go"}]}
+    out = normalize.move_dynamic_sections(body)
+    # Stable trailing text is preserved in the system prompt.
+    assert stable in out["system"]
+    # But the gitStatus block itself was lifted out.
+    assert "gitStatus:" not in out["system"]
+    assert " M proxy/normalize.py" not in out["system"]
+    # And the gitStatus block landed in the user message (not the stable text).
+    user = out["messages"][0]["content"]
+    assert "gitStatus: This is the git status." in user
+    assert stable not in user
+
+
+# --- move_dynamic_sections edge cases --------------------------------------
+
+def test_04c_user_content_already_a_list():
+    """When first user message content is already a list, dynamic section is
+    appended as a new content block (not string-concatenated to the first block).
+    """
+    body = {
+        "system": "You are helpful.\nWorking directory: C:\\git\\ds4-ops\n",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "existing block"},
+                ],
+            }
+        ],
+    }
+    out = normalize.move_dynamic_sections(body)
+    # System should be cleaned.
+    assert "Working directory:" not in out["system"]
+    # First user message content remains a list.
+    content = out["messages"][0]["content"]
+    assert isinstance(content, list)
+    # A new block containing the dynamic section must have been appended.
+    combined = " ".join(block.get("text", "") for block in content)
+    assert "Working directory: C:\\git\\ds4-ops" in combined
+
+
+def test_04d_none_content_in_user_message_does_not_crash():
+    """A user message with content=None must not raise; dynamic section goes
+    to that message slot (None -> appendix string) per the else branch.
+    """
+    body = {
+        "system": "You are helpful.\nWorking directory: C:\\git\\ds4-ops\n",
+        "messages": [{"role": "user", "content": None}],
+    }
+    # Must not raise.
+    out = normalize.move_dynamic_sections(body)
+    # System is cleaned.
+    assert "Working directory:" not in out["system"]
+    # The user message content received the appendix (None branch -> appendix).
+    assert "Working directory: C:\\git\\ds4-ops" in out["messages"][0]["content"]
+
+
+def test_04e_empty_string_content_in_user_message():
+    """A user message with empty-string content gets the dynamic section appended."""
+    body = {
+        "system": "You are helpful.\nPlatform: win32\n",
+        "messages": [{"role": "user", "content": ""}],
+    }
+    out = normalize.move_dynamic_sections(body)
+    assert "Platform:" not in out["system"]
+    assert "Platform: win32" in out["messages"][0]["content"]
+
+
+def test_04f_only_assistant_messages_does_not_crash():
+    """When messages contains only assistant roles, no user target exists —
+    the dynamic content is discarded but no exception is raised and the
+    system prompt is still cleaned.
+    """
+    # The dynamic section WAS extracted from system (verified below: "OS Version:"
+    # is absent). With no user message to receive it, the content is DISCARDED —
+    # not stored elsewhere, not accumulated. This is by design: the proxy opts for
+    # cache stability over dynamic-content preservation when there is no target.
+    body = {
+        "system": "You are helpful.\nOS Version: Windows 11\n",
+        "messages": [{"role": "assistant", "content": "Sure."}],
+    }
+    out = normalize.move_dynamic_sections(body)
+    # System is cleaned.
+    assert "OS Version:" not in out["system"]
+    # by design: dynamic content is discarded when there is no user message target
+    # Assistant message is unchanged.
+    assert out["messages"][0]["content"] == "Sure."
+
+
+def test_04f2_assistant_then_user_dynamic_goes_to_user():
+    # When assistant messages precede the first user message, move_dynamic_sections
+    # must skip the assistant entries and append the extracted section to the
+    # first user message (the break-on-first-user-match path).
+    body = {
+        "system": "You are helpful.\nShell: bash\n",
+        "messages": [
+            {"role": "assistant", "content": "Welcome!"},
+            {"role": "user", "content": "Hello."},
+        ],
+    }
+    out = normalize.move_dynamic_sections(body)
+    assert "Shell:" not in out["system"]
+    assert out["messages"][0]["content"] == "Welcome!"  # assistant unchanged
+    assert "Shell: bash" in out["messages"][1]["content"]  # user received it
+
+
+def test_04f3_empty_messages_list_system_still_cleaned():
+    # `messages: []` (present but empty) is distinct from no 'messages' key.
+    # Dynamic sections must still be extracted from system, but since there is
+    # no user message to append to, the content is discarded — no crash.
+    body = {
+        "system": "You are helpful.\nPlatform: win32\n",
+        "messages": [],
+    }
+    out = normalize.move_dynamic_sections(body)
+    assert "Platform:" not in out["system"]
+    assert out["messages"] == []
+
+
+def test_04g_non_dict_message_entry_raises():
+    # Non-dict entries in the messages list cause AttributeError because the
+    # code calls .get() on each entry. Claude Code always sends well-formed
+    # Anthropic API requests, so this case cannot arise in production.
+    body = {
+        "system": SYSTEM_WITH_CWD,
+        "messages": ["not-a-dict"],
+    }
+    with pytest.raises(AttributeError):
+        normalize.move_dynamic_sections(body)
+
+
+# ===========================================================================
+# proxy/normalize.py — normalize_date (table-driven)
+# ===========================================================================
+
+_NORMALIZE_DATE_CASES = [
+    (
+        "timestamp_z_suffix",
+        {"system": "Today's date is 2026-07-11T09:36:00Z\nHello."},
+        "Today's date is 2026-07-11",
+        "T09:36:00Z",
+    ),
+    (
+        "timestamp_tz_offset",
+        {"system": "Today's date is 2026-07-11T09:36:00+09:00\nHello."},
+        "Today's date is 2026-07-11",
+        "T09:36:00+09:00",
+    ),
+    (
+        "already_date_only",
+        {"system": "Today's date is 2026-07-11\nHello."},
+        "Today's date is 2026-07-11",
+        None,  # no substring to assert absent
+    ),
+    (
+        "malformed_kept_as_is",
+        {"system": "Today's date is sometime-soon\nHello."},
+        None,  # no assertion on present string
+        None,
+    ),
+    (
+        "space_separated_timestamp",
+        {"system": "Today's date is 2026-07-11 09:36:00\nHello."},
+        "Today's date is 2026-07-11",
+        " 09:36:00",
+    ),
+    (
+        "malformed_time_no_separator_date_preserved",
+        # "2026-07-1109:00" — no T or space between date and time.
+        # The regex (?:[T ][0-9:.\-+Z]*)? requires [T ] as separator;
+        # "0" (first char of "09:00") is not a separator so the optional
+        # group does not match.  Result: date retained, "09:00" not consumed.
+        {"system": "Today's date is 2026-07-1109:00\nHello."},
+        "Today's date is 2026-07-11",
+        None,
+    ),
+    (
+        "malformed_time_after_T_date_preserved",
+        # "2026-07-11Tnot-a-time" — T matches [T ] but subsequent chars
+        # "not-a-time" are not in [0-9:.\-+Z].  The optional group matches
+        # only "T" (zero-length [0-9:.\-+Z]* match), consuming the T.
+        # Remaining "not-a-time" stays in the string.
+        # Date is correctly extracted; no corruption of the date value.
+        {"system": "Today's date is 2026-07-11Tnot-a-time\nHello."},
+        "Today's date is 2026-07-11",
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, body, present, absent",
+    _NORMALIZE_DATE_CASES,
+    ids=[c[0] for c in _NORMALIZE_DATE_CASES],
+)
+def test_06_normalize_date_table(name, body, present, absent):
+    import copy as _copy
+    original = _copy.deepcopy(body)
+    out = normalize.normalize_date(body)
+    if present is not None:
+        assert present in out["system"], f"[{name}] expected {present!r} in system"
+    if absent is not None:
+        assert absent not in out["system"], f"[{name}] expected {absent!r} absent from system"
+    if name == "malformed_kept_as_is":
+        assert out["system"] == original["system"]
+    if name == "already_date_only":
+        assert out["system"] == original["system"]
+
+
+def test_06b_normalize_date_list_shaped_system():
+    """normalize_date strips timestamp from list-shaped system content blocks."""
+    body = {
+        "system": [
+            {"type": "text", "text": "Today's date is 2026-07-11T09:36:00Z\nBe helpful."},
+        ]
+    }
+    out = normalize.normalize_date(body)
+    block_text = out["system"][0]["text"]
+    assert "Today's date is 2026-07-11" in block_text
+    assert "T09:36:00Z" not in block_text
+
+
+def test_06c_normalize_date_skips_non_text_block():
+    # Non-text content blocks (e.g. cache_control) carry no "text" field;
+    # they must be preserved unchanged and not cause a crash.
+    body = {
+        "system": [
+            {"type": "text", "text": "Today's date is 2026-07-11T09:36:00Z"},
+            {"type": "cache_control", "ttl": 3600},
+        ]
+    }
+    out = normalize.normalize_date(body)
+    assert out["system"][0]["text"] == "Today's date is 2026-07-11"
+    assert out["system"][1] == {"type": "cache_control", "ttl": 3600}

--- a/tests/feature-13-ds4-proxy/test_normalize_reminder.py
+++ b/tests/feature-13-ds4-proxy/test_normalize_reminder.py
@@ -1,0 +1,384 @@
+# Tests: proxy/normalize.py
+# Tags: scope:issue-specific
+#
+# L3 gap (what this test suite does NOT catch — explicitly deferred):
+# - Real asyncio TLS handshake behavior with mkcert certificates
+# - Actual SSE streaming under CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1
+# - End-to-end chunked transfer between real client and upstream ds4 server
+# - Proxy handler integration (server.py not yet written; auth→normalize→
+#     forward→sanitize pipeline tested post-/write-code as L2 integration tests)
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+
+import pytest
+
+from proxy import normalize
+
+
+# ===========================================================================
+# proxy/normalize.py — move_dynamic_sections: image block edge case
+# ===========================================================================
+
+def test_image_block_preserved_by_move_dynamic():
+    """Non-text blocks (image) in user content are preserved by move_dynamic_sections.
+
+    The dynamic section is appended as a new text block; the existing image
+    block at index 0 is untouched.
+    """
+    body = {
+        "system": "You are helpful.\nWorking directory: C:\\git\\ds4-ops\n",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": "image/png", "data": "abc"},
+                    },
+                    {"type": "text", "text": "hi"},
+                ],
+            }
+        ],
+    }
+    out = normalize.move_dynamic_sections(body)
+    # System is cleaned.
+    assert "Working directory:" not in out["system"]
+    # Image block is still present at index 0.
+    content = out["messages"][0]["content"]
+    assert isinstance(content, list)
+    assert content[0]["type"] == "image"
+    assert content[0]["source"]["data"] == "abc"
+    # Dynamic section was appended as a new text block.
+    combined = " ".join(b.get("text", "") for b in content)
+    assert "Working directory: C:\\git\\ds4-ops" in combined
+
+
+# ===========================================================================
+# proxy/normalize.py — strip_system_reminders (table-driven)
+# ===========================================================================
+
+_STRIP_REMINDER_CASES = [
+    (
+        "single_reminder",
+        "before<system-reminder>secret</system-reminder>after",
+        "beforeafter",
+    ),
+    (
+        "multiple_reminders",
+        (
+            "a<system-reminder>one</system-reminder>"
+            "b<system-reminder>two</system-reminder>c"
+        ),
+        "abc",
+    ),
+    (
+        "multiline_dotall",
+        "start<system-reminder>\nline one\nline two\n</system-reminder>end",
+        "startend",
+    ),
+    (
+        "no_reminder",
+        "no reminders here",
+        "no reminders here",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, system_text, expected",
+    _STRIP_REMINDER_CASES,
+    ids=[c[0] for c in _STRIP_REMINDER_CASES],
+)
+def test_09_strip_system_reminders_table(name, system_text, expected):
+    body = {"system": system_text}
+    out = normalize.strip_system_reminders(body)
+    assert out["system"] == expected
+    assert "system-reminder" not in out["system"]
+
+
+def test_09b_strip_reminders_list_shaped_system():
+    """strip_system_reminders strips reminder from list-shaped system blocks."""
+    body = {
+        "system": [
+            {"type": "text", "text": "keep<system-reminder>hidden</system-reminder>me"},
+            {"type": "text", "text": "no reminder here"},
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    assert out["system"][0]["text"] == "keepme"
+    assert out["system"][1]["text"] == "no reminder here"
+
+
+def test_09c_strip_reminders_skips_non_text_block():
+    # Non-text content blocks (e.g. cache_control) carry no "text" field;
+    # they must be preserved unchanged and not cause a crash.
+    body = {
+        "system": [
+            {"type": "text", "text": "before<system-reminder>x</system-reminder>after"},
+            {"type": "cache_control", "ttl": 3600},
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    assert out["system"][0]["text"] == "beforeafter"
+    assert out["system"][1] == {"type": "cache_control", "ttl": 3600}
+
+
+def test_11a_strip_nested_system_reminders():
+    # Nested: <system-reminder>a<system-reminder>b</system-reminder>c</system-reminder>
+    # The lazy regex matches the FIRST close tag, so it strips
+    # "<system-reminder>a<system-reminder>b</system-reminder>" in one pass,
+    # leaving "c</system-reminder>end". The orphan-close pass then removes
+    # the dangling "</system-reminder>", yielding "cend". Content ("a", "b")
+    # inside the outer tag is dropped; "c" between the inner close and the
+    # outer close survives because the lazy match consumed the outer open tag
+    # together with "a" and the inner open tag.
+    body = {"system": "<system-reminder>a<system-reminder>b</system-reminder>c</system-reminder>end"}
+    out = normalize.strip_system_reminders(body)
+    assert "system-reminder" not in out["system"]
+    assert out["system"] == "cend"
+
+
+def test_11b_strip_unclosed_system_reminder_tag():
+    # An unclosed <system-reminder> tag does not match the complete-pair regex
+    # and is left in place. This is the safe/conservative behavior: do not
+    # accidentally strip content when the close tag is missing.
+    body = {"system": "before<system-reminder>unclosed content"}
+    out = normalize.strip_system_reminders(body)
+    assert out["system"] == body["system"]
+
+
+# --- C5: strip_system_reminders acting on message content ------------------
+
+def test_12a_strip_reminders_from_user_message_string():
+    body = {
+        "system": "sys",
+        "messages": [
+            {
+                "role": "user",
+                "content": "hi <system-reminder>hidden context</system-reminder>there",
+            }
+        ],
+    }
+    out = normalize.strip_system_reminders(body)
+    assert out["messages"][0]["content"] == "hi there"
+    assert "system-reminder" not in out["messages"][0]["content"]
+
+
+def test_12b_strip_reminders_from_assistant_message():
+    # The implementation iterates all messages regardless of role, so an
+    # assistant message with a reminder is also stripped.
+    body = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": "ok<system-reminder>note</system-reminder>done",
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    assert out["messages"][0]["content"] == "okdone"
+
+
+def test_12c_strip_reminders_from_content_block_list():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "keep<system-reminder>x</system-reminder>me"},
+                    {"type": "text", "text": "no reminder here"},
+                ],
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    blocks = out["messages"][0]["content"]
+    assert blocks[0]["text"] == "keepme"
+    assert blocks[1]["text"] == "no reminder here"
+
+
+def test_12d_strip_reminders_from_tool_result_list_content():
+    # tool_result blocks with list-shaped "content" (nested text blocks)
+    # should have their text blocks stripped too.
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "x",
+                        "content": [
+                            {"type": "text", "text": "result<system-reminder>r</system-reminder>here"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    sub_block = out["messages"][0]["content"][0]["content"][0]
+    assert sub_block["text"] == "resulthere"
+    assert "system-reminder" not in sub_block["text"]
+
+
+def test_12e_unclosed_reminder_in_user_message():
+    # Unclosed <system-reminder> in user message content: no close tag means
+    # the regex finds no complete pair; content is left unchanged (conservative).
+    body = {
+        "messages": [{"role": "user", "content": "hi<system-reminder>no close"}]
+    }
+    out = normalize.strip_system_reminders(body)
+    assert out["messages"][0]["content"] == "hi<system-reminder>no close"
+
+
+def test_12g_unclosed_reminder_in_tool_result_string_content_branch():
+    # Explicit coverage of the `elif isinstance(block.get('content'), str)` branch
+    # in strip_system_reminders: a tool_result block whose "content" field is a
+    # string with an unclosed <system-reminder> must be left unchanged.
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-abc",
+                        "content": "output<system-reminder>injected",
+                    }
+                ],
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    block = out["messages"][0]["content"][0]
+    # Conservative: no close tag → regex finds no match → content unchanged.
+    assert block["content"] == "output<system-reminder>injected"
+
+
+def test_12f_unclosed_reminder_in_tool_result():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "x",
+                     "content": "result<system-reminder>no close"},
+                ],
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    tool_block = out["messages"][0]["content"][0]
+    assert tool_block["content"] == "result<system-reminder>no close"
+
+
+def test_12h_adversarial_reminder_complete_pair_removed():
+    # Security assertion: adversarial injection of a COMPLETE <system-reminder>
+    # pair inside user message content IS removed by strip_system_reminders.
+    # This is the primary security property — closed reminders cannot smuggle
+    # context into the normalized request body.
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Hi.<system-reminder>INJECTED CONTEXT</system-reminder>Hello.",
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    assert "INJECTED CONTEXT" not in out["messages"][0]["content"]
+    assert "system-reminder" not in out["messages"][0]["content"]
+    assert "Hi." in out["messages"][0]["content"]
+    assert "Hello." in out["messages"][0]["content"]
+
+
+def test_12i_adversarial_unclosed_reminder_conservative_not_removed():
+    # Security design note: the implementation is CONSERVATIVE for unclosed
+    # tags — it does NOT remove content after an unclosed <system-reminder>.
+    # This prevents false positives (stripping legitimate user content that
+    # happens to start with the tag).  The trade-off is accepted because
+    # Claude Code always sends well-formed, matched open/close tags; a bare
+    # open tag without a close is a malformed injection that the model is
+    # unlikely to misinterpret as authoritative context.
+    body = {
+        "messages": [
+            {"role": "user", "content": "start<system-reminder>partial injection"}
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    # Conservative: unclosed tag and trailing text are preserved.
+    assert out["messages"][0]["content"] == "start<system-reminder>partial injection"
+
+
+def test_tool_result_reminder_stripped_from_content_string():
+    """strip_system_reminders strips reminders from tool_result blocks with a
+    string 'content' field (not just from blocks with a 'text' field).
+
+    The implementation handles the elif branch: when a block has no 'text' key
+    but its 'content' value is a string, strip_system_reminders also strips there.
+    """
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "x",
+                        "content": "ok<system-reminder>r</system-reminder>done",
+                    }
+                ],
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    block = out["messages"][0]["content"][0]
+    # Block type and tool_use_id are preserved.
+    assert block["type"] == "tool_result"
+    assert block["tool_use_id"] == "x"
+    # The reminder IS stripped from the string 'content' field.
+    assert block["content"] == "okdone"
+    assert "system-reminder" not in block["content"]
+
+
+def test_tool_result_list_content_mixed_text_and_nontextblocks():
+    # C4: nested tool_result where 'content' is a list containing both a text
+    # block WITH a system-reminder AND a non-text block (image).
+    # strip_system_reminders must strip from the text sub-block and leave the
+    # image sub-block untouched (it has no 'text' key).
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tr-1",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "before<system-reminder>injected</system-reminder>after",
+                            },
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": "abc",
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    out = normalize.strip_system_reminders(body)
+    sub_blocks = out["messages"][0]["content"][0]["content"]
+    # Text block: reminder stripped, surrounding text preserved.
+    assert sub_blocks[0]["text"] == "beforeafter"
+    assert "system-reminder" not in sub_blocks[0]["text"]
+    # Image block: unchanged.
+    assert sub_blocks[1]["type"] == "image"
+    assert sub_blocks[1]["source"]["data"] == "abc"

--- a/tests/feature-13-ds4-proxy/test_normalize_sort_apply.py
+++ b/tests/feature-13-ds4-proxy/test_normalize_sort_apply.py
@@ -1,0 +1,246 @@
+# Tests: proxy/normalize.py
+# Tags: scope:issue-specific
+#
+# L3 gap (what this test suite does NOT catch — explicitly deferred):
+# - Real asyncio TLS handshake behavior with mkcert certificates
+# - Actual SSE streaming under CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1
+# - End-to-end chunked transfer between real client and upstream ds4 server
+# - Proxy handler integration (server.py not yet written; auth→normalize→
+#     forward→sanitize pipeline tested post-/write-code as L2 integration tests)
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+
+import copy
+
+import pytest
+
+from proxy import normalize
+
+
+# ===========================================================================
+# proxy/normalize.py — sort_tools
+# ===========================================================================
+
+def test_13_sort_tools_mixed_order():
+    body = {
+        "tools": [
+            {"name": "Write"},
+            {"name": "Bash"},
+            {"name": "Read"},
+        ]
+    }
+    out = normalize.sort_tools(body)
+    assert [t["name"] for t in out["tools"]] == ["Bash", "Read", "Write"]
+
+
+def test_14_sort_tools_no_tools_key():
+    body = {"system": "hi"}
+    out = normalize.sort_tools(body)
+    assert out == body
+
+
+def test_15_sort_tools_idempotent():
+    body = {
+        "tools": [
+            {"name": "Write"},
+            {"name": "Bash"},
+            {"name": "Read"},
+        ]
+    }
+    once = normalize.sort_tools(body)
+    twice = normalize.sort_tools(once)
+    assert once == twice
+
+
+# --- C8: sort_tools edge cases ---------------------------------------------
+
+def test_15a_sort_tools_empty_list():
+    body = {"tools": []}
+    out = normalize.sort_tools(body)
+    assert out["tools"] == []
+
+
+def test_15b_sort_tools_duplicate_names_stable():
+    # Duplicate names: both appear; Python's sorted() is stable, so the two
+    # "A" entries keep their original relative order (id 1 before id 2).
+    body = {
+        "tools": [
+            {"name": "A", "id": 1},
+            {"name": "A", "id": 2},
+            {"name": "B", "id": 3},
+        ]
+    }
+    out = normalize.sort_tools(body)
+    assert [(t["name"], t["id"]) for t in out["tools"]] == [
+        ("A", 1),
+        ("A", 2),
+        ("B", 3),
+    ]
+
+
+def test_15c_sort_tools_missing_name_key():
+    # Actual behavior: t.get('name', '') treats a missing name as the empty
+    # string, which sorts BEFORE any real name. No crash; the tool is kept.
+    body = {
+        "tools": [
+            {"name": "Write"},
+            {"noname": "x"},
+            {"name": "Bash"},
+        ]
+    }
+    out = normalize.sort_tools(body)
+    names = [t.get("name") for t in out["tools"]]
+    assert names == [None, "Bash", "Write"]
+    # The nameless tool is preserved intact, not dropped.
+    assert {"noname": "x"} in out["tools"]
+
+
+def test_15d_sort_tools_explicit_none_name():
+    # When a tool has {"name": None}, t.get('name', '') returns None (the stored
+    # value, not the default ''), because the key IS present. Python 3 cannot
+    # compare None < str, so sorted() raises TypeError.
+    # This test documents the actual behavior: sort_tools propagates the error.
+    body = {
+        "tools": [
+            {"name": "Write"},
+            {"name": None},
+            {"name": "Bash"},
+        ]
+    }
+    with pytest.raises(TypeError):
+        normalize.sort_tools(body)
+
+
+def test_15e_non_dict_tool_entry_raises():
+    # Same: a non-dict tool entry causes AttributeError in the sort lambda.
+    body = {"tools": ["not-a-dict", {"name": "Bash"}]}
+    with pytest.raises(AttributeError):
+        normalize.sort_tools(body)
+
+
+# ===========================================================================
+# proxy/normalize.py — immutability (C9)
+# ===========================================================================
+
+def _dynamic_body():
+    return {
+        "system": (
+            "You are helpful.\n"
+            "Working directory: C:\\git\\ds4-ops\n"
+            "Today's date is 2026-07-11T09:36:00Z\n"
+            "<system-reminder>hidden</system-reminder>\n"
+        ),
+        "messages": [{"role": "user", "content": "run"}],
+        "tools": [{"name": "Write"}, {"name": "Bash"}],
+    }
+
+
+def test_immutable_move_dynamic_sections():
+    body = _dynamic_body()
+    snapshot = copy.deepcopy(body)
+    normalize.move_dynamic_sections(body)
+    assert body == snapshot
+
+
+def test_immutable_normalize_date():
+    body = _dynamic_body()
+    snapshot = copy.deepcopy(body)
+    normalize.normalize_date(body)
+    assert body == snapshot
+
+
+def test_immutable_strip_system_reminders():
+    body = _dynamic_body()
+    snapshot = copy.deepcopy(body)
+    normalize.strip_system_reminders(body)
+    assert body == snapshot
+
+
+def test_immutable_sort_tools():
+    body = _dynamic_body()
+    snapshot = copy.deepcopy(body)
+    normalize.sort_tools(body)
+    assert body == snapshot
+
+
+# === Idempotency ===
+
+
+def _idempotency_body():
+    """A body that exercises all four normalization rules at once."""
+    return {
+        "system": (
+            "You are helpful.\n"
+            "Working directory: C:\\git\\ds4-ops\n"
+            "Today's date is 2026-07-11T09:36:00Z\n"
+            "<system-reminder>hidden</system-reminder>\n"
+        ),
+        "messages": [{"role": "user", "content": "run"}],
+        "tools": [{"name": "Write"}, {"name": "Bash"}],
+    }
+
+
+def test_idempotent_move_dynamic_sections():
+    body = _idempotency_body()
+    first = normalize.move_dynamic_sections(body)
+    second = normalize.move_dynamic_sections(first)
+    # Second call must not re-append dynamic sections into user content.
+    assert second["system"] == first["system"]
+    assert second["messages"][0]["content"] == first["messages"][0]["content"]
+
+
+def test_idempotent_normalize_date():
+    body = _idempotency_body()
+    first = normalize.normalize_date(body)
+    second = normalize.normalize_date(first)
+    assert second == first
+
+
+def test_idempotent_strip_system_reminders():
+    body = _idempotency_body()
+    first = normalize.strip_system_reminders(body)
+    second = normalize.strip_system_reminders(first)
+    assert second == first
+
+
+def test_idempotent_apply_all():
+    body = _idempotency_body()
+    first = normalize.apply_all(body)
+    second = normalize.apply_all(first)
+    assert second == first
+
+
+# ===========================================================================
+# proxy/normalize.py — apply_all
+# ===========================================================================
+
+def test_16_apply_all_order_and_all_rules():
+    body = {
+        "system": (
+            "You are helpful.\n"
+            "Working directory: C:\\git\\ds4-ops\n"
+            "Today's date is 2026-07-11T09:36:00Z\n"
+            "<system-reminder>hidden</system-reminder>\n"
+        ),
+        "messages": [{"role": "user", "content": "run"}],
+        "tools": [
+            {"name": "Write"},
+            {"name": "Bash"},
+        ],
+    }
+    out = normalize.apply_all(body)
+    # A: dynamic section lifted out of system, into user message.
+    assert "Working directory:" not in out["system"]
+    assert "Working directory: C:\\git\\ds4-ops" in out["messages"][0]["content"]
+    # B: date normalized.
+    assert "Today's date is 2026-07-11" in out["system"]
+    assert "T09:36:00Z" not in out["system"]
+    # C: system-reminder stripped.
+    assert "system-reminder" not in out["system"]
+    # D: tools sorted.
+    assert [t["name"] for t in out["tools"]] == ["Bash", "Write"]
+
+
+def test_17_apply_all_empty_body():
+    out = normalize.apply_all({})
+    assert out == {}

--- a/tests/test_feature-13-ds4-proxy.py
+++ b/tests/test_feature-13-ds4-proxy.py
@@ -1,0 +1,27 @@
+# Tests: proxy/normalize.py, proxy/http_io.py, proxy/auth.py
+# Tags: scope:issue-specific
+#
+# L3 gap (what this test suite does NOT catch — explicitly deferred):
+# - Real asyncio TLS handshake behavior with mkcert certificates
+# - Actual SSE streaming under CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1
+# - End-to-end chunked transfer between real client and upstream ds4 server
+# - Proxy handler integration (server.py not yet written; auth→normalize→
+#     forward→sanitize pipeline tested post-/write-code as L2 integration tests)
+# - Launcher scripts (ds4-server.sh, code-ds4.cmd, ds4-proxy.sh not yet
+#     written; bind address, HTTPS URL, NODE_EXTRA_CA_CERTS, KV-cache flags
+#     deferred to post-/write-code)
+# - .env.example / docs consistency (files not yet written; env var, host/port
+#     SSOT, TLS setup validation deferred to post-/write-code)
+# - tee-log security (tee.py not yet written; logging toggle, pre/post-norm
+#     body files, no auth-token leakage in logs deferred to post-/write-code)
+# - Malformed JSON shape at handler level (server.py not yet written; non-list
+#     messages, non-dict entries, non-list tools → controlled 4xx coverage
+#     deferred to post-/write-code as L2 handler integration tests)
+# - Security idempotency (repeated starts, duplicate CA/env entries: deferred
+#     to post-/write-code environment-level tests)
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+"""Dispatcher: all tests live in tests/feature-13-ds4-proxy/.
+
+pytest discovers the subdirectory automatically — no test functions here.
+"""

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,177 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "ds4-proxy"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "httpx", specifier = ">=0.27" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Summary

- Add Python asyncio TLS reverse proxy (`proxy/`) in front of ds4-server for prompt normalization, TLS termination, and token auth
- Normalize prompts before forwarding to ds4: strip volatile system-prompt lines (move to first user message), collapse timestamped date, remove `<system-reminder>` blocks, sort tools deterministically — stabilizes KV cache prefix for higher hit rates
- Token authentication via `hmac.compare_digest`; `DS4_PROXY_AUTH_TOKEN` required at startup
- SSE passthrough with zero buffering (`CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1` compatible)
- 10 MB body size limit (413 on exceed); hop-by-hop header stripping; close-delimited responses
- ds4-server bind address changed from `0.0.0.0` to `127.0.0.1`; proxy is now the sole LAN endpoint
- Windows launcher (`code-ds4.cmd`) updated to HTTPS URL and `NODE_EXTRA_CA_CERTS` via `DS4_CA_CERT`
- 118 tests (L1 unit) covering normalization rules, HTTP framing, and auth

<!-- issue-close-pr-of: 13 -->

## Test plan
- [ ] `uv run pytest tests/feature-13-ds4-proxy/ -q` — all 118 tests pass
- [ ] `mkcert -install && mkcert -cert-file ~/.config/ds4-proxy/cert.pem -key-file ~/.config/ds4-proxy/key.pem localhost <mac-lan-ip>` on Mac
- [ ] Set `DS4_PROXY_AUTH_TOKEN` in repo-root `.env`, start proxy with `scripts/ds4-proxy.sh`
- [ ] Start ds4-server with `scripts/ds4-server.sh` (now binds to 127.0.0.1)
- [ ] Set `DS4_CA_CERT` and `DS4_ANTHROPIC_BASE_URL=https://<mac-ip>:8443` in Windows `.env`, launch `scripts/code-ds4.cmd`
- [ ] Run `/context` in Claude Code — verify window ~393216; confirm SSE streams without hanging
- [ ] Send wrong auth token — confirm 401 response
- [ ] Enable `DS4_PROXY_TEE=on` — confirm pre/post JSON files appear in log dir

Closes #13