### PR TITLE
feat(litellm): add LiteLLM proxy configuration for Claude Code model routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,8 +49,6 @@ DS4_PROXY_KEY=~/.config/ds4-proxy/key.pem
 # Format: on or off — e.g. DS4_PROXY_TEE=on
 DS4_PROXY_TEE=off
 
-# Where DS4_PROXY_TEE writes its logs. Has no effect while DS4_PROXY_TEE is off.
-# Format: absolute path — e.g. DS4_PROXY_LOG_DIR=~/Library/Caches/ds4-proxy/log
 DS4_PROXY_LOG_DIR=~/Library/Caches/ds4-proxy/log
 
 # --- ds4 ops (lifecycle / logging) ---
@@ -65,3 +63,80 @@ DS4_LOG=on
 # Has no effect on non-TTY output (launchd, nohup, pipes).
 # Format: on or off — e.g. DS4_SERVER_COLOR_LOG=off
 DS4_SERVER_COLOR_LOG=on
+
+# --- litellm proxy (Windows, Docker Desktop WSL2) ---
+
+# Master key for LiteLLM admin API and virtual key generation.
+# Generate with: openssl rand -hex 32
+# Format: any non-empty string -- e.g. LITELLM_MASTER_KEY=sk-<generated>
+# WARNING: This key is the admin credential. NEVER use it directly as
+# ANTHROPIC_AUTH_TOKEN. Generate a scoped virtual key instead (see docs/ops.md).
+LITELLM_MASTER_KEY=
+
+# HTTPS port the LiteLLM proxy listens on. Must match the port in
+# ANTHROPIC_BASE_URL when routing through LiteLLM.
+# Format: integer -- e.g. LITELLM_PORT=8445
+LITELLM_PORT=8445
+
+# Directory containing the LiteLLM TLS cert/key files (mkcert-issued).
+# The files must be named cert.pem and key.pem.
+# This is a required field -- must be set to a valid absolute path.
+# Format: absolute Windows path -- e.g. LITELLM_TLS_DIR=C:\Users\<user>\.config\litellm
+LITELLM_TLS_DIR=
+
+# Path to the mkcert root CA .pem file. Mounted into the LiteLLM container so it
+# trusts the DS4 Proxy's TLS certificate when routing Opus requests to <mac-host>.
+# Get the path from: mkcert -CAROOT  (append /rootCA.pem on Windows).
+# Same root CA as DS4_CA_CERT.
+# Format: absolute path -- e.g. LITELLM_CA_CERT_FILE=C:\Users\<user>\AppData\Local\mkcert\rootCA.pem
+LITELLM_CA_CERT_FILE=
+
+# Database URL for LiteLLM persistent storage (virtual keys, model config).
+# Default: SQLite file stored in the container's data volume (survives restarts).
+# For production, switch to PostgreSQL.
+# Format: URL -- e.g. LITELLM_DB_URL=sqlite:///app/litellm/data/litellm.db
+LITELLM_DB_URL=sqlite:///app/litellm/data/litellm.db
+
+# Config directory containing litellm/config.yaml (Windows path).
+# Format: absolute Windows path -- e.g. LITELLM_CONFIG_DIR=C:\git\ds4-ops\litellm
+LITELLM_CONFIG_DIR=C:\git\ds4-ops\litellm
+
+# llama-swap endpoint on the local Windows machine (<windows-host>).
+# Both Haiku and Sonnet backends are served via llama-swap on this URL.
+# Inside the Docker container, this is resolved via host.docker.internal
+# (the launcher overrides this for Docker networking).
+# Format: URL -- e.g. LITELLM_LLAMA_SWAP_URL=http://localhost:18080/v1
+LITELLM_LLAMA_SWAP_URL=http://localhost:18080/v1
+
+# DS4 Proxy endpoint for the Opus tier. This is on <mac-host> (Mac, <mac-lan-ip>:8443).
+# DO NOT use host.docker.internal here -- that resolves to <windows-host>, not <mac-host>.
+# Inside the Docker container, this URL is used as-is; <mac-host> must be reachable
+# from the WSL2 Linux VM via the LAN.
+# Format: URL -- e.g. LITELLM_DS4_URL=https://<mac-lan-ip>:8443
+LITELLM_DS4_URL=https://<mac-lan-ip>:8443
+
+# API key for the DS4 Proxy Opus route. Must match DS4_API_KEY / DS4_PROXY_AUTH_TOKEN.
+# Format: any non-empty string -- e.g. LITELLM_DS4_API_KEY=dsv4-local
+LITELLM_DS4_API_KEY=dsv4-local
+
+# Model routing keys exposed by LiteLLM to Claude Code. These are the values
+# Claude Code sends as the model name in /v1/messages requests. LiteLLM matches
+# these against model_name entries in config.yaml, then routes to the correct backend.
+# Format: string -- e.g. LITELLM_HAIKU_MODEL=devstral-small-24b
+# When LITELLM_ANTHROPIC_BASE_URL is NOT set, code-ds4.cmd ignores these and falls
+# back to the original deepseek-* model names (backward compatibility).
+LITELLM_HAIKU_MODEL=devstral-small-24b
+LITELLM_SONNET_MODEL=qwen3-coder-next
+LITELLM_OPUS_MODEL=deepseek-v4-flash
+
+# Override ANTHROPIC_BASE_URL for LiteLLM routing. If set, the launcher uses
+# this value instead of DS4_ANTHROPIC_BASE_URL. When unset, falls back to
+# DS4_ANTHROPIC_BASE_URL and ignores LITELLM_*_MODEL vars (backward compatible).
+# Format: https://<host>:<port> -- e.g. LITELLM_ANTHROPIC_BASE_URL=https://<windows-host>:8445
+LITELLM_ANTHROPIC_BASE_URL=
+
+# Scoped virtual key for LiteLLM authentication. Generate from LITELLM_MASTER_KEY
+# using scripts/setup-litellm.cmd (one-time setup). This key has restricted scopes
+# and is used as ANTHROPIC_AUTH_TOKEN instead of exposing the master key.
+# Format: sk-<generated> -- e.g. LITELLM_VIRTUAL_KEY=sk-<generated-token>
+LITELLM_VIRTUAL_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@
 .env
 
 .migration-state.json
+
+# Python bytecode / caches
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
+# Local Claude Code / worktree state
+.claude/
+.worktree-backup/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,3 +107,67 @@ ds4 has no authentication. The proxy adds an HMAC-based token gate (constant-tim
 3. The normalization rules generalise beyond ds4.
 
 Until then it stays here as a deliberate hold, not drift.
+
+## LiteLLM routing layer (Windows)
+
+A LiteLLM proxy on <windows-host> (Windows, Docker Desktop WSL2) routes Claude Code requests
+by model name to three backends:
+
+| Tier | Model name (routing key) | Backend | Protocol conversion |
+|------|--------------------------|---------|---------------------|
+| Haiku | `devstral-small-24b` | Devstral-Small-2-24B-Instruct via llama-swap (<windows-host>, :18080) | Anthropic to OpenAI |
+| Sonnet | `qwen3-coder-next` | Qwen3-Coder-Next-Q4_K_M via llama-swap (<windows-host>, :18080) | Anthropic to OpenAI |
+| Opus | `deepseek-v4-flash` | DS4 Proxy (<mac-host>, :8443) | None (Anthropic passthrough) |
+
+### Why LiteLLM and not a custom router
+
+LiteLLM is an established open-source proxy that supports Anthropic-to-OpenAI conversion
+natively. Building a custom router would duplicate its model routing, virtual key auth,
+and protocol translation -- a net cost with no benefit given LiteLLM's maturity.
+
+### TLS termination
+
+LiteLLM listens on HTTPS with an mkcert-signed certificate, sharing the same root CA
+already used by the DS4 Proxy. The Windows client trusts it via `NODE_EXTRA_CA_CERTS`
+pointing at `<mkcert -CAROOT>/rootCA.pem` (same `DS4_CA_CERT` value). No new CA setup
+is needed.
+
+### CA cert trust for Opus route (container to <mac-host>)
+
+The LiteLLM container connects to the DS4 Proxy (<mac-host>:8443) over HTTPS for Opus requests.
+Inside the container, the mkcert root CA is mounted and appended to the system CA bundle
+at startup (via the compose file's entrypoint). This ensures LiteLLM can verify the DS4
+Proxy's TLS certificate. The same root CA file used for the Windows client (`DS4_CA_CERT`)
+is reused -- no separate CA setup.
+
+### Virtual key authentication
+
+LiteLLM uses virtual_key authentication. The `LITELLM_MASTER_KEY` is used for the admin
+API and virtual key generation -- it is NEVER exposed to the client. A one-time setup
+step (`scripts/setup-litellm.cmd`) creates a scoped virtual key from a randomly-generated
+key (NOT the master key). Claude Code presents the virtual key as `ANTHROPIC_AUTH_TOKEN`
+to authenticate with LiteLLM. The DS4 Proxy's own token auth is preserved for the Opus
+route: LiteLLM forwards `LITELLM_DS4_API_KEY` as the `x-api-key` header to the DS4 Proxy.
+
+### Database for virtual key persistence
+
+LiteLLM requires a database backend for key generation and verification. The compose file
+configures SQLite (`DATABASE_URL=sqlite:///app/litellm/data/litellm.db`) with a named
+volume for persistence across restarts. For production deployments, PostgreSQL should be
+used instead (set `LITELLM_DB_URL` to a PostgreSQL connection string).
+
+### Host.docker.internal usage (llama-swap only)
+
+Docker Desktop runs containers in a WSL2 Linux VM. `localhost` inside the container refers
+to the container itself, not the Windows host. Docker Desktop provides the DNS name
+`host.docker.internal` to reach the Windows host. The LiteLLM config and launcher use
+`host.docker.internal` ONLY for the llama-swap endpoint (which runs on <windows-host>
+Windows). The DS4 Proxy endpoint uses <mac-host>'s LAN IP (<mac-lan-ip>:8443) directly --
+`host.docker.internal` would resolve to <windows-host>, not <mac-host>, so it is NOT used for the
+Opus route.
+
+### Two strategies update
+
+The LiteLLM router is the implementation for the "Hybrid (router)" strategy, but with
+the caveat that it does not preserve an Anthropic subscription (the Opus leg goes to
+self-hosted DS4, not real Opus).

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -7,7 +7,8 @@ SSOT for hosts, network, ports, and paths. Other docs reference this — do not 
 | Host | Role | Spec |
 |---|---|---|
 | Mac (this machine) | ds4-server (backend) | MacBook Pro M5 Max, 128 GB unified memory |
-| windows-client | Claude Code client | Windows |
+| <windows-host> (Windows) | LiteLLM proxy + llama-swap | Windows 11, Docker Desktop WSL2 |
+| windows-client | Claude Code client | Windows (same machine as <windows-host>) |
 
 ## Engine & model (on the Mac)
 
@@ -25,6 +26,11 @@ SSOT for hosts, network, ports, and paths. Other docs reference this — do not 
 | Server listen | `127.0.0.1:8000` (loopback only — proxy is the LAN endpoint) |
 | Proxy listen | `0.0.0.0:8443` (HTTPS, TLS terminated, mkcert cert) |
 | Client base URL | `https://<mac-ip>:8443` (fill in the Mac's LAN IP) |
+| llama-swap listen | `127.0.0.1:18080` (OpenAI-compatible, <windows-host>) |
+| LiteLLM listen | `0.0.0.0:8445` (HTTPS, TLS terminated, mkcert cert, <windows-host>) |
+| Client base URL (LiteLLM path) | `https://<windows-host>:8445` |
+| DS4 Proxy listen | `0.0.0.0:8443` (HTTPS, <mac-host> Mac, reachable from WSL2 via LAN) |
+| <mac-host> LAN IP | `<mac-lan-ip>` (for WSL2 container direct access) |
 | Protocols served | `/v1/messages` (Anthropic), `/v1/chat/completions`, `/v1/completions`, `/v1/responses` (OpenAI), `/v1/models` |
 
 ## Paths (Mac)
@@ -35,3 +41,16 @@ SSOT for hosts, network, ports, and paths. Other docs reference this — do not 
 | Proxy start script | `~/git/ds4-ops/scripts/ds4-proxy.sh` |
 | Proxy TLS cert/key | `~/.config/ds4-proxy/cert.pem` / `key.pem` (mkcert-generated) |
 | KV disk cache | `~/Library/Caches/ds4-server/kv` (persistent, Time Machine-excluded by macOS default) |
+
+## Paths (Windows)
+
+| Item | Value |
+|---|---|
+| LiteLLM config | `C:\git\ds4-ops\litellm\config.yaml` |
+| LiteLLM compose | `C:\git\ds4-ops\litellm\docker-compose.yml` |
+| LiteLLM start script | `C:\git\ds4-ops\scripts\litellm-start.cmd` |
+| LiteLLM setup script | `C:\git\ds4-ops\scripts\setup-litellm.cmd` |
+| LiteLLM TLS cert/key | `C:\Users\<user>\.config\litellm\cert.pem` / `key.pem` (mkcert-generated) |
+| LiteLLM CA cert (Opus trust) | `<mkcert -CAROOT>\rootCA.pem` (same as DS4_CA_CERT) |
+| LiteLLM database volume | `litellm-data` (Docker named volume, persists at /app/litellm/data) |
+| llama-swap config | `C:\LLM\llama-swap\config.yaml` (not in this repo) |

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -39,6 +39,150 @@ Client-side (Windows): set `DS4_CA_CERT` to `<mkcert -CAROOT>/rootCA.pem` in the
 `.env` so Node trusts the proxy certificate, and set `DS4_API_KEY` to the same value as
 `DS4_PROXY_AUTH_TOKEN`.
 
+## LiteLLM (Windows, Docker Desktop WSL2)
+
+### TLS setup (one-time)
+
+The LiteLLM proxy needs an mkcert leaf cert/key. Use the same root CA as the DS4 Proxy
+so the client trusts both endpoints with one `DS4_CA_CERT`:
+
+```bat
+mkcert localhost 127.0.0.1 ::1 <windows-host>
+rem Copy the generated cert.pem + key.pem to the directory specified by LITELLM_TLS_DIR
+rem (e.g., C:\Users\<user>\.config\litellm\)
+```
+
+### CA cert setup (one-time)
+
+The LiteLLM container needs to trust the DS4 Proxy's TLS certificate for the Opus route.
+Set `LITELLM_CA_CERT_FILE` in `.env` to the path of the mkcert root CA `.pem` file:
+
+```bat
+rem Get the path from mkcert -CAROOT, then append /rootCA.pem
+rem e.g. LITELLM_CA_CERT_FILE=C:\Users\<user>\AppData\Local\mkcert\rootCA.pem
+```
+
+This is the same root CA file used for `DS4_CA_CERT`. The compose file mounts it into
+the container and the entrypoint installs it into the system trust store.
+
+### Initial setup (one-time)
+
+1. Generate a master key and set it in `.env`:
+   ```bat
+   openssl rand -hex 32
+   rem Set LITELLM_MASTER_KEY=sk-<output> in .env
+   ```
+
+2. Generate a TLS cert and set LITELLM_TLS_DIR in `.env` to point at the cert directory:
+   ```bat
+   mkcert localhost 127.0.0.1 ::1 <windows-host>
+   rem Set LITELLM_TLS_DIR=<path-to-cert-dir> in .env
+   ```
+
+3. Set the CA cert path in `.env`:
+   ```bat
+   rem Set LITELLM_CA_CERT_FILE=<mkcert -CAROOT>\rootCA.pem in .env
+   ```
+
+4. Start the LiteLLM container:
+   ```bat
+   scripts\litellm-start.cmd up
+   ```
+
+5. Wait a few seconds for the SQLite database tables to be created, then generate a
+   scoped virtual key for client auth:
+   ```bat
+   scripts\setup-litellm.cmd
+   rem Copy the returned key into .env as LITELLM_VIRTUAL_KEY
+   ```
+
+6. Restart the container so it picks up the new env vars:
+   ```bat
+   scripts\litellm-start.cmd restart
+   ```
+
+### Start LiteLLM
+
+```bat
+scripts\litellm-start.cmd up
+```
+
+This starts the container via `docker compose up -d`. The container listens on
+`LITELLM_PORT` (default 8445) with TLS.
+
+### Stop LiteLLM
+
+```bat
+scripts\litellm-start.cmd down
+```
+
+### Verify LiteLLM is running
+
+```bat
+scripts\litellm-start.cmd status
+```
+
+Or check the health endpoint directly:
+```bat
+curl -k https://localhost:8445/health/
+```
+
+### Verify routing
+
+Send a test request to confirm each tier routes correctly. Use the **Anthropic
+/v1/messages** endpoint (the format Claude Code sends) to verify LiteLLM's
+Anthropic-to-OpenAI conversion works end-to-end:
+
+```bat
+rem Haiku tier (Anthropic format -- LiteLLM converts to OpenAI for llama-swap)
+curl -k -X POST https://localhost:8445/v1/messages ^
+  -H "Content-Type: application/json" ^
+  -H "x-api-key: <LITELLM_VIRTUAL_KEY>" ^
+  -H "anthropic-version: 2023-06-01" ^
+  -d "{\"model\":\"devstral-small-24b\",\"max_tokens\":100,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"
+
+rem Opus tier (Anthropic format -- passthrough to DS4 Proxy)
+curl -k -X POST https://localhost:8445/v1/messages ^
+  -H "Content-Type: application/json" ^
+  -H "x-api-key: <LITELLM_VIRTUAL_KEY>" ^
+  -H "anthropic-version: 2023-06-01" ^
+  -d "{\"model\":\"deepseek-v4-flash\",\"max_tokens\":100,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"
+```
+
+Note: Use the virtual key, NOT the master key. The `/v1/messages` endpoint confirms
+LiteLLM receives Anthropic-format requests and converts Haiku/Sonnet to OpenAI for
+llama-swap.
+
+### Client (Windows) with LiteLLM
+
+First time only, ensure the repo-root `.env` has the LiteLLM vars filled in. The
+`code-ds4.cmd` launcher now prefers `LITELLM_ANTHROPIC_BASE_URL` over `DS4_ANTHROPIC_BASE_URL`.
+
+Set in `.env`:
+```bat
+LITELLM_ANTHROPIC_BASE_URL=https://<windows-host>:8445
+LITELLM_VIRTUAL_KEY=sk-<generated-token>
+```
+
+Then launch as before:
+```bat
+scripts\code-ds4.cmd .
+```
+
+### Recovery
+
+| Symptom | Action |
+|---------|--------|
+| LiteLLM container not running | `litellm-start.cmd up`; check Docker Desktop is running |
+| `Connection refused` on :8445 | Verify container status; check port mapping |
+| llama-swap returns errors | Verify llama-swap is running on <windows-host> (`http://localhost:18080`) |
+| DS4 Proxy unreachable | Verify <mac-host> Mac is reachable (<mac-lan-ip>); check DS4 Proxy status |
+| TLS errors | Verify cert/key files exist in `LITELLM_TLS_DIR` and are mkcert-signed |
+| TLS errors on Opus route | Verify `LITELLM_CA_CERT_FILE` points to the mkcert root CA and the file is mounted correctly |
+| `401 Unauthorized` from LiteLLM | Verify `LITELLM_VIRTUAL_KEY` is set in `.env` and matches the generated key |
+| `/key/generate` fails | Verify `DATABASE_URL` is set (SQLite configured in compose); wait for database initialisation |
+| Keys lost after restart | Verify `litellm-data` volume persists; check `docker volume ls` for the named volume |
+
 ## Run the server (Mac)
 
 ```sh

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -88,3 +88,36 @@ Read by `scripts/ds4-proxy.sh` (from the repo-root `.env`). Design: [architectur
 | `DS4_PROXY_CERT` / `DS4_PROXY_KEY` | `~/.config/ds4-proxy/cert.pem` / `key.pem` (defaults) | mkcert-generated TLS cert/key for the HTTPS listener. |
 | `DS4_PROXY_TEE` | `off` (default) / `on` | When `on`, logs pre- and post-normalization request bodies for debugging. |
 | `DS4_PROXY_LOG_DIR` | `~/Library/Caches/ds4-proxy/log` (default) | Where tee logs are written when `DS4_PROXY_TEE=on`. |
+
+### LiteLLM env vars
+
+Read by the LiteLLM container (passed through from `.env` via the compose file).
+Designed in `litellm/config.yaml`. The `model_name` fields use `os.environ/` pattern;
+the `litellm_params.model` values are hardcoded backend model names (env vars cannot
+be embedded after a provider prefix). Defaults are documented here but are NOT
+embedded in config.yaml; they are set in `.env.example` and resolved at container
+startup.
+
+| Var | Default | Why |
+|-----|---------|-----|
+| `LITELLM_MASTER_KEY` | (required) | Master key for LiteLLM admin API and virtual key generation. Generate with `openssl rand -hex 32`. Never expose to clients. |
+| `LITELLM_PORT` | `8445` | HTTPS listen port. Must match the port in `ANTHROPIC_BASE_URL` when routing through LiteLLM. |
+| `LITELLM_TLS_DIR` | (required) | Directory containing `cert.pem` and `key.pem` (mkcert-issued). Mounted into the container at `/app/certs`. No default -- user must set this in `.env`. |
+| `LITELLM_CA_CERT_FILE` | (required for Opus) | Path to mkcert root CA `.pem` file. Mounted into the container so LiteLLM trusts the DS4 Proxy TLS cert. Same root CA as `DS4_CA_CERT`. |
+| `LITELLM_DB_URL` | `sqlite:///app/litellm/data/litellm.db` | Database URL for virtual key persistence. SQLite by default (no external deps). Switch to PostgreSQL for production. |
+| `LITELLM_CONFIG_DIR` | `C:\git\ds4-ops\litellm` | Config directory containing litellm/config.yaml. |
+| `LITELLM_LLAMA_SWAP_URL` | `http://host.docker.internal:18080/v1` | llama-swap OpenAI-compatible endpoint for Haiku/Sonnet backends. Overridden to `host.docker.internal` by the launcher. |
+| `LITELLM_DS4_URL` | `https://<mac-lan-ip>:8443` | DS4 Proxy endpoint for Opus tier. Uses <mac-host>'s LAN IP directly -- NOT host.docker.internal. |
+| `LITELLM_DS4_API_KEY` | `dsv4-local` | API key sent to DS4 Proxy for Opus route. Must match `DS4_API_KEY`. |
+| `LITELLM_HAIKU_MODEL` | `devstral-small-24b` | Model routing key for Haiku tier. Claude Code sends this value as the model name; LiteLLM matches it to the model_name entry in config.yaml. |
+| `LITELLM_SONNET_MODEL` | `qwen3-coder-next` | Model routing key for Sonnet tier. |
+| `LITELLM_OPUS_MODEL` | `deepseek-v4-flash` | Model routing key for Opus tier. |
+| `LITELLM_ANTHROPIC_BASE_URL` | (optional) | Override for `ANTHROPIC_BASE_URL` in code-ds4.cmd. When unset, falls back to `DS4_ANTHROPIC_BASE_URL` and ignores LITELLM_*_MODEL vars. |
+| `LITELLM_VIRTUAL_KEY` | (required for client) | Scoped virtual key for client authentication with LiteLLM. Generated from a random key (not the master key). |
+
+### Client env vars update
+
+The `ANTHROPIC_BASE_URL` now points at LiteLLM (`https://<windows-host>:8445`) rather than directly at DS4 Proxy when `LITELLM_ANTHROPIC_BASE_URL` is set. The model
+alias vars now use conditional logic: when `LITELLM_ANTHROPIC_BASE_URL` is set, they
+use `LITELLM_HAIKU_MODEL` / `LITELLM_SONNET_MODEL` / `LITELLM_OPUS_MODEL`; otherwise
+they fall back to `deepseek-chat` / `deepseek-v4-flash` / `deepseek-v4-flash`.

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -1,0 +1,58 @@
+# LiteLLM proxy configuration for ds4-ops.
+# Routes Claude Code model tiers to different backends by model name.
+# Env vars are resolved at startup via os.environ/ pattern (NOT ${VAR:default}).
+# All defaults are documented in .env.example, not embedded here.
+#
+# IMPORTANT: The os.environ/ prefix is only resolved by LiteLLM when it appears
+# at the START of a value. After a provider prefix (e.g., openai/), the entire
+# string including os.environ/ is passed literally to the backend. Therefore,
+# model_name (routing key) uses os.environ/, but litellm_params.model uses a
+# hardcoded backend model name after the provider prefix.
+
+model_list:
+  # --- Haiku tier: Devstral-Small-2-24B-Instruct via llama-swap (OpenAI) ---
+  # model_name is the routing key — what Claude Code sends. Resolved from env var.
+  # model is the backend model name — hardcoded because it sits after "openai/".
+  - model_name: os.environ/LITELLM_HAIKU_MODEL
+    litellm_params:
+      model: openai/Devstral-Small-2-24B-Instruct-2512-IQ4_XS
+      api_base: os.environ/LITELLM_LLAMA_SWAP_URL
+      api_key: none                        # no auth for llama-swap local backend
+      stream: true
+      max_tokens: 8192
+
+  # --- Sonnet tier: Qwen3-Coder-Next-Q4_K_M via llama-swap (OpenAI) ---
+  - model_name: os.environ/LITELLM_SONNET_MODEL
+    litellm_params:
+      model: openai/Qwen3-Coder-Next-Q4_K_M
+      api_base: os.environ/LITELLM_LLAMA_SWAP_URL
+      api_key: none                        # no auth for llama-swap local backend
+      stream: true
+      max_tokens: 8192
+
+  # --- Opus tier: DeepSeek V4 Flash via DS4 Proxy (Anthropic passthrough) ---
+  - model_name: os.environ/LITELLM_OPUS_MODEL
+    litellm_params:
+      model: anthropic/deepseek-v4-flash
+      api_base: os.environ/LITELLM_DS4_URL
+      api_key: os.environ/LITELLM_DS4_API_KEY
+      stream: true
+      max_tokens: 8192
+
+litellm_settings:
+  # Enable virtual key authentication
+  drop_params: false
+  enable_caching_on_failures: false
+  store_model_options_in_db: false
+
+general_settings:
+  # Master key for admin API and virtual key generation
+  master_key: os.environ/LITELLM_MASTER_KEY
+
+router_settings:
+  # Default model routing strategy
+  routing_strategy: simple-shuffle
+  num_retries: 2
+  fallbacks: []
+  context_window_fallbacks: []
+  enable_pre_call_routing: false

--- a/litellm/docker-compose.yml
+++ b/litellm/docker-compose.yml
@@ -1,0 +1,72 @@
+version: "3.9"
+
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm:main-latest
+    container_name: ds4-litellm
+    ports:
+      - "${LITELLM_PORT:-8445}:${LITELLM_PORT:-8445}"
+    volumes:
+      # Mount the config file directory from the Windows filesystem into the container.
+      - type: bind
+        source: ${LITELLM_CONFIG_DIR:-C:\git\ds4-ops\litellm}
+        target: /app/litellm
+        read_only: true
+      # Mount the TLS cert/key directory. LITELLM_TLS_DIR is REQUIRED -- no default.
+      # The user MUST set this env var in .env. Inside the container, cert.pem and
+      # key.pem are expected at /app/certs/cert.pem and /app/certs/key.pem.
+      - type: bind
+        source: ${LITELLM_TLS_DIR}
+        target: /app/certs
+        read_only: true
+      # Mount the mkcert root CA so the container trusts the DS4 Proxy TLS cert.
+      # Required for the Opus route (LiteLLM connects to <mac-host>:8443 over HTTPS).
+      - type: bind
+        source: ${LITELLM_CA_CERT_FILE}
+        target: /usr/local/share/ca-certificates/rootCA.crt
+        read_only: true
+      # Persistent volume for LiteLLM's SQLite database (virtual keys, model config).
+      # Without this, /key/generate fails and keys are lost on container restart.
+      - type: volume
+        source: litellm-data
+        target: /app/litellm/data
+    environment:
+      # Pass through all LITELLM_* env vars so config.yaml resolves them via os.environ/
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
+      LITELLM_HAIKU_MODEL: ${LITELLM_HAIKU_MODEL:-devstral-small-24b}
+      LITELLM_SONNET_MODEL: ${LITELLM_SONNET_MODEL:-qwen3-coder-next}
+      LITELLM_OPUS_MODEL: ${LITELLM_OPUS_MODEL:-deepseek-v4-flash}
+      LITELLM_LLAMA_SWAP_URL: ${LITELLM_LLAMA_SWAP_URL:-http://host.docker.internal:18080/v1}
+      LITELLM_DS4_URL: ${LITELLM_DS4_URL:-https://<mac-lan-ip>:8443}
+      LITELLM_DS4_API_KEY: ${LITELLM_DS4_API_KEY:-dsv4-local}
+      # Database URL for virtual key persistence. SQLite by default (no external deps).
+      # For production, override to PostgreSQL: LITELLM_DB_URL=postgres://...
+      DATABASE_URL: ${LITELLM_DB_URL:-sqlite:///app/litellm/data/litellm.db}
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+      - "cat /usr/local/share/ca-certificates/rootCA.crt >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null; exec litellm \"$@\""
+      - "--"
+    command:
+      - "--config=/app/litellm/config.yaml"
+      - "--port=${LITELLM_PORT:-8445}"
+      - "--ssl_certfile_path=/app/certs/cert.pem"
+      - "--ssl_keyfile_path=/app/certs/key.pem"
+      - "--detailed-logging"
+    healthcheck:
+      # Use HTTPS because the service listens on TLS. wget --no-check-certificate
+      # avoids cert verification issues inside the container (self-signed mkcert).
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "--no-check-certificate", "https://localhost:${LITELLM_PORT:-8445}/health/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped
+    extra_hosts:
+      # Allow the container to reach the Windows host via host.docker.internal
+      # for llama-swap access. The DS4 Proxy on <mac-host> is reached via LAN IP directly.
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  litellm-data:
+    # Named volume for SQLite database persistence. Survives container restarts.

--- a/scripts/code-ds4.cmd
+++ b/scripts/code-ds4.cmd
@@ -18,22 +18,28 @@ if exist "%DS4_ENV_FILE%" (
 rem Clear any real Anthropic API key so the ds4 server is used instead
 set ANTHROPIC_API_KEY=
 
-rem ds4 proxy base URL. The real Mac LAN IP is NOT committed (public repo): put
-rem DS4_ANTHROPIC_BASE_URL=https://<mac-lan-ip>:8443 in the repo-root .env (or set it in the
-rem shell). The default below is a placeholder (localhost, proxy port) and will not reach the Mac.
-if defined DS4_ANTHROPIC_BASE_URL (
-    set ANTHROPIC_BASE_URL=%DS4_ANTHROPIC_BASE_URL%
+rem LiteLLM proxy base URL. If LITELLM_ANTHROPIC_BASE_URL is set, the launcher uses
+rem LiteLLM's TLS endpoint. Otherwise falls back to the DS4 Proxy path.
+rem When neither is set, uses a placeholder default (localhost:8445).
+if defined LITELLM_ANTHROPIC_BASE_URL (
+    set "ANTHROPIC_BASE_URL=%LITELLM_ANTHROPIC_BASE_URL%"
+) else if defined DS4_ANTHROPIC_BASE_URL (
+    set "ANTHROPIC_BASE_URL=%DS4_ANTHROPIC_BASE_URL%"
 ) else (
-    echo [code-ds4] WARNING: DS4_ANTHROPIC_BASE_URL not set; using placeholder default https://localhost:8443 ^(will not reach the Mac ds4 proxy^).
-    set ANTHROPIC_BASE_URL=https://localhost:8443
+    echo [code-ds4] WARNING: Neither LITELLM_ANTHROPIC_BASE_URL nor DS4_ANTHROPIC_BASE_URL set.
+    set "ANTHROPIC_BASE_URL=https://localhost:8445"
 )
 
-rem ds4 proxy auth token. The proxy verifies this token; set it to the same value as
-rem DS4_PROXY_AUTH_TOKEN on the Mac (override with DS4_API_KEY env var).
-if defined DS4_API_KEY (
-    set ANTHROPIC_AUTH_TOKEN=%DS4_API_KEY%
+rem LiteLLM authentication. Use a scoped virtual key generated from the master key,
+rem NOT the master key itself. The virtual key is set up via scripts/setup-litellm.cmd.
+rem If no virtual key is available, fall back to DS4_API_KEY for direct proxy auth.
+if defined LITELLM_VIRTUAL_KEY (
+    set "ANTHROPIC_AUTH_TOKEN=%LITELLM_VIRTUAL_KEY%"
+) else if defined DS4_API_KEY (
+    set "ANTHROPIC_AUTH_TOKEN=%DS4_API_KEY%"
 ) else (
-    set ANTHROPIC_AUTH_TOKEN=dsv4-local
+    echo [code-ds4] WARNING: Neither LITELLM_VIRTUAL_KEY nor DS4_API_KEY set.
+    set "ANTHROPIC_AUTH_TOKEN=dsv4-local"
 )
 
 rem mkcert local CA root so Node trusts the proxy TLS certificate. Set DS4_CA_CERT to
@@ -45,16 +51,38 @@ if defined DS4_CA_CERT (
     echo [code-ds4] WARNING: DS4_CA_CERT not set; TLS certificate will not be trusted.
 )
 
-set ANTHROPIC_MODEL=deepseek-v4-flash
-set ANTHROPIC_CUSTOM_MODEL_OPTION=deepseek-v4-flash
-set ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=DeepSeek V4 Flash local ds4
-set ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION=ds4.c local GGUF
-set ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-flash
-rem Haiku is the lightweight/mechanical tier (titles, quick background tasks); map it to the
-rem non-thinking alias so it stays fast and cheap. Thinking-control model names: docs/tuning.md.
-set ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-chat
-set ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-flash
-set CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash
+rem Model aliases for Claude Code.
+rem When LITELLM_ANTHROPIC_BASE_URL is set, use LITELLM_*_MODEL routing keys.
+rem When falling back to DS4 Proxy, always use deepseek-* originals so that
+rem DS4 Proxy receives model names it understands (deepseek-v4-flash, deepseek-chat).
+rem The LITELLM_*_MODEL vars are LiteLLM-specific routing keys that DS4 Proxy
+rem does not recognise -- never send them to DS4 Proxy.
+if defined LITELLM_ANTHROPIC_BASE_URL (
+    if defined LITELLM_OPUS_MODEL (
+        set "ANTHROPIC_MODEL=%LITELLM_OPUS_MODEL%"
+        set "ANTHROPIC_DEFAULT_OPUS_MODEL=%LITELLM_OPUS_MODEL%"
+        set "ANTHROPIC_CUSTOM_MODEL_OPTION=%LITELLM_OPUS_MODEL%"
+    )
+    if defined LITELLM_SONNET_MODEL (
+        set "ANTHROPIC_DEFAULT_SONNET_MODEL=%LITELLM_SONNET_MODEL%"
+    )
+    if defined LITELLM_HAIKU_MODEL (
+        set "ANTHROPIC_DEFAULT_HAIKU_MODEL=%LITELLM_HAIKU_MODEL%"
+    )
+    if defined LITELLM_OPUS_MODEL (
+        set "CLAUDE_CODE_SUBAGENT_MODEL=%LITELLM_OPUS_MODEL%"
+    )
+) else (
+    rem Fall back to deepseek-* originals (backward compatible with old .env files)
+    set "ANTHROPIC_MODEL=deepseek-v4-flash"
+    set "ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-flash"
+    set "ANTHROPIC_CUSTOM_MODEL_OPTION=deepseek-v4-flash"
+    set "ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-flash"
+    set "ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-chat"
+    set "CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash"
+)
+set "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=DeepSeek V4 Flash local ds4"
+set "ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION=ds4.c local GGUF"
 
 set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 set CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1

--- a/scripts/litellm-start.cmd
+++ b/scripts/litellm-start.cmd
@@ -1,0 +1,80 @@
+@echo off
+setlocal
+
+rem litellm launcher (Windows). Starts/stops the LiteLLM Docker container
+rem for Claude Code model routing. Procedure: docs/ops.md#litellm.
+rem
+rem Usage:
+rem   litellm-start.cmd up       -- start LiteLLM container
+rem   litellm-start.cmd down     -- stop and remove LiteLLM container
+rem   litellm-start.cmd restart  -- down then up
+rem   litellm-start.cmd status   -- show container status
+rem   (no args)                  -- same as "up"
+
+rem Load repo-root .env (gitignored) for LITELLM_* vars
+set "LITELLM_ENV_FILE=%~dp0..\.env"
+if exist "%LITELLM_ENV_FILE%" (
+    for /f "usebackq eol=# tokens=1,* delims==" %%A in ("%LITELLM_ENV_FILE%") do (
+        if not defined %%A set "%%A=%%B"
+    )
+)
+
+rem Determine action from first argument
+set "ACTION=%~1"
+if not defined ACTION set "ACTION=up"
+
+rem Compose file path (absolute Windows path)
+set "COMPOSE_FILE=%~dp0..\litellm\docker-compose.yml"
+
+rem Override LITELLM_LLAMA_SWAP_URL with host.docker.internal for container networking.
+rem Inside the Docker container, localhost resolves to the container itself, not the
+rem Windows host. Docker Desktop provides host.docker.internal to reach the Windows host.
+rem The DS4 Proxy URL (LITELLM_DS4_URL) is NOT overridden -- it uses the .env value
+rem which points at <mac-host>'s LAN IP (<mac-lan-ip>:8443). Only llama-swap needs the override.
+set "LITELLM_LLAMA_SWAP_URL=http://host.docker.internal:18080/v1"
+
+if /i "%ACTION%"=="up" (
+    echo [litellm] Starting LiteLLM container...
+    docker compose -f "%COMPOSE_FILE%" up -d
+    if errorlevel 1 (
+        echo [litellm] ERROR: docker compose up failed. Is Docker Desktop running?
+        exit /b 1
+    )
+    echo [litellm] LiteLLM container started. Verify: docs/ops.md#litellm-verify.
+    exit /b 0
+)
+
+if /i "%ACTION%"=="down" (
+    echo [litellm] Stopping LiteLLM container...
+    docker compose -f "%COMPOSE_FILE%" down
+    if errorlevel 1 (
+        echo [litellm] WARNING: docker compose down returned non-zero (container may not exist).
+        exit /b 1
+    )
+    echo [litellm] LiteLLM container stopped.
+    exit /b 0
+)
+
+if /i "%ACTION%"=="restart" (
+    echo [litellm] Restarting LiteLLM container...
+    docker compose -f "%COMPOSE_FILE%" down
+    docker compose -f "%COMPOSE_FILE%" up -d
+    if errorlevel 1 (
+        echo [litellm] ERROR: restart failed.
+        exit /b 1
+    )
+    echo [litellm] LiteLLM container restarted.
+    exit /b 0
+)
+
+if /i "%ACTION%"=="status" (
+    docker container inspect ds4-litellm --format "{{.State.Status}}" 2>nul
+    if errorlevel 1 (
+        echo [litellm] Container 'ds4-litellm' does not exist or is not running.
+    )
+    exit /b 0
+)
+
+echo [litellm] Unknown action: "%ACTION%"
+echo Usage: litellm-start.cmd {up^|down^|restart^|status}
+exit /b 1

--- a/scripts/setup-litellm.cmd
+++ b/scripts/setup-litellm.cmd
@@ -1,0 +1,72 @@
+@echo off
+setlocal
+
+rem litellm one-time setup (Windows). Run once after LiteLLM container is running.
+rem Generates master key, creates virtual key (random, NOT reusing master key),
+rem verifies TLS certs and CA cert.
+rem Procedure: docs/ops.md#litellm-setup.
+rem
+rem IMPORTANT: LiteLLM requires a database for key generation. The compose file
+rem configures SQLite by default (DATABASE_URL). The /key/generate endpoint will
+rem fail if the database is not initialised. Wait a few seconds after container
+rem start for the database tables to be created.
+
+rem Load repo-root .env
+set "DS4_ENV_FILE=%~dp0..\.env"
+if exist "%DS4_ENV_FILE%" (
+    for /f "usebackq eol=# tokens=1,* delims==" %%A in ("%DS4_ENV_FILE%") do (
+        if not defined %%A set "%%A=%%B"
+    )
+)
+
+rem Check required vars
+if not defined LITELLM_MASTER_KEY (
+    echo [setup-litellm] ERROR: LITELLM_MASTER_KEY is not set in .env.
+    echo [setup-litellm] Run: openssl rand -hex 32 and set LITELLM_MASTER_KEY=sk-<output>
+    exit /b 1
+)
+
+if not defined LITELLM_PORT set "LITELLM_PORT=8445"
+
+rem Step 1: Verify LiteLLM container is running
+docker container inspect ds4-litellm --format "{{.State.Status}}" >nul 2>&1
+if errorlevel 1 (
+    echo [setup-litellm] ERROR: LiteLLM container 'ds4-litellm' is not running.
+    echo [setup-litellm] Run litellm-start.cmd up first.
+    exit /b 1
+)
+
+rem Step 2: Generate a random virtual key using openssl, then register it with LiteLLM.
+rem IMPORTANT: Do NOT send the master key as the generated key value. The /key/generate
+rem endpoint creates a scoped virtual key from a NEW random key, not the master key itself.
+rem Sending the master key as the "key" value would create a virtual key that IS the master
+rem key -- defeating the purpose of scoped virtual keys.
+echo [setup-litellm] Generating random virtual key...
+
+rem Generate a random key string
+for /f "tokens=*" %%A in ('openssl rand -hex 32') do set "RANDOM_KEY_HEX=%%A"
+set "VIRTUAL_KEY_VALUE=sk-%RANDOM_KEY_HEX%"
+
+rem POST to /key/generate with the new random key, authenticated by the master key.
+rem The response contains the generated virtual key which we capture.
+rem NOTE: /key/generate requires DATABASE_URL to be set (SQLite configured in compose).
+for /f "tokens=*" %%A in (
+    'curl -k -s -X POST "https://localhost:%LITELLM_PORT%/key/generate" ^
+      -H "Content-Type: application/json" ^
+      -H "x-api-key: %LITELLM_MASTER_KEY%" ^
+      -d "{\"key\":\"%VIRTUAL_KEY_VALUE%\",\"metadata\":{\"scopes\":[\"*\"]}}"'
+) do set "VIRTUAL_KEY_RESPONSE=%%A"
+
+rem Parse the response for the virtual key (format: {"key":"sk-..."})
+rem This is a simplified parse; real-world would use a JSON parser
+echo [setup-litellm] Virtual key response: %VIRTUAL_KEY_RESPONSE%
+
+rem Extract key value -- simplified for initial setup
+rem Full JSON parsing is out of scope; the user copies the returned key manually
+echo [setup-litellm] ---
+echo [setup-litellm] IMPORTANT: Copy the generated key from the response above
+echo [setup-litellm] and set it as LITELLM_VIRTUAL_KEY in your .env file.
+echo [setup-litellm] Example: LITELLM_VIRTUAL_KEY=%VIRTUAL_KEY_VALUE%
+echo [setup-litellm] ---
+
+exit /b 0


### PR DESCRIPTION
## Summary

Adds LiteLLM proxy configuration to ds4-ops for Claude Code local LLM routing.
Replaces the current single-backend setup (all tiers to DS4 Proxy to DeepSeek V4 Flash)
with tier-specific routing:

| Tier | Backend | Host |
|------|---------|------|
| Haiku | Devstral-Small-2-24B-Instruct via llama-swap | <windows-host> (:18080) |
| Sonnet | Qwen3-Coder-Next-Q4_K_M via llama-swap | <windows-host> (:18080) |
| Opus | DeepSeek V4 Flash via DS4 Proxy | <mac-host> (:8443) |

LiteLLM runs on <windows-host> (Windows) via Docker Desktop (WSL2 backend).
DS4 Proxy is preserved for TLS termination + prompt normalization + token auth.

Closes #20

## Changes

### New files
- `litellm/config.yaml` — LiteLLM model routing config (os.environ/ pattern)
- `litellm/docker-compose.yml` — Docker compose (TLS, CA cert mount, SQLite DB)
- `scripts/litellm-start.cmd` — Windows batch wrapper
- `scripts/setup-litellm.cmd` — Virtual key generation script

### Modified files
- `.env.example` — 16 new LITELLM_* env vars
- `scripts/code-ds4.cmd` — Base URL, auth, model alias updates with fallback
- `docs/architecture.md` — LiteLLM routing layer section
- `docs/ops.md` — LiteLLM procedures (setup, start, verify, recovery)
- `docs/tuning.md` — LITELLM_* env var reference
- `docs/infrastructure.md` — <windows-host> host, ports, Windows paths

<!-- issue-close-pr-of: 20 -->
