### PR TITLE
feat(ops): unified ds4ctl control command, launchd auto-start, log control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,16 @@ DS4_PROXY_TEE=off
 # Where DS4_PROXY_TEE writes its logs. Has no effect while DS4_PROXY_TEE is off.
 # Format: absolute path — e.g. DS4_PROXY_LOG_DIR=~/Library/Caches/ds4-proxy/log
 DS4_PROXY_LOG_DIR=~/Library/Caches/ds4-proxy/log
+
+# --- ds4 ops (lifecycle / logging) ---
+
+# Write ds4 service stdout/stderr to log files (proxy.log / kvcache.log).
+# off stops this log's disk writes (does not affect DS4_PROXY_TEE body-dump logs).
+# Console output and DS4_PROXY_TEE logging are unaffected by this toggle.
+# Format: on or off — e.g. DS4_LOG=off
+DS4_LOG=on
+
+# Apply ANSI color to ds4-server output in the terminal (not in log files).
+# Has no effect on non-TTY output (launchd, nohup, pipes).
+# Format: on or off — e.g. DS4_SERVER_COLOR_LOG=off
+DS4_SERVER_COLOR_LOG=on

--- a/README.md
+++ b/README.md
@@ -22,16 +22,17 @@ Standard layout (mirrors the agents-repo convention):
 | [docs/ops.md](docs/ops.md) | How — run the server/client, monitoring, recovery |
 | [docs/history.md](docs/history.md) | Completed work with why — incidents (write storm, sleep freeze) and decisions |
 | [docs/infrastructure.md](docs/infrastructure.md) | SSOT for hosts, network, ports, paths |
-| [scripts/ds4-server.sh](scripts/ds4-server.sh) | Canonical Mac start script |
+| [scripts/ds4ctl.sh](scripts/ds4ctl.sh) | Unified Mac control command — `start\|stop\|restart\|status\|logs\|install\|uninstall [proxy\|server\|all]` |
+| [scripts/ds4-server.sh](scripts/ds4-server.sh) | Foreground launcher for ds4-server (thin wrapper; used by launchd) |
 | [scripts/code-ds4.cmd](scripts/code-ds4.cmd) | Windows client launcher — loads `.env`, sets ds4 env, isolates the VS Code process, launches VS Code |
 | [.env.example](.env.example) | Template for the gitignored `.env` — Windows client `DS4_ANTHROPIC_BASE_URL` (Mac IP) and `DS4_API_KEY` |
 
 ## Quick start
 
-**Mac (server):**
+**Mac (server + proxy):**
 ```sh
 git -C ~/git/ds4 pull                 # update the antirez/ds4 build clone if needed
-~/git/ds4-ops/scripts/ds4-server.sh
+~/git/ds4-ops/scripts/ds4ctl.sh start all   # background; or 'install all' for auto-start at login
 ```
 
 **Windows (client):** put the Mac's IP in a gitignored `.env` (first time only), then run the

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -25,7 +25,12 @@ Add the shared auth token to the server-side `.env` (repo root, gitignored):
 # .env: DS4_PROXY_AUTH_TOKEN=<generated-secret>   (generate with /create-key)
 ```
 
-Start the proxy (foreground; refuses to start if `DS4_PROXY_AUTH_TOKEN` is unset):
+Start the proxy in the background:
+```sh
+~/git/ds4-ops/scripts/ds4ctl.sh start proxy
+```
+
+Or foreground (for debugging):
 ```sh
 ~/git/ds4-ops/scripts/ds4-proxy.sh
 ```
@@ -38,20 +43,88 @@ Client-side (Windows): set `DS4_CA_CERT` to `<mkcert -CAROOT>/rootCA.pem` in the
 
 ```sh
 mkdir -p ~/Library/Caches/ds4-server/kv     # first time only
-~/git/ds4-ops/scripts/ds4-server.sh
+~/git/ds4-ops/scripts/ds4ctl.sh start server
 ```
 
-Runs in the foreground. For background:
+For foreground (debugging):
 ```sh
-nohup ~/git/ds4-ops/scripts/ds4-server.sh > ~/ds4-server.log 2>&1 &
+~/git/ds4-ops/scripts/ds4-server.sh
 ```
 
 Stop:
 ```sh
-kill "$(pgrep -f ds4-server)"
+~/git/ds4-ops/scripts/ds4ctl.sh stop server
 ```
 
+Note: if the service is launchd-managed (auto-start installed), `stop` exits with an error
+and guides you to use `ds4ctl uninstall server` instead.
+
 `caffeinate` is baked into the script and exits with the server; no separate step.
+
+## Unified control (Mac)
+
+```sh
+~/git/ds4-ops/scripts/ds4ctl.sh start all      # start both services
+~/git/ds4-ops/scripts/ds4ctl.sh stop all       # stop both
+~/git/ds4-ops/scripts/ds4ctl.sh restart all    # restart both
+~/git/ds4-ops/scripts/ds4ctl.sh status all     # show status
+~/git/ds4-ops/scripts/ds4ctl.sh logs server    # tail ds4-server log (color in TTY)
+~/git/ds4-ops/scripts/ds4ctl.sh logs proxy     # tail ds4-proxy log
+~/git/ds4-ops/scripts/ds4ctl.sh logs all       # tail both logs
+```
+
+Targets: `proxy`, `server`, `all` (default when omitted).
+
+## Automatic startup (launchd)
+
+Install both services as LaunchAgents (start at login, restart on crash):
+```sh
+~/git/ds4-ops/scripts/ds4ctl.sh install all
+```
+
+Uninstall (stops the service and removes auto-start):
+```sh
+~/git/ds4-ops/scripts/ds4ctl.sh uninstall all
+```
+
+Plist locations and labels:
+- `~/Library/LaunchAgents/com.nire.ds4-proxy.plist` (`com.nire.ds4-proxy`)
+- `~/Library/LaunchAgents/com.nire.ds4-server.plist` (`com.nire.ds4-server`)
+
+KeepAlive=true means launchd restarts the service automatically on crash.
+
+**DS4_LOG change requires reinstall**: the log paths are baked into the plist at install time.
+After changing `DS4_LOG` in `.env`, run `ds4ctl install all` to regenerate the plist.
+
+**Stopping a launchd-managed service**: `ds4ctl stop` will refuse with an error when the
+service is launchd-managed (KeepAlive would restart it immediately anyway). Use
+`ds4ctl uninstall <svc>` to stop and disable auto-start. To restart a launchd-managed
+service: `ds4ctl uninstall <svc>` then `ds4ctl install <svc>`.
+
+**start vs stop asymmetry**: when launchd manages a service, `ds4ctl start` is a silent
+no-op (informational — launchd's KeepAlive is already running it), while `ds4ctl stop`
+returns an error (stopping would be immediately undone by KeepAlive, so the command refuses
+to create that confusion). This asymmetry is intentional.
+
+## Log control
+
+Three independent toggles control different log streams:
+
+| Toggle | Controls | off effect |
+|---|---|---|
+| `DS4_LOG` | Service stdout/stderr → `proxy.log` / `kvcache.log` | No disk write for these logs |
+| `DS4_PROXY_TEE` | Proxy body-dump debug logs (`DS4_PROXY_LOG_DIR`) | No body-dump disk write |
+| `DS4_SERVER_COLOR_LOG` | ANSI color in terminal output for ds4-server | Plain text in terminal |
+
+`DS4_LOG=off` stops only the stdout/stderr log files. If `DS4_PROXY_TEE=on`, the proxy
+still writes body-dump logs to `DS4_PROXY_LOG_DIR` — they are independent.
+
+Log file paths: `~/Library/Logs/ds4-proxy/proxy.log` and `~/Library/Logs/ds4-server/kvcache.log`.
+
+For color-highlighted live log viewing:
+```sh
+~/git/ds4-ops/scripts/ds4ctl.sh logs server   # TTY: color; pipe/file: plain
+```
 
 ## Client (Windows)
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -226,4 +226,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("[ds4-proxy] shutting down", file=sys.stderr)

--- a/scripts/ds4-proxy.sh
+++ b/scripts/ds4-proxy.sh
@@ -1,20 +1,11 @@
 #!/bin/sh
-# Starts the ds4 reverse proxy (TLS termination + prompt normalization + token auth).
-# The proxy sits in front of ds4-server and is the sole LAN-visible endpoint.
-# ds4-server itself listens on 127.0.0.1:8000 after this change.
-# See docs/architecture.md#reverse-proxy-layer for the full rationale.
+# Foreground launcher for ds4-proxy. Used by launchd ProgramArguments and for
+# direct foreground runs. For daily use, prefer: ds4ctl start proxy
+# See scripts/ds4ctl.sh for the unified control command.
 set -eu
 
-# Load .env from the repo root (gitignored). DS4_PROXY_AUTH_TOKEN is required.
 DOTENV_FILE="$HOME/git/ds4-ops/.env"
 # shellcheck source=scripts/lib/load-dotenv.sh
 . "$(dirname "$0")/lib/load-dotenv.sh"
 
-# Fail early if auth token is missing (config.py also checks, but fail here too).
-if [ -z "${DS4_PROXY_AUTH_TOKEN:-}" ]; then
-    echo "[ds4-proxy] DS4_PROXY_AUTH_TOKEN is not set in .env — refusing to start" >&2
-    exit 1
-fi
-
-cd "$HOME/git/ds4-ops"
-exec uv run python -m proxy.server
+exec "$(dirname "$0")/ds4ctl.sh" __run proxy

--- a/scripts/ds4-server.sh
+++ b/scripts/ds4-server.sh
@@ -1,40 +1,15 @@
 #!/bin/sh
-# Starts ds4-server (antirez/ds4) as a self-hosted Claude Code backend.
+# Foreground launcher for ds4-server. Used by launchd ProgramArguments and for
+# direct foreground runs. For daily use, prefer: ds4ctl start server
+# See scripts/ds4ctl.sh for the unified control command.
 #
-# caffeinate -ism: prevent idle / AC-system / disk sleep so macOS can never
-#   freeze the process mid-generation. -d (display sleep) is intentionally
-#   OMITTED so the display can still turn off (screen burn-in protection);
-#   the assertion is tied to this script's child process, not the display.
-#
-# stdout/stderr (including ds4's own kv-cache hit/evict log lines) are teed to
-# LOG_DIR/kvcache.log so they are both visible live and persisted.
-#
-# See ../docs/server-mac.md for the rationale behind every flag and value.
+# caffeinate -ism: prevent idle/AC-system/disk sleep. -d (display sleep) is
+# intentionally OMITTED so the display can turn off (screen burn-in protection).
+# The kvcache.log tee is handled by ds4ctl (ds4_exec) via DS4_LOG toggle.
 set -eu
 
-# Load .env from the repo root (gitignored).
 DOTENV_FILE="$HOME/git/ds4-ops/.env"
 # shellcheck source=scripts/lib/load-dotenv.sh
 . "$(dirname "$0")/lib/load-dotenv.sh"
 
-cd "$HOME/git/ds4"          # antirez/ds4 build clone (ds4flash.gguf lives here)
-
-LOG_DIR="$HOME/Library/Logs/ds4-server"
-mkdir -p "$LOG_DIR"
-
-# DS4_SERVER_HOST overrides the bind address (default: 127.0.0.1).
-# Set to 0.0.0.0 (or a specific LAN IP) for temporary A/B testing vs proxy.
-# Revert to 127.0.0.1 after testing — the raw server has no auth.
-HOST="${DS4_SERVER_HOST:-127.0.0.1}"
-
-caffeinate -ism ./ds4-server \
-  --metal \
-  --quality \
-  --ctx 393216 \
-  --kv-disk-dir "$HOME/Library/Caches/ds4-server/kv" \
-  --kv-disk-space-mb 32768 \
-  --kv-cache-cold-max-tokens 90000 \
-  --kv-cache-continued-interval-tokens 25000 \
-  --warm-weights \
-  --host "$HOST" \
-  2>&1 | tee -a "$LOG_DIR/kvcache.log"
+exec "$(dirname "$0")/ds4ctl.sh" __run server

--- a/scripts/ds4ctl.sh
+++ b/scripts/ds4ctl.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# ds4ctl — unified control command for ds4-proxy and ds4-server.
+# Usage: ds4ctl <start|stop|restart|status|logs|install|uninstall> [proxy|server|all]
+set -eu
+
+DS4CTL="$(cd "$(dirname "$0")" && pwd)/ds4ctl.sh"
+
+DOTENV_FILE="$HOME/git/ds4-ops/.env"
+# shellcheck source=scripts/lib/load-dotenv.sh
+. "$(dirname "$0")/lib/load-dotenv.sh"
+# shellcheck source=scripts/lib/paths.sh
+. "$(dirname "$0")/lib/paths.sh"
+# shellcheck source=scripts/lib/colorize.sh
+. "$(dirname "$0")/lib/colorize.sh"
+# shellcheck source=scripts/lib/launchd.sh
+. "$(dirname "$0")/lib/launchd.sh"
+# shellcheck source=scripts/lib/lifecycle.sh
+. "$(dirname "$0")/lib/lifecycle.sh"
+
+_usage() {
+    cat >&2 <<'EOF'
+Usage: ds4ctl <command> [proxy|server|all]
+
+Commands:
+  start     Start service(s) in the background (nohup + PID)
+  stop      Stop service(s)
+  restart   Stop then start service(s)
+  status    Show running status
+  logs      Tail log file(s) (requires DS4_LOG=on)
+  install   Install launchd LaunchAgent for auto-start
+  uninstall Remove launchd LaunchAgent
+
+Targets: proxy, server, all (default)
+EOF
+}
+
+if [ $# -lt 1 ]; then
+    _usage
+    exit 2
+fi
+
+cmd="$1"
+target="${2:-all}"
+
+# Validate target
+case "$target" in
+    proxy|server|all) ;;
+    *)
+        echo "[ds4ctl] unknown target: $target" >&2
+        _usage
+        exit 2
+        ;;
+esac
+
+# Expand 'all' to list of services
+if [ "$target" = "all" ]; then
+    _services="proxy server"
+else
+    _services="$target"
+fi
+
+case "$cmd" in
+    start)
+        for _svc in $_services; do
+            ds4_start "$_svc"
+        done
+        ;;
+    stop)
+        _err=0
+        for _svc in $_services; do
+            ds4_stop "$_svc" || _err=$?
+        done
+        exit $_err
+        ;;
+    restart)
+        _err=0
+        for _svc in $_services; do
+            ds4_restart "$_svc" || _err=$?
+        done
+        exit $_err
+        ;;
+    status)
+        for _svc in $_services; do
+            ds4_status "$_svc"
+        done
+        ;;
+    logs)
+        if [ "$target" = "all" ]; then
+            ds4_logs "all"
+        else
+            ds4_logs "$_services"
+        fi
+        ;;
+    install)
+        for _svc in $_services; do
+            ds4_install "$_svc"
+        done
+        ;;
+    uninstall)
+        for _svc in $_services; do
+            ds4_uninstall "$_svc"
+        done
+        ;;
+    __run)
+        # Internal: called by nohup/launchd to exec the real service process
+        if [ $# -lt 2 ]; then
+            echo "[ds4ctl] __run requires a service name" >&2
+            exit 2
+        fi
+        ds4_exec "$2"
+        ;;
+    *)
+        echo "[ds4ctl] unknown command: $cmd" >&2
+        _usage
+        exit 2
+        ;;
+esac

--- a/scripts/lib/colorize.sh
+++ b/scripts/lib/colorize.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# ds4_colorize: stdin→stdout ANSI color filter for ds4-server output.
+# Only applied to TTY output; files receive raw bytes (tee is upstream).
+set -eu
+
+ds4_colorize() {
+    awk '
+    {
+        line = $0
+        color = ""
+        if (line ~ /kv cache evicted|disk-cache-full/) {
+            color = "\033[33m"
+        } else if (line ~ /THINKING/ && line ~ /chat/) {
+            color = "\033[36m"
+        } else if (tolower(line) ~ /error|warn/) {
+            color = "\033[31m"
+        }
+        if (color != "") {
+            printf "%s%s\033[0m\n", color, line
+        } else {
+            print line
+        }
+        fflush()
+    }'
+}

--- a/scripts/lib/launchd.sh
+++ b/scripts/lib/launchd.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# launchd LaunchAgent helpers for ds4 services.
+# Sourced by ds4ctl.sh before lifecycle.sh.
+set -eu
+
+_ds4_plist_path() { echo "$HOME/Library/LaunchAgents/com.nire.ds4-${1}.plist"; }
+_ds4_plist_label() { echo "com.nire.ds4-${1}"; }
+
+_ds4_launchd_active() {
+    _label="$(_ds4_plist_label "$1")"
+    _plist="$(_ds4_plist_path "$1")"
+    [ -f "$_plist" ] && launchctl list "$_label" >/dev/null 2>&1
+}
+
+_ds4_write_plist() {
+    _svc="$1"
+    _plist="$(_ds4_plist_path "$_svc")"
+    _label="$(_ds4_plist_label "$_svc")"
+    _wrapper="$DS4_OPS_ROOT/scripts/ds4-${_svc}.sh"
+    _cwd="$(_ds4_cwd "$_svc")"
+    _logfile="$(_ds4_log_file "$_svc")"
+
+    if [ "${DS4_LOG:-on}" = "on" ]; then
+        _out_path="$_logfile"
+        _err_path="$_logfile"
+    else
+        _out_path="/dev/null"
+        _err_path="/dev/null"
+    fi
+
+    # Resolve uv path for launchd's minimal PATH
+    _uv_bin=""
+    if command -v uv >/dev/null 2>&1; then
+        _uv_bin="$(dirname "$(command -v uv)")"
+    fi
+    _path_val="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    if [ -n "$_uv_bin" ]; then
+        _path_val="${_uv_bin}:${_path_val}"
+    fi
+
+    mkdir -p "$(_ds4_log_dir "$_svc")"
+
+    cat > "$_plist" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${_label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>${_wrapper}</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>${_cwd}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>${_out_path}</string>
+    <key>StandardErrorPath</key>
+    <string>${_err_path}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${_path_val}</string>
+    </dict>
+</dict>
+</plist>
+PLIST_EOF
+}
+
+ds4_install() {
+    _svc="$1"
+    _plist="$(_ds4_plist_path "$_svc")"
+    _label="$(_ds4_plist_label "$_svc")"
+    mkdir -p "$HOME/Library/LaunchAgents"
+    _ds4_write_plist "$_svc"
+    launchctl unload "$_plist" 2>/dev/null || true
+    launchctl load -w "$_plist"
+    echo "[ds4-ops] installed $_label"
+}
+
+ds4_uninstall() {
+    _svc="$1"
+    _plist="$(_ds4_plist_path "$_svc")"
+    _label="$(_ds4_plist_label "$_svc")"
+    launchctl unload -w "$_plist" 2>/dev/null || true
+    rm -f "$_plist"
+    echo "[ds4-ops] uninstalled $_label"
+}

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+# Lifecycle management for ds4 services (start/stop/restart/status/logs/exec).
+# Sourced by ds4ctl.sh after launchd.sh (source order matters).
+set -eu
+
+_ds4_cmd() {
+    case "$1" in
+        proxy)
+            echo "uv run python -m proxy.server"
+            ;;
+        server)
+            HOST="${DS4_SERVER_HOST:-127.0.0.1}"
+            case "$HOST" in
+                *[!0-9a-zA-Z:.%-]*)
+                    echo "[ds4-ops] invalid DS4_SERVER_HOST value (allowed chars: 0-9 a-z A-Z : . %)" >&2
+                    exit 1
+                    ;;
+            esac
+            echo "caffeinate -ism ./ds4-server --metal --quality --ctx 393216 --kv-disk-dir \"$HOME/Library/Caches/ds4-server/kv\" --kv-disk-space-mb 32768 --kv-cache-cold-max-tokens 90000 --kv-cache-continued-interval-tokens 25000 --warm-weights --host \"$HOST\""
+            ;;
+    esac
+}
+
+_ds4_cwd() {
+    case "$1" in
+        proxy)  echo "$DS4_OPS_ROOT" ;;
+        server) echo "$DS4_SERVER_ROOT" ;;
+    esac
+}
+
+_ds4_running() {
+    _pid_file="$(_ds4_pid_file "$1")"
+    if [ -f "$_pid_file" ]; then
+        _pid=$(cat "$_pid_file")
+        if kill -0 "$_pid" 2>/dev/null; then
+            echo "$_pid"
+            return 0
+        else
+            rm -f "$_pid_file"
+        fi
+    fi
+    return 1
+}
+
+ds4_exec() {
+    _svc="$1"
+    if [ "$_svc" = "proxy" ] && [ -z "${DS4_PROXY_AUTH_TOKEN:-}" ]; then
+        echo "[ds4-proxy] DS4_PROXY_AUTH_TOKEN is not set in .env — refusing to start" >&2
+        exit 1
+    fi
+    mkdir -p "$(_ds4_log_dir "$_svc")"
+    _logfile="$(_ds4_log_file "$_svc")"
+    _cmd="$(_ds4_cmd "$_svc")"
+    _cwd="$(_ds4_cwd "$_svc")"
+
+    if [ -t 1 ]; then
+        # TTY (foreground interactive)
+        _color_filter="cat"
+        if [ "$_svc" = "server" ] && [ "${DS4_SERVER_COLOR_LOG:-on}" = "on" ]; then
+            _color_filter="ds4_colorize"
+        fi
+        if [ "${DS4_LOG:-on}" = "on" ]; then
+            cd "$_cwd"
+            eval "$_cmd" 2>&1 | tee -a "$_logfile" | "$_color_filter"
+        else
+            cd "$_cwd"
+            eval "$_cmd" 2>&1 | "$_color_filter"
+        fi
+    else
+        # Non-TTY (launchd / nohup) — exec to let caller track the process
+        cd "$_cwd"
+        eval "exec $_cmd"
+    fi
+}
+
+ds4_start() {
+    _svc="$1"
+    if _ds4_launchd_active "$_svc"; then
+        echo "[ds4-ops] $_svc is managed by launchd (KeepAlive). Use 'ds4ctl install $_svc' instead of 'start'." >&2
+        return 0
+    fi
+    if _pid=$(_ds4_running "$_svc"); then
+        echo "[ds4-ops] $_svc already running (pid $_pid)"
+        return 0
+    fi
+    if pgrep -f "$(_ds4_pgrep_pattern "$_svc")" >/dev/null 2>&1; then
+        echo "[ds4-ops] $_svc already running (untracked)"
+        return 0
+    fi
+    if [ "$_svc" = "proxy" ] && [ -z "${DS4_PROXY_AUTH_TOKEN:-}" ]; then
+        echo "[ds4-proxy] DS4_PROXY_AUTH_TOKEN is not set in .env — refusing to start" >&2
+        exit 1
+    fi
+    mkdir -p "$DS4_RUN_DIR"
+    mkdir -p "$(_ds4_log_dir "$_svc")"
+    _logfile="$(_ds4_log_file "$_svc")"
+    _pid_file="$(_ds4_pid_file "$_svc")"
+    if [ "${DS4_LOG:-on}" = "on" ]; then
+        nohup "$DS4CTL" __run "$_svc" >>"$_logfile" 2>&1 &
+    else
+        nohup "$DS4CTL" __run "$_svc" >/dev/null 2>&1 &
+    fi
+    echo $! > "$_pid_file"
+    _started_pid=$(cat "$_pid_file")
+    echo "[ds4-ops] started $_svc (pid $_started_pid)"
+}
+
+_ds4_stop_pid() {
+    _pid="$1"
+    _svc="$2"
+    # Kill children first to prevent reparenting to launchd/init
+    pkill -TERM -P "$_pid" 2>/dev/null || true
+    kill -TERM "$_pid" 2>/dev/null || true
+    _i=0
+    while [ $_i -lt 10 ] && kill -0 "$_pid" 2>/dev/null; do
+        sleep 1
+        _i=$((_i + 1))
+    done
+    if kill -0 "$_pid" 2>/dev/null; then
+        pkill -KILL -P "$_pid" 2>/dev/null || true
+        kill -KILL "$_pid" 2>/dev/null || true
+    fi
+    # Insurance: catch any stragglers (pattern is narrow enough to avoid false kills)
+    pkill -f "$(_ds4_pgrep_pattern "$_svc")" 2>/dev/null || true
+}
+
+ds4_stop() {
+    _svc="$1"
+    if _ds4_launchd_active "$_svc"; then
+        echo "[ds4-ops] $_svc is managed by launchd (KeepAlive — it will restart immediately if killed). To stop: 'ds4ctl uninstall $_svc'" >&2
+        return 1
+    fi
+    if _pid=$(_ds4_running "$_svc"); then
+        _ds4_stop_pid "$_pid" "$_svc"
+        rm -f "$(_ds4_pid_file "$_svc")"
+        echo "[ds4-ops] stopped $_svc"
+    else
+        echo "[ds4-ops] $_svc not running"
+    fi
+}
+
+ds4_restart() {
+    ds4_stop "$1"
+    ds4_start "$1"
+}
+
+ds4_status() {
+    _svc="$1"
+    if _pid=$(_ds4_running "$_svc"); then
+        echo "$_svc: running (pid $_pid)"
+    elif _ds4_launchd_active "$_svc"; then
+        echo "$_svc: running (launchd)"
+    else
+        echo "$_svc: stopped"
+    fi
+}
+
+ds4_logs() {
+    _svc="$1"
+    if [ "${DS4_LOG:-on}" != "on" ]; then
+        echo "[ds4-ops] log recording is disabled (DS4_LOG=off)" >&2
+        return 1
+    fi
+    if [ "$_svc" = "all" ]; then
+        _pf="$(_ds4_log_file proxy)"
+        _sf="$(_ds4_log_file server)"
+        if [ ! -f "$_pf" ] && [ ! -f "$_sf" ]; then
+            echo "[ds4-ops] no log files found" >&2
+            return 1
+        fi
+        # Use only existing files
+        _files=""
+        [ -f "$_pf" ] && _files="$_pf"
+        [ -f "$_sf" ] && _files="$_files $_sf"
+        # shellcheck disable=SC2086
+        tail -f $_files
+    else
+        _logfile="$(_ds4_log_file "$_svc")"
+        if [ ! -f "$_logfile" ]; then
+            echo "[ds4-ops] log file not found: $_logfile" >&2
+            return 1
+        fi
+        if [ -t 1 ] && [ "$_svc" = "server" ] && [ "${DS4_SERVER_COLOR_LOG:-on}" = "on" ]; then
+            tail -f "$_logfile" | ds4_colorize
+        else
+            tail -f "$_logfile"
+        fi
+    fi
+}

--- a/scripts/lib/paths.sh
+++ b/scripts/lib/paths.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# SSOT for ds4-ops service paths and patterns.
+set -eu
+
+DS4_OPS_ROOT="$HOME/git/ds4-ops"
+DS4_SERVER_ROOT="$HOME/git/ds4"
+DS4_RUN_DIR="$HOME/Library/Application Support/ds4-ops/run"
+
+_ds4_pid_file() { echo "$DS4_RUN_DIR/${1}.pid"; }
+
+_ds4_log_dir() {
+    case "$1" in
+        proxy)  echo "$HOME/Library/Logs/ds4-proxy" ;;
+        server) echo "$HOME/Library/Logs/ds4-server" ;;
+    esac
+}
+
+_ds4_log_file() {
+    case "$1" in
+        proxy)  echo "$(_ds4_log_dir proxy)/proxy.log" ;;
+        server) echo "$(_ds4_log_dir server)/kvcache.log" ;;
+    esac
+}
+
+_ds4_valid_svc() {
+    case "$1" in
+        proxy|server) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+_ds4_pgrep_pattern() {
+    case "$1" in
+        proxy)  echo "proxy.server" ;;
+        server) echo "caffeinate.*ds4-server" ;;
+    esac
+}

--- a/tests/feature-18-ds4ctl/test-colorize.sh
+++ b/tests/feature-18-ds4ctl/test-colorize.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl colorize — adds ANSI to ds4-server log lines; non-server lines pass through uncolored; tee'd log file stays ANSI-free (colorize is downstream of tee).
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/lib/colorize.sh exists (implementation pending).
+#
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+COLORIZE="$REPO/scripts/lib/colorize.sh"
+
+[ -f "$COLORIZE" ] || { echo "SKIP: $COLORIZE not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ESC="$(printf '\033')"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# A representative ds4-server log line (kv-cache activity).
+LINE='kv-cache: hit 90000 tokens, evict 25000'
+
+# --- Terminal path: colorize wraps the line in ANSI -------------------------
+out="$(printf '%s\n' "$LINE" | bash "$COLORIZE")"
+case "$out" in
+    *"$ESC"*) : ;;
+    *) fail "colorize did not add ANSI escape to a ds4-server line (got: $out)" ;;
+esac
+# The visible text must survive colorization.
+echo "$out" | grep -q "kv-cache" || fail "colorize dropped the original text"
+
+# --- Non-server line: no ANSI added (only ds4-server lines are colorized) ----
+PLAIN='2026-07-18 12:00:00 [INFO] proxy started'
+plainout="$(printf '%s\n' "$PLAIN" | bash "$COLORIZE")"
+case "$plainout" in
+    *"$ESC"*) fail "colorize added ANSI to a non-ds4-server line (got: $plainout)" ;;
+    *) : ;;
+esac
+# The original text must pass through untouched.
+[ "$plainout" = "$PLAIN" ] || fail "colorize altered a non-server line (got: $plainout)"
+
+# --- File path: colorize sits downstream of tee, so the file is ANSI-free ---
+FILE="$WORK/kvcache.log"
+printf '%s\n' "$LINE" | tee "$FILE" | bash "$COLORIZE" >/dev/null
+if grep -q "$ESC" "$FILE"; then
+    fail "tee'd log file contains ANSI escapes — colorize must be downstream of tee"
+fi
+grep -q "kv-cache" "$FILE" || fail "tee'd log file missing the raw line"
+
+echo "PASS: test-colorize"

--- a/tests/feature-18-ds4ctl/test-ctrlc.sh
+++ b/tests/feature-18-ds4ctl/test-ctrlc.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests: proxy SIGINT (Phase 1) — Ctrl-C stops proxy cleanly, no Python Traceback, normal exit.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Runs against the EXISTING proxy/server.py (not ds4ctl). Before Phase 1 lands
+# this is expected to FAIL (raw KeyboardInterrupt traceback); it is intentionally
+# NOT skipped on missing implementation so the regression is recorded.
+# Skips (exit 77) only when prerequisites (DS4_API_KEY / uv / openssl) are absent.
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+SERVER="$REPO/proxy/server.py"
+
+[ -f "$SERVER" ] || { echo "SKIP: $SERVER not found"; exit 77; }
+printenv DS4_API_KEY >/dev/null 2>&1 || { echo "SKIP: DS4_API_KEY not set"; exit 77; }
+command -v uv >/dev/null 2>&1 || { echo "SKIP: uv not available"; exit 77; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl not available"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Signal only the process we started (uv) and its direct children (python) —
+# never a broad `pkill -f proxy.server`, which could hit the user's real proxy.
+signal_tree() { # signal_tree <sig> <pid>
+    local sig="$1" p="$2" c
+    kill "-$sig" "$p" 2>/dev/null
+    for c in $(pgrep -P "$p" 2>/dev/null); do
+        signal_tree "$sig" "$c"
+    done
+}
+
+WORK="$(mktemp -d)"
+PID=""; WATCH=""
+cleanup() {
+    [ -n "$WATCH" ] && kill "$WATCH" 2>/dev/null
+    [ -n "$PID" ] && signal_tree KILL "$PID"
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# Self-signed TLS leaf so the proxy can bind TLS.
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$WORK/key.pem" \
+    -out "$WORK/cert.pem" -days 1 -subj "/CN=localhost" >/dev/null 2>&1 \
+    || { echo "SKIP: openssl cert generation failed"; exit 77; }
+
+# Pick an ephemeral port.
+PORT=$(( (RANDOM % 2000) + 18000 ))
+LOG="$WORK/proxy.log"
+
+export DS4_PROXY_AUTH_TOKEN="$DS4_API_KEY"
+export DS4_PROXY_CERT="$WORK/cert.pem"
+export DS4_PROXY_KEY="$WORK/key.pem"
+export DS4_PROXY_PORT="$PORT"
+export DS4_PROXY_TEE="off"
+
+# Launch the proxy directly (NOT under a timeout wrapper — a wrapper would
+# intercept the SIGINT we need to deliver to the proxy itself).
+( cd "$REPO" && exec uv run python -m proxy.server ) >"$LOG" 2>&1 &
+PID=$!
+
+# Independent watchdog: hard-kill the whole tree if it ever hangs (30s cap).
+( sleep 30; signal_tree KILL "$PID" ) &
+WATCH=$!
+
+# Wait for the listening banner (up to ~20s).
+_i=0
+while [ "$_i" -lt 200 ]; do
+    grep -q "listening" "$LOG" 2>/dev/null && break
+    kill -0 "$PID" 2>/dev/null || break
+    perl -e 'select undef,undef,undef,0.1'
+    _i=$((_i + 1))
+done
+grep -q "listening" "$LOG" 2>/dev/null || fail "proxy never reported listening (log: $(cat "$LOG"))"
+
+# Deliver SIGINT (Ctrl-C) to the proxy launcher and its python child.
+signal_tree INT "$PID"
+
+# Wait for exit.
+wait "$PID"; rc=$?
+PID=""
+[ -n "$WATCH" ] && kill "$WATCH" 2>/dev/null; WATCH=""
+
+# Phase 1 expectation: clean shutdown, no traceback, non-crash exit code.
+if grep -q "Traceback" "$LOG"; then
+    fail "proxy printed a Python Traceback on SIGINT:
+$(cat "$LOG")"
+fi
+if grep -qi "KeyboardInterrupt" "$LOG"; then
+    fail "proxy leaked KeyboardInterrupt on SIGINT (no handler installed)"
+fi
+# 0 = clean; 130 = SIGINT-terminated but not the target clean-exit contract.
+[ "$rc" = "0" ] || fail "proxy did not exit cleanly on SIGINT (rc=$rc)"
+
+echo "PASS: test-ctrlc"

--- a/tests/feature-18-ds4ctl/test-dispatch.sh
+++ b/tests/feature-18-ds4ctl/test-dispatch.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl dispatch — unknown subcommand/target exit 2 + usage; `all` expands to proxy+server.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# Uses a trace hook + PATH stubs so no real service is launched.
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Stub PATH so any launchd / process probe is inert -----------------------
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+for cmd in launchctl pgrep pkill caffeinate; do
+    printf '#!/bin/sh\nexit 0\n' > "$STUB/$cmd"
+    chmod +x "$STUB/$cmd"
+done
+
+# ds4ctl exposes an exec-capture hook: when DS4CTL_TRACE points at a file, each
+# resolved target is appended instead of acting, letting the dispatch layer be
+# tested without launching services.
+TRACE="$WORK/trace"
+export DS4CTL_TRACE="$TRACE"
+export HOME="$WORK/home"
+mkdir -p "$HOME"
+
+run() {
+    PATH="$STUB:$PATH" bash "$DS4CTL" "$@" >"$WORK/out" 2>"$WORK/err"
+    echo $?
+}
+
+# 1a. Unknown subcommand -> exit 2 + usage.
+rc="$(run bogus proxy)"
+[ "$rc" = "2" ] || fail "unknown subcommand: expected exit 2, got $rc"
+grep -qi "usage" "$WORK/out" "$WORK/err" || fail "unknown subcommand: no usage text"
+
+# 1b. Unknown target -> exit 2 + usage.
+rc="$(run start bogus)"
+[ "$rc" = "2" ] || fail "unknown target: expected exit 2, got $rc"
+grep -qi "usage" "$WORK/out" "$WORK/err" || fail "unknown target: no usage text"
+
+# 1c. Missing target -> exit 2 + usage.
+rc="$(run start)"
+[ "$rc" = "2" ] || fail "missing target: expected exit 2, got $rc"
+
+# 1d. `all` expands to both proxy and server (trace records each).
+: > "$TRACE"
+rc="$(run start all)"
+[ "$rc" = "0" ] || fail "start all: expected exit 0, got $rc (err: $(cat "$WORK/err"))"
+grep -q "proxy" "$TRACE" || fail "start all: proxy not dispatched"
+grep -q "server" "$TRACE" || fail "start all: server not dispatched"
+
+echo "PASS: test-dispatch"

--- a/tests/feature-18-ds4ctl/test-double-start.sh
+++ b/tests/feature-18-ds4ctl/test-double-start.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl double-start prevention — PID-file route and pgrep-fallback route both report `already running`.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"; [ -n "${LIVE:-}" ] && kill "$LIVE" 2>/dev/null' EXIT
+
+export HOME="$WORK/home"
+PID_DIR="$HOME/Library/Application Support/ds4-ops/run"
+mkdir -p "$PID_DIR"
+
+# Stub launchctl to report "not managed" so the manual route is exercised.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/launchctl"
+chmod +x "$STUB/launchctl"
+
+# --- Route A: live PID file pointing at a running process --------------------
+sleep 300 &
+LIVE=$!
+printf '%s\n' "$LIVE" > "$PID_DIR/proxy.pid"
+
+out="$(PATH="$STUB:$PATH" bash "$DS4CTL" start proxy 2>&1)"; rc=$?
+[ "$rc" != "0" ] || fail "PID-file route: expected non-zero exit, got 0"
+echo "$out" | grep -qi "already running" || fail "PID-file route: missing 'already running' (got: $out)"
+# Existing process must not be killed by a rejected start.
+kill -0 "$LIVE" 2>/dev/null || fail "PID-file route: live process was killed"
+
+# --- Route B: no PID file, pgrep fallback finds the process ------------------
+rm -f "$PID_DIR/proxy.pid"
+
+# pgrep stub reports a live match for the proxy pattern.
+cat > "$STUB/pgrep" <<EOF
+#!/bin/sh
+# Emit a PID for any query, simulating a running unsupervised process.
+echo $LIVE
+exit 0
+EOF
+chmod +x "$STUB/pgrep"
+
+out="$(PATH="$STUB:$PATH" bash "$DS4CTL" start proxy 2>&1)"; rc=$?
+[ "$rc" != "0" ] || fail "pgrep fallback: expected non-zero exit, got 0"
+echo "$out" | grep -qi "already running" || fail "pgrep fallback: missing 'already running' (got: $out)"
+
+echo "PASS: test-double-start"

--- a/tests/feature-18-ds4ctl/test-launchd-stop.sh
+++ b/tests/feature-18-ds4ctl/test-launchd-stop.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl stop refuses when launchd-managed — exit 1, uninstall guidance, no manual kill.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+LAUNCHD_LIB="$REPO/scripts/lib/launchd.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+PID_DIR="$HOME/Library/Application Support/ds4-ops/run"
+mkdir -p "$PID_DIR"
+
+cleanup() {
+    [ -n "${LIVE:-}" ] && kill "$LIVE" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# launchctl stub: report the label as loaded (managed) for `print`/`list`.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+cat > "$STUB/launchctl" <<'EOF'
+#!/bin/sh
+# Any query about a ds4 label reports it as loaded -> managed.
+case "$*" in
+    *ds4*) echo "com.nire.ds4-proxy = { state = running }"; exit 0 ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB/launchctl"
+
+# A live process with a matching PID file — the guard must NOT kill it, because
+# launchd owns the lifecycle and manual stop is refused.
+sleep 300 &
+LIVE=$!
+printf '%s\n' "$LIVE" > "$PID_DIR/proxy.pid"
+
+out="$(PATH="$STUB:$PATH" bash "$DS4CTL" stop proxy 2>&1)"; rc=$?
+
+[ "$rc" = "1" ] || fail "expected exit 1 when launchd-managed, got $rc (out: $out)"
+echo "$out" | grep -qi "uninstall" || fail "no uninstall guidance in output (got: $out)"
+# The managed process must be left untouched.
+kill -0 "$LIVE" 2>/dev/null || fail "managed process $LIVE was killed — guard failed"
+[ -f "$PID_DIR/proxy.pid" ] || fail "PID file was removed despite refusal"
+
+echo "PASS: test-launchd-stop"

--- a/tests/feature-18-ds4ctl/test-log-toggle.sh
+++ b/tests/feature-18-ds4ctl/test-log-toggle.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl DS4_LOG toggle — on creates/appends a log file; off writes no file.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+PID_DIR="$HOME/Library/Application Support/ds4-ops/run"
+mkdir -p "$PID_DIR"
+LOG_DIR="$HOME/Library/Logs/ds4-proxy"
+
+cleanup() {
+    [ -f "$PID_DIR/proxy.pid" ] && kill "$(cat "$PID_DIR/proxy.pid")" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/launchctl"
+chmod +x "$STUB/launchctl"
+
+# Fake service emits a marker line to stdout so the log capture can be observed.
+FAKE="$WORK/fake-service.sh"
+cat > "$FAKE" <<'EOF'
+#!/bin/sh
+echo "FAKE-MARKER-LINE"
+exec sleep 300
+EOF
+chmod +x "$FAKE"
+export DS4CTL_EXEC_OVERRIDE="$FAKE"
+
+wait_for() { _i=0; while [ ! -s "$1" ] && [ "$_i" -lt "${2}0" ]; do perl -e 'select undef,undef,undef,0.1'; _i=$((_i+1)); done; [ -s "$1" ]; }
+stop_proxy() { PATH="$STUB:$PATH" bash "$DS4CTL" stop proxy >/dev/null 2>&1 || true; perl -e 'select undef,undef,undef,0.3'; }
+
+# --- DS4_LOG=on -> log file created and receives service output -------------
+rm -rf "$LOG_DIR"
+DS4_LOG=on PATH="$STUB:$PATH" bash "$DS4CTL" start proxy >"$WORK/out" 2>&1 || fail "start (log on) failed: $(cat "$WORK/out")"
+wait_for "$PID_DIR/proxy.pid" 5 || fail "log on: proxy did not start"
+LOGFILE=""
+_i=0
+while [ "$_i" -lt 50 ]; do
+    LOGFILE="$(ls "$LOG_DIR"/*.log 2>/dev/null | head -n1 || true)"
+    [ -n "$LOGFILE" ] && [ -s "$LOGFILE" ] && break
+    perl -e 'select undef,undef,undef,0.1'; _i=$((_i+1))
+done
+[ -n "$LOGFILE" ] || fail "log on: no *.log file created under $LOG_DIR"
+grep -q "FAKE-MARKER-LINE" "$LOGFILE" || fail "log on: service output not captured in $LOGFILE"
+
+# Append semantics: restart appends rather than truncating.
+BEFORE_BYTES=$(wc -c < "$LOGFILE")
+stop_proxy
+DS4_LOG=on PATH="$STUB:$PATH" bash "$DS4CTL" start proxy >"$WORK/out" 2>&1 || fail "restart (log on) failed"
+wait_for "$PID_DIR/proxy.pid" 5 || fail "log on restart: proxy did not start"
+perl -e 'select undef,undef,undef,0.5'
+AFTER_BYTES=$(wc -c < "$LOGFILE")
+[ "$AFTER_BYTES" -ge "$BEFORE_BYTES" ] || fail "log on: file shrank ($AFTER_BYTES < $BEFORE_BYTES) — not appending"
+stop_proxy
+
+# --- DS4_LOG=off -> no log file written -------------------------------------
+rm -rf "$LOG_DIR"
+DS4_LOG=off PATH="$STUB:$PATH" bash "$DS4CTL" start proxy >"$WORK/out" 2>&1 || fail "start (log off) failed: $(cat "$WORK/out")"
+wait_for "$PID_DIR/proxy.pid" 5 || fail "log off: proxy did not start"
+perl -e 'select undef,undef,undef,0.5'
+if ls "$LOG_DIR"/*.log >/dev/null 2>&1; then
+    fail "log off: a log file was created under $LOG_DIR"
+fi
+stop_proxy
+
+echo "PASS: test-log-toggle"

--- a/tests/feature-18-ds4ctl/test-logs.sh
+++ b/tests/feature-18-ds4ctl/test-logs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl logs — DS4_LOG=off errors; DS4_LOG=on tails an existing log; `logs all` launches cleanly.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# `tail` is stubbed to return immediately so the follow mode does not block.
+#
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+mkdir -p "$HOME"
+LOG_DIR="$HOME/Library/Logs/ds4-proxy"
+
+trap 'rm -rf "$WORK"' EXIT
+
+# Stub launchctl / pgrep inert, and stub `tail` so follow-mode exits at once.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/launchctl"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/pgrep"
+# tail stub: echo a marker and return immediately (no blocking -f).
+cat > "$STUB/tail" <<'EOF'
+#!/bin/sh
+echo "TAIL-INVOKED $*"
+exit 0
+EOF
+chmod +x "$STUB/launchctl" "$STUB/pgrep" "$STUB/tail"
+
+# --- DS4_LOG=off -> logs reports an error ------------------------------------
+out="$(DS4_LOG=off PATH="$STUB:$PATH" bash "$DS4CTL" logs proxy 2>&1)"; rc=$?
+[ "$rc" != "0" ] || fail "logs (log off): expected non-zero exit, got 0 (out: $out)"
+echo "$out" | grep -qi "error\|off\|disabled\|no log" || fail "logs (log off): no error message (got: $out)"
+
+# --- DS4_LOG=on with an existing log file -> tail is invoked -----------------
+mkdir -p "$LOG_DIR"
+LOGFILE="$LOG_DIR/proxy.log"
+printf 'existing log line\n' > "$LOGFILE"
+
+out="$(DS4_LOG=on PATH="$STUB:$PATH" bash "$DS4CTL" logs proxy 2>&1)"; rc=$?
+[ "$rc" = "0" ] || fail "logs (log on): expected exit 0, got $rc (out: $out)"
+echo "$out" | grep -q "TAIL-INVOKED" || fail "logs (log on): tail was not invoked on the log file (got: $out)"
+
+# --- logs all -> launches cleanly (no error) --------------------------------
+# Ensure a server log exists too so `all` has something to tail.
+printf 'server log line\n' > "$LOG_DIR/server.log"
+out="$(DS4_LOG=on PATH="$STUB:$PATH" bash "$DS4CTL" logs all 2>&1)"; rc=$?
+[ "$rc" = "0" ] || fail "logs all: expected exit 0, got $rc (out: $out)"
+
+echo "PASS: test-logs"

--- a/tests/feature-18-ds4ctl/test-pid-lifecycle.sh
+++ b/tests/feature-18-ds4ctl/test-pid-lifecycle.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl PID lifecycle — start writes PID; stop kills parent+child and removes PID; stale PID is swept.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# A fake service (parent that forks a child) stands in for the real backend via
+# the DS4CTL_EXEC_OVERRIDE seam so no real ds4 process is launched.
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+PID_DIR="$HOME/Library/Application Support/ds4-ops/run"
+mkdir -p "$PID_DIR"
+
+cleanup() {
+    [ -f "$PID_DIR/proxy.pid" ] && kill "$(cat "$PID_DIR/proxy.pid")" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# launchctl stub: report "not managed" so the manual daemon route runs.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/launchctl"
+chmod +x "$STUB/launchctl"
+
+# Fake service: fork a long-lived child, record its PID, then block. Killing the
+# process group (or parent+child) must take both down.
+FAKE="$WORK/fake-service.sh"
+cat > "$FAKE" <<EOF
+#!/bin/sh
+sleep 300 &
+echo \$! > "$WORK/child.pid"
+exec sleep 300
+EOF
+chmod +x "$FAKE"
+export DS4CTL_EXEC_OVERRIDE="$FAKE"
+
+wait_for() { # wait_for <file> <timeout-sec>
+    _i=0
+    while [ ! -s "$1" ] && [ "$_i" -lt "${2}0" ]; do
+        perl -e 'select undef,undef,undef,0.1'
+        _i=$((_i + 1))
+    done
+    [ -s "$1" ]
+}
+
+# --- start -> PID file created, parent+child alive --------------------------
+PATH="$STUB:$PATH" bash "$DS4CTL" start proxy >"$WORK/out" 2>&1 || fail "start proxy failed: $(cat "$WORK/out")"
+wait_for "$PID_DIR/proxy.pid" 5 || fail "start: proxy.pid not created"
+wait_for "$WORK/child.pid" 5 || fail "start: fake child never spawned"
+PARENT="$(cat "$PID_DIR/proxy.pid")"
+CHILD="$(cat "$WORK/child.pid")"
+kill -0 "$PARENT" 2>/dev/null || fail "start: parent $PARENT not alive"
+kill -0 "$CHILD" 2>/dev/null || fail "start: child $CHILD not alive"
+
+# --- stop -> parent+child gone, PID file removed ----------------------------
+PATH="$STUB:$PATH" bash "$DS4CTL" stop proxy >"$WORK/out" 2>&1 || fail "stop proxy failed: $(cat "$WORK/out")"
+perl -e 'select undef,undef,undef,0.5'
+kill -0 "$PARENT" 2>/dev/null && fail "stop: parent $PARENT still alive"
+kill -0 "$CHILD" 2>/dev/null && fail "stop: child $CHILD still alive (not reaped)"
+[ -f "$PID_DIR/proxy.pid" ] && fail "stop: proxy.pid not removed"
+
+# --- stale PID -> swept on next start ---------------------------------------
+echo "999999" > "$PID_DIR/proxy.pid"   # a PID that is not running
+rm -f "$WORK/child.pid"
+PATH="$STUB:$PATH" bash "$DS4CTL" start proxy >"$WORK/out" 2>&1 || fail "start after stale PID failed: $(cat "$WORK/out")"
+wait_for "$WORK/child.pid" 5 || fail "stale PID: service did not (re)start"
+NEWPID="$(cat "$PID_DIR/proxy.pid")"
+[ "$NEWPID" != "999999" ] || fail "stale PID: proxy.pid still holds the dead 999999"
+kill -0 "$NEWPID" 2>/dev/null || fail "stale PID: new parent $NEWPID not alive"
+
+echo "PASS: test-pid-lifecycle"

--- a/tests/feature-18-ds4ctl/test-plist.sh
+++ b/tests/feature-18-ds4ctl/test-plist.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl launchd plist — Label, KeepAlive=true, RunAtLoad=true, ProgramArguments, StandardOutPath present; reinstall overwrites without duplicating.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+#
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+mkdir -p "$HOME/Library/LaunchAgents"
+trap 'rm -rf "$WORK"' EXIT
+
+# Stub launchctl so `install` cannot actually load the agent.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 0\n' > "$STUB/launchctl"
+chmod +x "$STUB/launchctl"
+
+PATH="$STUB:$PATH" bash "$DS4CTL" install proxy >"$WORK/out" 2>&1 || fail "install proxy failed: $(cat "$WORK/out")"
+
+PLIST="$(ls "$HOME/Library/LaunchAgents"/*.plist 2>/dev/null | head -n1 || true)"
+[ -n "$PLIST" ] || fail "no plist written under ~/Library/LaunchAgents"
+
+need_key() { grep -q "<key>$1</key>" "$PLIST" || fail "plist missing <key>$1</key>"; }
+need_key "Label"
+need_key "ProgramArguments"
+need_key "StandardOutPath"
+need_key "KeepAlive"
+need_key "RunAtLoad"
+
+# KeepAlive and RunAtLoad must be boolean true.
+grep -A1 "<key>KeepAlive</key>" "$PLIST" | grep -q "<true/>" || fail "KeepAlive is not <true/>"
+grep -A1 "<key>RunAtLoad</key>" "$PLIST" | grep -q "<true/>" || fail "RunAtLoad is not <true/>"
+
+# Label should identify the proxy target.
+grep -A1 "<key>Label</key>" "$PLIST" | grep -qi "proxy" || fail "Label does not reference the proxy target"
+
+# --- Reinstall overwrites in place, no duplicate plist ----------------------
+PLIST_BASENAME="$(basename "$PLIST")"
+PATH="$STUB:$PATH" bash "$DS4CTL" install proxy >"$WORK/out2" 2>&1 || fail "second install proxy failed: $(cat "$WORK/out2")"
+
+# Exactly one plist for the proxy target must exist after reinstall.
+COUNT=$(ls "$HOME/Library/LaunchAgents"/*.plist 2>/dev/null | wc -l | tr -d ' ')
+[ "$COUNT" = "1" ] || fail "reinstall: expected 1 plist, found $COUNT (duplicate written)"
+[ -f "$HOME/Library/LaunchAgents/$PLIST_BASENAME" ] || fail "reinstall: plist $PLIST_BASENAME missing after overwrite"
+
+# Overwritten plist must still be valid (keys intact, not appended/corrupted).
+need_key "Label"
+need_key "ProgramArguments"
+# A single <plist> root — appending rather than overwriting would duplicate it.
+PLIST_ROOTS=$(grep -c "<plist" "$HOME/Library/LaunchAgents/$PLIST_BASENAME")
+[ "$PLIST_ROOTS" = "1" ] || fail "reinstall: plist has $PLIST_ROOTS <plist> roots — content duplicated, not overwritten"
+
+echo "PASS: test-plist"

--- a/tests/feature-18-ds4ctl/test-restart.sh
+++ b/tests/feature-18-ds4ctl/test-restart.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl restart — stops the running process, starts a fresh one, PID changes.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# A fake service stands in for the real backend via the DS4CTL_EXEC_OVERRIDE
+# seam so no real ds4 process is launched.
+#
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+PID_DIR="$HOME/Library/Application Support/ds4-ops/run"
+mkdir -p "$PID_DIR"
+
+cleanup() {
+    [ -f "$PID_DIR/proxy.pid" ] && kill "$(cat "$PID_DIR/proxy.pid")" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# launchctl stub: report "not managed" so the manual daemon route runs.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/launchctl"
+chmod +x "$STUB/launchctl"
+
+# Fake service: block so the parent PID stays alive until stopped.
+FAKE="$WORK/fake-service.sh"
+cat > "$FAKE" <<'EOF'
+#!/bin/sh
+exec sleep 300
+EOF
+chmod +x "$FAKE"
+export DS4CTL_EXEC_OVERRIDE="$FAKE"
+
+wait_for() { _i=0; while [ ! -s "$1" ] && [ "$_i" -lt "${2}0" ]; do perl -e 'select undef,undef,undef,0.1'; _i=$((_i+1)); done; [ -s "$1" ]; }
+
+# --- start -> record the original PID ---------------------------------------
+PATH="$STUB:$PATH" bash "$DS4CTL" start proxy >"$WORK/out" 2>&1 || fail "start proxy failed: $(cat "$WORK/out")"
+wait_for "$PID_DIR/proxy.pid" 5 || fail "start: proxy.pid not created"
+OLDPID="$(cat "$PID_DIR/proxy.pid")"
+kill -0 "$OLDPID" 2>/dev/null || fail "start: parent $OLDPID not alive"
+
+# --- restart -> old process stopped, new process started, PID changed -------
+PATH="$STUB:$PATH" bash "$DS4CTL" restart proxy >"$WORK/out" 2>&1 || fail "restart proxy failed: $(cat "$WORK/out")"
+wait_for "$PID_DIR/proxy.pid" 5 || fail "restart: proxy.pid not created"
+NEWPID="$(cat "$PID_DIR/proxy.pid")"
+
+# 1. Old process must be gone.
+perl -e 'select undef,undef,undef,0.5'
+kill -0 "$OLDPID" 2>/dev/null && fail "restart: old process $OLDPID still alive (not stopped)"
+# 2. New process must be alive.
+kill -0 "$NEWPID" 2>/dev/null || fail "restart: new process $NEWPID not alive"
+# 3. PID must have changed.
+[ "$NEWPID" != "$OLDPID" ] || fail "restart: PID did not change ($NEWPID == $OLDPID)"
+
+echo "PASS: test-restart"

--- a/tests/feature-18-ds4ctl/test-status.sh
+++ b/tests/feature-18-ds4ctl/test-status.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl status — running reports "running (pid N)"; stopped reports "stopped".
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+#
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+PID_DIR="$HOME/Library/Application Support/ds4-ops/run"
+mkdir -p "$PID_DIR"
+
+cleanup() {
+    [ -n "${LIVE:-}" ] && kill "$LIVE" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# launchctl stub: report "not managed" so status reflects the manual PID file.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/launchctl"
+chmod +x "$STUB/launchctl"
+
+# pgrep stub: no unsupervised match, so status depends solely on the PID file.
+printf '#!/bin/sh\nexit 1\n' > "$STUB/pgrep"
+chmod +x "$STUB/pgrep"
+
+# --- running -> "running (pid N)" -------------------------------------------
+sleep 300 &
+LIVE=$!
+printf '%s\n' "$LIVE" > "$PID_DIR/proxy.pid"
+
+out="$(PATH="$STUB:$PATH" bash "$DS4CTL" status proxy 2>&1)"; rc=$?
+echo "$out" | grep -qi "running" || fail "status (running): missing 'running' (got: $out)"
+echo "$out" | grep -q "$LIVE" || fail "status (running): pid $LIVE not shown (got: $out)"
+
+# --- stopped -> "stopped" ----------------------------------------------------
+kill "$LIVE" 2>/dev/null
+wait "$LIVE" 2>/dev/null
+LIVE=""
+rm -f "$PID_DIR/proxy.pid"
+
+out="$(PATH="$STUB:$PATH" bash "$DS4CTL" status proxy 2>&1)"; rc=$?
+echo "$out" | grep -qi "stopped" || fail "status (stopped): missing 'stopped' (got: $out)"
+
+echo "PASS: test-status"

--- a/tests/feature-18-ds4ctl/test-stop-all.sh
+++ b/tests/feature-18-ds4ctl/test-stop-all.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl `stop all` partial-failure continuation — proxy launchd-managed (refused), server still stopped.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+PID_DIR="$HOME/Library/Application Support/ds4-ops/run"
+mkdir -p "$PID_DIR"
+
+cleanup() {
+    [ -n "${PROXY:-}" ] && kill "$PROXY" 2>/dev/null
+    [ -n "${SERVER:-}" ] && kill "$SERVER" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# launchctl stub: proxy label is managed (running); server label is unmanaged.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+cat > "$STUB/launchctl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *proxy*) echo "com.nire.ds4-proxy = { state = running }"; exit 0 ;;
+    *server*) exit 1 ;;   # not loaded -> manual
+esac
+exit 0
+EOF
+chmod +x "$STUB/launchctl"
+
+# Live processes for each target.
+sleep 300 & PROXY=$!
+sleep 300 & SERVER=$!
+printf '%s\n' "$PROXY" > "$PID_DIR/proxy.pid"
+printf '%s\n' "$SERVER" > "$PID_DIR/server.pid"
+
+out="$(PATH="$STUB:$PATH" bash "$DS4CTL" stop all 2>&1)"; rc=$?
+
+# Proxy (managed) must be left running and its PID file kept.
+kill -0 "$PROXY" 2>/dev/null || fail "stop all: managed proxy $PROXY was killed"
+[ -f "$PID_DIR/proxy.pid" ] || fail "stop all: proxy.pid removed despite managed refusal"
+echo "$out" | grep -qi "uninstall" || fail "stop all: no uninstall guidance for the managed proxy (out: $out)"
+
+# Server (manual) must be stopped despite the proxy failure — continuation.
+perl -e 'select undef,undef,undef,0.5'
+kill -0 "$SERVER" 2>/dev/null && fail "stop all: manual server $SERVER not stopped (no continuation)"
+[ -f "$PID_DIR/server.pid" ] && fail "stop all: server.pid not removed"
+
+# A partial failure should surface as a non-zero overall exit.
+[ "$rc" != "0" ] || fail "stop all: expected non-zero exit on partial failure, got 0"
+
+echo "PASS: test-stop-all"

--- a/tests/feature-18-ds4ctl/test-uninstall.sh
+++ b/tests/feature-18-ds4ctl/test-uninstall.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tests: ds4ctl uninstall — removes the LaunchAgents plist and calls `launchctl unload -w`.
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Skips (exit 77) until scripts/ds4ctl.sh exists (implementation pending).
+# launchctl is stubbed to record its argv so the unload call can be asserted.
+#
+# L3 gap: real launchctl load/unload persistence across reboots; actual
+#   caffeinate process supervision on macOS; real DS4_API_KEY auth check.
+set -u
+
+REPO="/Users/nire/git/ds4-ops"
+DS4CTL="$REPO/scripts/ds4ctl.sh"
+
+[ -f "$DS4CTL" ] || { echo "SKIP: $DS4CTL not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+export HOME="$WORK/home"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+mkdir -p "$LAUNCH_AGENTS"
+trap 'rm -rf "$WORK"' EXIT
+
+PLIST="$LAUNCH_AGENTS/com.nire.ds4-proxy.plist"
+
+# launchctl stub: record every invocation's argv for later assertion.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+LAUNCHCTL_LOG="$WORK/launchctl.log"
+export LAUNCHCTL_LOG
+cat > "$STUB/launchctl" <<'EOF'
+#!/bin/sh
+echo "$*" >> "$LAUNCHCTL_LOG"
+exit 0
+EOF
+chmod +x "$STUB/launchctl"
+
+# Seed an installed plist so uninstall has something to remove.
+cat > "$PLIST" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.nire.ds4-proxy</string>
+</dict></plist>
+EOF
+
+out="$(PATH="$STUB:$PATH" bash "$DS4CTL" uninstall proxy 2>&1)"; rc=$?
+[ "$rc" = "0" ] || fail "uninstall proxy failed: rc=$rc (out: $out)"
+
+# 1. The plist must be removed.
+[ ! -f "$PLIST" ] || fail "uninstall: plist $PLIST was not removed"
+
+# 2. launchctl unload -w must have been called.
+[ -f "$LAUNCHCTL_LOG" ] || fail "uninstall: launchctl was never invoked"
+grep -q "unload" "$LAUNCHCTL_LOG" || fail "uninstall: launchctl unload not called (log: $(cat "$LAUNCHCTL_LOG"))"
+grep -- "-w" "$LAUNCHCTL_LOG" | grep -q "unload" || fail "uninstall: launchctl unload missing -w (log: $(cat "$LAUNCHCTL_LOG"))"
+
+echo "PASS: test-uninstall"


### PR DESCRIPTION
## Summary

- Adds `scripts/ds4ctl.sh`: unified `start|stop|restart|status|logs|install|uninstall [proxy|server|all]` command
- launchd LaunchAgent auto-start at login with KeepAlive=true for both services (`ds4ctl install all`)
- `DS4_LOG=on/off` in `.env` toggles stdout/stderr file logging to prevent disk write storms
- ANSI terminal color for ds4-server output (`DS4_SERVER_COLOR_LOG`); log files always receive plain bytes
- `ds4ctl logs` live tail with color; proxy Ctrl-C no longer prints a traceback
- Modular `scripts/lib/` split: paths / colorize / lifecycle / launchd
- Existing `ds4-proxy.sh` / `ds4-server.sh` shrunk to thin backward-compatible wrappers

## Test plan

- [ ] `ds4ctl start proxy` starts proxy in background; `status proxy` shows running PID
- [ ] `ds4ctl start server` starts ds4-server via caffeinate; `status server` shows running PID
- [ ] `ds4ctl stop all` stops both services; PID files removed
- [ ] `ds4ctl install all` creates plists; `launchctl list com.nire.ds4-proxy` returns 0
- [ ] `ds4ctl uninstall all` removes plists and stops services
- [ ] `ds4ctl logs server` tails kvcache.log with ANSI color in terminal
- [ ] `DS4_LOG=off ds4ctl start server` produces no log file
- [ ] Ctrl-C on `ds4-proxy.sh` exits cleanly with no traceback
- [ ] `ds4ctl stop server` while launchd-managed prints guidance and exits 1

Closes #18

<!-- issue-close-pr-of: 18 -->