### PR TITLE
fix(ccgw): rename client-side ds4- prefix to ccgw-, pin Compose project name (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,43 @@
 # Copy to .env (gitignored) and fill in your values. The Windows launcher
-# scripts/code-ds4.cmd and the Mac proxy scripts/ds4-proxy.sh load this file at startup.
+# scripts/code-ccgw.cmd and the Mac proxy scripts/ds4-proxy.sh load this file at startup.
 
-# --- ds4 client (Windows launcher) ---
+# --- ccgw client (Windows launcher) ---
 
-# Point the launcher at your Mac's ds4 proxy so Claude Code reaches it. Without
-# it the launcher warns and falls back to https://localhost:8443, which does not
-# reach the Mac. Does not change the model or auth token.
-# Format: https://<host>:<port> — e.g. DS4_ANTHROPIC_BASE_URL=https://<mac-lan-ip>:8443
-DS4_ANTHROPIC_BASE_URL=https://localhost:8443
+# Fallback base URL for the Claude Code launcher when LITELLM_ANTHROPIC_BASE_URL is
+# not set. Routes directly to the DS4 Proxy on your Mac. Does not change the model or
+# auth token.
+# Format: https://<host>:<port> — e.g. CCGW_ANTHROPIC_BASE_URL=https://<mac-lan-ip>:8443
+CCGW_ANTHROPIC_BASE_URL=https://localhost:8443
 
-# Points Node.js at your local mkcert root CA so it trusts the proxy certificate.
-# Use the same root CA that signed the proxy cert; get its path from mkcert -CAROOT, then append /rootCA.pem.
-# Format: absolute path — e.g. DS4_CA_CERT=C:\Users\<you>\AppData\Local\mkcert\rootCA.pem
-DS4_CA_CERT=
+# Points Node at your local mkcert root CA so it trusts the proxy certificate.
+# Use the same root CA that signed the proxy cert; get its path from mkcert -CAROOT.
+# Format: absolute path — e.g. CCGW_CA_CERT=C:\Users\<you>\AppData\Local\mkcert\rootCA.pem
+CCGW_CA_CERT=
 
-# Override the auth token sent to the proxy. The proxy verifies this token; must
-# match DS4_PROXY_AUTH_TOKEN on the Mac. Does not affect the base URL.
-# Format: any non-empty string — e.g. DS4_API_KEY=dsv4-local
-DS4_API_KEY=dsv4-local
+# Fallback auth token for the DS4 Proxy when LITELLM_VIRTUAL_KEY is not set. Must
+# match DS4_PROXY_AUTH_TOKEN on the Mac.
+# Format: any non-empty string — e.g. CCGW_API_KEY=dsv4-local
+CCGW_API_KEY=dsv4-local
+
+# Override ANTHROPIC_BASE_URL for LiteLLM routing. If set, the launcher routes through
+# LiteLLM and uses LITELLM_*_MODEL vars. When unset, falls back to CCGW_ANTHROPIC_BASE_URL
+# and ignores LITELLM_*_MODEL vars (backward compatible).
+# Format: https://<host>:<port> — e.g. LITELLM_ANTHROPIC_BASE_URL=https://<windows-host>:8445
+LITELLM_ANTHROPIC_BASE_URL=
+
+# Scoped virtual key for LiteLLM authentication. Generate from LITELLM_MASTER_KEY
+# using scripts/setup-litellm.cmd. Has restricted scopes — use instead of exposing
+# the master key as ANTHROPIC_AUTH_TOKEN.
+# Format: sk-<generated> — e.g. LITELLM_VIRTUAL_KEY=sk-<generated-token>
+LITELLM_VIRTUAL_KEY=
+
+# Model routing keys sent by Claude Code as model names in /v1/messages requests.
+# LiteLLM matches them against model_name entries in config.yaml.
+# Ignored when LITELLM_ANTHROPIC_BASE_URL is unset (backward compatibility).
+# Format: string — e.g. LITELLM_HAIKU_MODEL=devstral-small-24b
+LITELLM_HAIKU_MODEL=devstral-small-24b
+LITELLM_SONNET_MODEL=qwen3-coder-next
+LITELLM_OPUS_MODEL=deepseek-v4-flash
 
 # --- ds4 server (Mac backend) ---
 
@@ -29,12 +49,12 @@ DS4_SERVER_HOST=127.0.0.1
 
 # --- ds4 proxy (Mac server side) ---
 
-# HTTPS port the proxy listens on. Must match the port in DS4_ANTHROPIC_BASE_URL.
+# HTTPS port the proxy listens on. Must match the port in CCGW_ANTHROPIC_BASE_URL.
 # Format: integer — e.g. DS4_PROXY_PORT=8443
 DS4_PROXY_PORT=8443
 
 # Token the proxy requires from every client request. Generate with: /create-key
-# Must match the DS4_API_KEY value in the Windows-side .env.
+# Must match the CCGW_API_KEY value in the Windows-side .env.
 # Format: any non-empty string — e.g. DS4_PROXY_AUTH_TOKEN=<generated-secret>
 DS4_PROXY_AUTH_TOKEN=
 
@@ -54,8 +74,8 @@ DS4_PROXY_LOG_DIR=~/Library/Caches/ds4-proxy/log
 # --- ds4 ops (lifecycle / logging) ---
 
 # Write ds4 service stdout/stderr to log files (proxy.log / kvcache.log).
-# off stops this log's disk writes (does not affect DS4_PROXY_TEE body-dump logs).
-# Console output and DS4_PROXY_TEE logging are unaffected by this toggle.
+# off stops disk writes (does not affect DS4_PROXY_TEE body-dump logs).
+# Console output and DS4_PROXY_TEE logging are unaffected.
 # Format: on or off — e.g. DS4_LOG=off
 DS4_LOG=on
 
@@ -68,84 +88,62 @@ DS4_SERVER_COLOR_LOG=on
 
 # Master key for LiteLLM admin API and virtual key generation.
 # Generate with: openssl rand -hex 32
-# Format: any non-empty string -- e.g. LITELLM_MASTER_KEY=sk-<generated>
+# Format: any non-empty string — e.g. LITELLM_MASTER_KEY=sk-<generated>
 # WARNING: This key is the admin credential. NEVER use it directly as
 # ANTHROPIC_AUTH_TOKEN. Generate a scoped virtual key instead (see docs/ops.md).
 LITELLM_MASTER_KEY=
 
 # HTTPS port the LiteLLM proxy listens on. Must match the port in
 # ANTHROPIC_BASE_URL when routing through LiteLLM.
-# Format: integer -- e.g. LITELLM_PORT=8445
+# Format: integer — e.g. LITELLM_PORT=8445
 LITELLM_PORT=8445
 
 # Directory containing the LiteLLM TLS cert/key files (mkcert-issued).
-# This is a required field -- must be set to a valid absolute path.
-# Format: absolute Windows path -- e.g. LITELLM_TLS_DIR=C:\Users\<user>\.config\litellm
+# Required — must be set to a valid absolute path.
+# Format: absolute Windows path — e.g. LITELLM_TLS_DIR=C:\Users\<user>\.config\litellm
 LITELLM_TLS_DIR=
 
 # Filename of the TLS certificate inside LITELLM_TLS_DIR. Override when the cert
 # filename is not cert.pem (e.g. mkcert IP-SAN certs use <host>+1.pem).
-# Format: filename only -- e.g. LITELLM_TLS_CERT=<host>+1.pem
+# Format: filename only — e.g. LITELLM_TLS_CERT=<host>+1.pem
 LITELLM_TLS_CERT=
 
 # Filename of the TLS private key inside LITELLM_TLS_DIR. Override when the key
 # filename is not key.pem.
-# Format: filename only -- e.g. LITELLM_TLS_KEY=<host>+1-key.pem
+# Format: filename only — e.g. LITELLM_TLS_KEY=<host>+1-key.pem
 LITELLM_TLS_KEY=
 
 # Path to the mkcert root CA .pem file. Mounted into the LiteLLM container so it
 # trusts the DS4 Proxy's TLS certificate when routing Opus requests to <mac-host>.
-# Get the path from: mkcert -CAROOT  (append /rootCA.pem on Windows).
-# Same root CA as DS4_CA_CERT.
-# Format: absolute path -- e.g. LITELLM_CA_CERT_FILE=C:\Users\<user>\AppData\Local\mkcert\rootCA.pem
+# Get the path from: mkcert -CAROOT (append /rootCA.pem on Windows).
+# Same root CA as CCGW_CA_CERT.
+# Format: absolute path — e.g. LITELLM_CA_CERT_FILE=C:\Users\<user>\AppData\Local\mkcert\rootCA.pem
 LITELLM_CA_CERT_FILE=
 
 # Database URL for LiteLLM persistent storage (virtual keys, model config).
 # LiteLLM main-latest requires PostgreSQL; SQLite is not supported.
 # Leave unset to use the bundled postgres service (docker-compose.yml default).
-# Format: URL -- e.g. LITELLM_DB_URL=postgresql://litellm:litellm@postgres:5432/litellm
+# Format: URL — e.g. LITELLM_DB_URL=postgresql://litellm:litellm@postgres:5432/litellm
 LITELLM_DB_URL=
 
 # Config directory containing litellm/config.yaml (Windows path).
-# Format: absolute Windows path -- e.g. LITELLM_CONFIG_DIR=C:\git\ds4-ops\litellm
+# Format: absolute Windows path — e.g. LITELLM_CONFIG_DIR=C:\git\ds4-ops\litellm
 LITELLM_CONFIG_DIR=C:\git\ds4-ops\litellm
 
-# llama-swap endpoint on the local Windows machine (<windows-host>).
-# Both Haiku and Sonnet backends are served via llama-swap on this URL.
-# Inside the Docker container, this is resolved via host.docker.internal
-# (the launcher overrides this for Docker networking).
-# Format: URL -- e.g. LITELLM_LLAMA_SWAP_URL=http://localhost:18080/v1
-LITELLM_LLAMA_SWAP_URL=http://localhost:18080/v1
+# llama-swap endpoints on the local Windows machine for Haiku and Sonnet tiers.
+# Inside the Docker container, these resolve via host.docker.internal.
+# The launcher overrides localhost → host.docker.internal for Docker networking.
+# Format: URL — e.g. LITELLM_HAIKU_URL=http://localhost:18080/v1
+LITELLM_HAIKU_URL=http://localhost:18080/v1
+LITELLM_SONNET_URL=http://localhost:18080/v1
 
 # DS4 Proxy endpoint for the Opus tier. This is on <mac-host> (Mac, <mac-lan-ip>:8443).
-# DO NOT use host.docker.internal here -- that resolves to <windows-host>, not <mac-host>.
+# DO NOT use host.docker.internal here — that resolves to <windows-host>, not <mac-host>.
 # Inside the Docker container, this URL is used as-is; <mac-host> must be reachable
 # from the WSL2 Linux VM via the LAN.
-# Format: URL -- e.g. LITELLM_DS4_URL=https://<mac-lan-ip>:8443
-LITELLM_DS4_URL=https://<mac-lan-ip>:8443
+# Format: URL — e.g. LITELLM_OPUS_URL=https://<mac-lan-ip>:8443
+LITELLM_OPUS_URL=https://<mac-lan-ip>:8443
 
-# API key for the DS4 Proxy Opus route. Must match DS4_API_KEY / DS4_PROXY_AUTH_TOKEN.
-# Format: any non-empty string -- e.g. LITELLM_DS4_API_KEY=dsv4-local
-LITELLM_DS4_API_KEY=dsv4-local
-
-# Model routing keys exposed by LiteLLM to Claude Code. These are the values
-# Claude Code sends as the model name in /v1/messages requests. LiteLLM matches
-# these against model_name entries in config.yaml, then routes to the correct backend.
-# Format: string -- e.g. LITELLM_HAIKU_MODEL=devstral-small-24b
-# When LITELLM_ANTHROPIC_BASE_URL is NOT set, code-ds4.cmd ignores these and falls
-# back to the original deepseek-* model names (backward compatibility).
-LITELLM_HAIKU_MODEL=devstral-small-24b
-LITELLM_SONNET_MODEL=qwen3-coder-next
-LITELLM_OPUS_MODEL=deepseek-v4-flash
-
-# Override ANTHROPIC_BASE_URL for LiteLLM routing. If set, the launcher uses
-# this value instead of DS4_ANTHROPIC_BASE_URL. When unset, falls back to
-# DS4_ANTHROPIC_BASE_URL and ignores LITELLM_*_MODEL vars (backward compatible).
-# Format: https://<host>:<port> -- e.g. LITELLM_ANTHROPIC_BASE_URL=https://<windows-host>:8445
-LITELLM_ANTHROPIC_BASE_URL=
-
-# Scoped virtual key for LiteLLM authentication. Generate from LITELLM_MASTER_KEY
-# using scripts/setup-litellm.cmd (one-time setup). This key has restricted scopes
-# and is used as ANTHROPIC_AUTH_TOKEN instead of exposing the master key.
-# Format: sk-<generated> -- e.g. LITELLM_VIRTUAL_KEY=sk-<generated-token>
-LITELLM_VIRTUAL_KEY=
+# API key for the DS4 Proxy Opus route. Must match CCGW_API_KEY / DS4_PROXY_AUTH_TOKEN.
+# Format: any non-empty string — e.g. LITELLM_OPUS_API_KEY=dsv4-local
+LITELLM_OPUS_API_KEY=dsv4-local

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ds4-ops (nirecom/ds4-ops)
+# cc-local-llm (nirecom/cc-local-llm)
 
 Running **DeepSeek V4 Flash** via [`antirez/ds4`](https://github.com/antirez/ds4) as a
 self-hosted **Claude Code backend**.
@@ -10,6 +10,7 @@ self-hosted **Claude Code backend**.
 > This repo holds only the **ops / config / decisions** for using ds4 as a Claude Code
 > backend. The engine is the public upstream `antirez/ds4`, cloned separately at `~/git/ds4`
 > on the Mac; the local directory here is `ds4-ops` to stay distinct from that clone.
+> The GitHub repo has been renamed to `cc-local-llm` — the local clone path is unchanged.
 
 ## Docs
 
@@ -24,8 +25,8 @@ Standard layout (mirrors the agents-repo convention):
 | [docs/infrastructure.md](docs/infrastructure.md) | SSOT for hosts, network, ports, paths |
 | [scripts/ds4ctl.sh](scripts/ds4ctl.sh) | Unified Mac control command — `start\|stop\|restart\|status\|logs\|install\|uninstall [proxy\|server\|all]` |
 | [scripts/ds4-server.sh](scripts/ds4-server.sh) | Foreground launcher for ds4-server (thin wrapper; used by launchd) |
-| [scripts/code-ds4.cmd](scripts/code-ds4.cmd) | Windows client launcher — loads `.env`, sets ds4 env, isolates the VS Code process, launches VS Code |
-| [.env.example](.env.example) | Template for the gitignored `.env` — Windows client `DS4_ANTHROPIC_BASE_URL` (Mac IP) and `DS4_API_KEY` |
+| [scripts/code-ccgw.cmd](scripts/code-ccgw.cmd) | Windows client launcher — loads `.env`, sets ccgw env, isolates the VS Code process, launches VS Code |
+| [.env.example](.env.example) | Template for the gitignored `.env` — Windows client `CCGW_ANTHROPIC_BASE_URL` (Mac IP) and `CCGW_API_KEY` |
 
 ## Quick start
 
@@ -39,8 +40,8 @@ git -C ~/git/ds4 pull                 # update the antirez/ds4 build clone if ne
 bundled launcher (loads `.env`, sets the ds4 env, isolates the VS Code process, opens VS Code):
 ```bat
 copy .env.example .env
-rem edit .env: DS4_ANTHROPIC_BASE_URL=http://<mac-ip>:8000
-scripts\code-ds4.cmd .
+rem edit .env: CCGW_ANTHROPIC_BASE_URL=http://<mac-ip>:8000
+scripts\code-ccgw.cmd .
 ```
 See [docs/ops.md](docs/ops.md#client-windows) for details and the terminal alternative.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ self-hosted **Claude Code backend**.
 > This repo holds only the **ops / config / decisions** for using ds4 as a Claude Code
 > backend. The engine is the public upstream `antirez/ds4`, cloned separately at `~/git/ds4`
 > on the Mac; the local directory here is `ds4-ops` to stay distinct from that clone.
-> The GitHub repo has been renamed to `cc-local-llm` — the local clone path is unchanged.
+> The GitHub repo is planned to be renamed to `cc-local-llm` post-merge; until that rename
+> lands, the remote is still `nirecom/ds4-ops`. The local clone path is unaffected either way.
 
 ## Docs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ Each rule is a pure function; all four are applied in order via `apply_all()`. T
 
 ### Why token auth
 
-ds4 has no authentication. The proxy adds an HMAC-based token gate (constant-time comparison via `hmac.compare_digest`) so that only Claude Code with the correct `DS4_API_KEY` can reach ds4. This matters because the proxy is exposed to the LAN via HTTPS rather than `0.0.0.0` plain HTTP; auth prevents use by other devices on the network.
+ds4 has no authentication. The proxy adds an HMAC-based token gate (constant-time comparison via `hmac.compare_digest`) so that only Claude Code with the correct `CCGW_API_KEY` can reach ds4. This matters because the proxy is exposed to the LAN via HTTPS rather than `0.0.0.0` plain HTTP; auth prevents use by other devices on the network.
 
 ### Design choices
 
@@ -98,7 +98,7 @@ ds4 has no authentication. The proxy adds an HMAC-based token gate (constant-tim
 
 ### Repository placement — may split out later
 
-`proxy/` currently lives inside ds4-ops rather than in its own repository. The coupling justifies co-location today: it shares the repo-root `.env` (its auth token must match the client's `DS4_API_KEY`, its listen port must match the client's base URL), the ops/tuning/infrastructure docs describe proxy, server, and client as one system, and it has no second consumer. The normalization rules are ds4-specific — they stabilise *this* model's KV-cache prefix — so the package is not yet a general-purpose library.
+`proxy/` currently lives inside cc-local-llm rather than in its own repository. The coupling justifies co-location today: it shares the repo-root `.env` (its auth token must match the client's `CCGW_API_KEY`, its listen port must match the client's base URL), the ops/tuning/infrastructure docs describe proxy, server, and client as one system, and it has no second consumer. The normalization rules are ds4-specific — they stabilise *this* model's KV-cache prefix — so the package is not yet a general-purpose library.
 
 `proxy/` is nonetheless a self-contained Python package (its own `pyproject.toml` / `uv.lock`), so extraction stays cheap and can preserve history via `git filter-repo`. Split it into its own repository when any of these triggers fires:
 
@@ -129,7 +129,7 @@ and protocol translation -- a net cost with no benefit given LiteLLM's maturity.
 
 LiteLLM listens on HTTPS with an mkcert-signed certificate, sharing the same root CA
 already used by the DS4 Proxy. The Windows client trusts it via `NODE_EXTRA_CA_CERTS`
-pointing at `<mkcert -CAROOT>/rootCA.pem` (same `DS4_CA_CERT` value). No new CA setup
+pointing at `<mkcert -CAROOT>/rootCA.pem` (same `CCGW_CA_CERT` value). No new CA setup
 is needed.
 
 ### CA cert trust for Opus route (container to <mac-host>)
@@ -137,7 +137,7 @@ is needed.
 The LiteLLM container connects to the DS4 Proxy (<mac-host>:8443) over HTTPS for Opus requests.
 Inside the container, the mkcert root CA is mounted and appended to the system CA bundle
 at startup (via the compose file's entrypoint). This ensures LiteLLM can verify the DS4
-Proxy's TLS certificate. The same root CA file used for the Windows client (`DS4_CA_CERT`)
+Proxy's TLS certificate. The same root CA file used for the Windows client (`CCGW_CA_CERT`)
 is reused -- no separate CA setup.
 
 ### Virtual key authentication
@@ -147,15 +147,13 @@ API and virtual key generation -- it is NEVER exposed to the client. A one-time 
 step (`scripts/setup-litellm.cmd`) creates a scoped virtual key from a randomly-generated
 key (NOT the master key). Claude Code presents the virtual key as `ANTHROPIC_AUTH_TOKEN`
 to authenticate with LiteLLM. The DS4 Proxy's own token auth is preserved for the Opus
-route: LiteLLM forwards `LITELLM_DS4_API_KEY` as the `x-api-key` header to the DS4 Proxy.
+route: LiteLLM forwards `LITELLM_OPUS_API_KEY` as the `x-api-key` header to the DS4 Proxy.
 
 ### Database for virtual key persistence
 
 LiteLLM requires a database backend for key generation and verification. The compose file
-configures SQLite (`DATABASE_URL=sqlite:///app/litellm/data/litellm.db`) with a named
-volume for persistence across restarts. For production deployments, PostgreSQL should be
-used instead (set `LITELLM_DB_URL` to a PostgreSQL connection string).
-
+configures PostgreSQL (`DATABASE_URL=postgresql://litellm:litellm@postgres:5432/litellm`) with a named
+volume for persistence across restarts. 
 ### Host.docker.internal usage (llama-swap only)
 
 Docker Desktop runs containers in a WSL2 Linux VM. `localhost` inside the container refers

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -51,6 +51,6 @@ SSOT for hosts, network, ports, and paths. Other docs reference this — do not 
 | LiteLLM start script | `C:\git\ds4-ops\scripts\litellm-start.cmd` |
 | LiteLLM setup script | `C:\git\ds4-ops\scripts\setup-litellm.cmd` |
 | LiteLLM TLS cert/key | `C:\Users\<user>\.config\litellm\cert.pem` / `key.pem` (mkcert-generated) |
-| LiteLLM CA cert (Opus trust) | `<mkcert -CAROOT>\rootCA.pem` (same as DS4_CA_CERT) |
-| LiteLLM database volume | `litellm-data` (Docker named volume, persists at /app/litellm/data) |
+| LiteLLM CA cert (Opus trust) | `<mkcert -CAROOT>\rootCA.pem` (same as CCGW_CA_CERT) |
+| LiteLLM database volume | `litellm-postgres` (Docker named volume, PostgreSQL data at /var/lib/postgresql/data) |
 | llama-swap config | `C:\LLM\llama-swap\config.yaml` (not in this repo) |

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -11,7 +11,7 @@ auth); ds4-server itself listens on loopback. Rationale:
 
 One-time TLS setup. The proxy's cert must be trusted by the Windows client, so sign it with the
 **same mkcert root CA the client already uses** — do not create a separate root CA on the Mac.
-Sharing one root means the client trusts the proxy by pointing `DS4_CA_CERT` at that existing
+Sharing one root means the client trusts the proxy by pointing `CCGW_CA_CERT` at that existing
 root; nothing new has to be distributed and trusted.
 
 1. On the Windows client, issue a leaf cert/key for the proxy from the existing root CA. The
@@ -35,8 +35,8 @@ Or foreground (for debugging):
 ~/git/ds4-ops/scripts/ds4-proxy.sh
 ```
 
-Client-side (Windows): set `DS4_CA_CERT` to `<mkcert -CAROOT>/rootCA.pem` in the repo-root
-`.env` so Node trusts the proxy certificate, and set `DS4_API_KEY` to the same value as
+Client-side (Windows): set `CCGW_CA_CERT` to `<mkcert -CAROOT>/rootCA.pem` in the repo-root
+`.env` so Node trusts the proxy certificate, and set `CCGW_API_KEY` to the same value as
 `DS4_PROXY_AUTH_TOKEN`.
 
 ## LiteLLM (Windows, Docker Desktop WSL2)
@@ -44,7 +44,7 @@ Client-side (Windows): set `DS4_CA_CERT` to `<mkcert -CAROOT>/rootCA.pem` in the
 ### TLS setup (one-time)
 
 The LiteLLM proxy needs an mkcert leaf cert/key. Use the same root CA as the DS4 Proxy
-so the client trusts both endpoints with one `DS4_CA_CERT`:
+so the client trusts both endpoints with one `CCGW_CA_CERT`:
 
 ```bat
 mkcert localhost 127.0.0.1 ::1 <windows-host>
@@ -62,7 +62,7 @@ rem Get the path from mkcert -CAROOT, then append /rootCA.pem
 rem e.g. LITELLM_CA_CERT_FILE=C:\Users\<user>\AppData\Local\mkcert\rootCA.pem
 ```
 
-This is the same root CA file used for `DS4_CA_CERT`. The compose file mounts it into
+This is the same root CA file used for `CCGW_CA_CERT`. The compose file mounts it into
 the container and the entrypoint installs it into the system trust store.
 
 ### Initial setup (one-time)
@@ -156,7 +156,7 @@ llama-swap.
 ### Client (Windows) with LiteLLM
 
 First time only, ensure the repo-root `.env` has the LiteLLM vars filled in. The
-`code-ds4.cmd` launcher now prefers `LITELLM_ANTHROPIC_BASE_URL` over `DS4_ANTHROPIC_BASE_URL`.
+`code-ccgw.cmd` launcher now prefers `LITELLM_ANTHROPIC_BASE_URL` over `CCGW_ANTHROPIC_BASE_URL`.
 
 Set in `.env`:
 ```bat
@@ -166,7 +166,7 @@ LITELLM_VIRTUAL_KEY=sk-<generated-token>
 
 Then launch as before:
 ```bat
-scripts\code-ds4.cmd .
+scripts\code-ccgw.cmd .
 ```
 
 ### Recovery
@@ -181,7 +181,7 @@ scripts\code-ds4.cmd .
 | TLS errors on Opus route | Verify `LITELLM_CA_CERT_FILE` points to the mkcert root CA and the file is mounted correctly |
 | `401 Unauthorized` from LiteLLM | Verify `LITELLM_VIRTUAL_KEY` is set in `.env` and matches the generated key |
 | `/key/generate` fails | Verify `DATABASE_URL` is set (SQLite configured in compose); wait for database initialisation |
-| Keys lost after restart | Verify `litellm-data` volume persists; check `docker volume ls` for the named volume |
+| Keys lost after restart | Verify `litellm-postgres` volume persists; check `docker volume ls` for the named volume |
 
 ## Run the server (Mac)
 
@@ -276,27 +276,27 @@ First time only, create the repo-root `.env` from the template and put the Mac's
 (the IP is never committed — `.env` is gitignored):
 ```bat
 copy .env.example .env
-rem then edit .env: DS4_ANTHROPIC_BASE_URL=https://<mac-ip>:8443
-rem and DS4_CA_CERT=<mkcert -CAROOT>\rootCA.pem (so Node trusts the proxy cert)
+rem then edit .env: CCGW_ANTHROPIC_BASE_URL=https://<mac-ip>:8443
+rem and CCGW_CA_CERT=<mkcert -CAROOT>\rootCA.pem (so Node trusts the proxy cert)
 ```
 Then launch VS Code with the ds4 backend via the bundled wrapper:
 ```bat
-scripts\code-ds4.cmd .
+scripts\code-ccgw.cmd .
 ```
 The wrapper loads `.env`, then sets the ds4 env (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`,
 the `deepseek-v4-flash` model aliases (the haiku tier uses the non-thinking `deepseek-chat`),
-`NODE_EXTRA_CA_CERTS` from `DS4_CA_CERT`,
+`NODE_EXTRA_CA_CERTS` from `CCGW_CA_CERT`,
 and `CLAUDE_CODE_AUTO_COMPACT_WINDOW=393216` /
 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75`), then launches VS Code. The base URL now points at the
-proxy (`https://<mac-ip>:8443`), not ds4 directly. If `DS4_ANTHROPIC_BASE_URL` is set
+proxy (`https://<mac-ip>:8443`), not ds4 directly. If `CCGW_ANTHROPIC_BASE_URL` is set
 in neither `.env` nor the shell, the wrapper warns and falls back to `https://localhost:8443`
 (a placeholder that will not reach the Mac). A value set in the shell takes precedence over
-`.env`. `DS4_API_KEY` overrides the auth token; the proxy verifies it, so it must match
-`DS4_PROXY_AUTH_TOKEN` on the Mac. `DS4_CA_CERT` must point at `<mkcert -CAROOT>/rootCA.pem`
+`.env`. `CCGW_API_KEY` overrides the auth token; the proxy verifies it, so it must match
+`DS4_PROXY_AUTH_TOKEN` on the Mac. `CCGW_CA_CERT` must point at `<mkcert -CAROOT>/rootCA.pem`
 so Node trusts the proxy certificate (if unset the wrapper warns and TLS will not be trusted).
 
 **Isolation from native (subscription) VS Code:** the wrapper passes
-`--user-data-dir "%LOCALAPPDATA%\vscode-ds4"`, starting a *separate* VS Code process. VS Code
+`--user-data-dir "%LOCALAPPDATA%\vscode-ccgw"`, starting a *separate* VS Code process. VS Code
 shares one process — and thus one environment — across every window under the same
 user-data-dir, so without this flag the ds4 env bleeds into native subscription windows. The
 separate profile keeps the ds4 session and native `code` / `codes` sessions independent on the
@@ -306,15 +306,15 @@ Do not add ds4 env vars to native sessions: a bare `ANTHROPIC_BASE_URL` plus a c
 replaces the subscription (see
 [architecture.md](architecture.md#two-strategies-chosen-by-whether-real-opus-is-wanted)).
 Caveat: if the ds4 profile is already running, close *all* its windows before changing
-`DS4_ANTHROPIC_BASE_URL` — closing one window is not enough; the process (and its captured
+`CCGW_ANTHROPIC_BASE_URL` — closing one window is not enough; the process (and its captured
 environment) persists until the last window of the profile closes, and new windows inherit the
 old value. The same folder may be open in the native and ds4 profiles at the same time: the
 "reuse the existing window for this folder" dedup is per-profile, so `codes .` followed by
-`code-ds4.cmd .` on one repo yields two independent windows (native backend + ds4 backend),
+`code-ccgw.cmd .` on one repo yields two independent windows (native backend + ds4 backend),
 not one activated window.
 
 Terminal alternative (no VS Code): set the same env vars the wrapper does
-(see [scripts/code-ds4.cmd](../scripts/code-ds4.cmd) for the full list) and run `claude`.
+(see [scripts/code-ccgw.cmd](../scripts/code-ccgw.cmd) for the full list) and run `claude`.
 
 Optional per-tier thinking split: also set the `ANTHROPIC_DEFAULT_*_MODEL` vars from
 [tuning.md](tuning.md#per-tier-thinking-split-without-a-router-optional).

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -84,7 +84,7 @@ Read by `scripts/ds4-proxy.sh` (from the repo-root `.env`). Design: [architectur
 |---|---|---|
 | `DS4_PROXY_PORT` | `8443` (default) | HTTPS listen port. Must match the port in the client's `ANTHROPIC_BASE_URL`. |
 | `DS4_PROXY_UPSTREAM` | `http://127.0.0.1:8000` (default) | The ds4 backend the proxy forwards to. |
-| `DS4_PROXY_AUTH_TOKEN` | required | Token every client request must present; must match the client's `DS4_API_KEY`. The proxy refuses to start if unset. |
+| `DS4_PROXY_AUTH_TOKEN` | required | Token every client request must present; must match the client's `CCGW_API_KEY`. The proxy refuses to start if unset. |
 | `DS4_PROXY_CERT` / `DS4_PROXY_KEY` | `~/.config/ds4-proxy/cert.pem` / `key.pem` (defaults) | mkcert-generated TLS cert/key for the HTTPS listener. |
 | `DS4_PROXY_TEE` | `off` (default) / `on` | When `on`, logs pre- and post-normalization request bodies for debugging. |
 | `DS4_PROXY_LOG_DIR` | `~/Library/Caches/ds4-proxy/log` (default) | Where tee logs are written when `DS4_PROXY_TEE=on`. |
@@ -103,16 +103,17 @@ startup.
 | `LITELLM_MASTER_KEY` | (required) | Master key for LiteLLM admin API and virtual key generation. Generate with `openssl rand -hex 32`. Never expose to clients. |
 | `LITELLM_PORT` | `8445` | HTTPS listen port. Must match the port in `ANTHROPIC_BASE_URL` when routing through LiteLLM. |
 | `LITELLM_TLS_DIR` | (required) | Directory containing `cert.pem` and `key.pem` (mkcert-issued). Mounted into the container at `/app/certs`. No default -- user must set this in `.env`. |
-| `LITELLM_CA_CERT_FILE` | (required for Opus) | Path to mkcert root CA `.pem` file. Mounted into the container so LiteLLM trusts the DS4 Proxy TLS cert. Same root CA as `DS4_CA_CERT`. |
-| `LITELLM_DB_URL` | `sqlite:///app/litellm/data/litellm.db` | Database URL for virtual key persistence. SQLite by default (no external deps). Switch to PostgreSQL for production. |
+| `LITELLM_CA_CERT_FILE` | (required for Opus) | Path to mkcert root CA `.pem` file. Mounted into the container so LiteLLM trusts the DS4 Proxy TLS cert. Same root CA as `CCGW_CA_CERT`. |
+| `LITELLM_DB_URL` | `postgresql://litellm:litellm@postgres:5432/litellm` | Database URL for virtual key persistence. PostgreSQL via bundled postgres service. Leave unset to use the compose default. |
 | `LITELLM_CONFIG_DIR` | `C:\git\ds4-ops\litellm` | Config directory containing litellm/config.yaml. |
-| `LITELLM_LLAMA_SWAP_URL` | `http://host.docker.internal:18080/v1` | llama-swap OpenAI-compatible endpoint for Haiku/Sonnet backends. Overridden to `host.docker.internal` by the launcher. |
-| `LITELLM_DS4_URL` | `https://<mac-lan-ip>:8443` | DS4 Proxy endpoint for Opus tier. Uses <mac-host>'s LAN IP directly -- NOT host.docker.internal. |
-| `LITELLM_DS4_API_KEY` | `dsv4-local` | API key sent to DS4 Proxy for Opus route. Must match `DS4_API_KEY`. |
+| `LITELLM_HAIKU_URL` | `http://host.docker.internal:18080/v1` | llama-swap endpoint for Haiku tier. Overridden to `host.docker.internal` by the launcher. |
+| `LITELLM_SONNET_URL` | `http://host.docker.internal:18080/v1` | llama-swap endpoint for Sonnet tier. Overridden to `host.docker.internal` by the launcher. |
+| `LITELLM_OPUS_URL` | `https://<mac-lan-ip>:8443` | DS4 Proxy endpoint for Opus tier. Uses <mac-host>'s LAN IP directly -- NOT host.docker.internal. |
+| `LITELLM_OPUS_API_KEY` | `dsv4-local` | API key sent to DS4 Proxy for Opus route. Must match `CCGW_API_KEY`. |
 | `LITELLM_HAIKU_MODEL` | `devstral-small-24b` | Model routing key for Haiku tier. Claude Code sends this value as the model name; LiteLLM matches it to the model_name entry in config.yaml. |
 | `LITELLM_SONNET_MODEL` | `qwen3-coder-next` | Model routing key for Sonnet tier. |
 | `LITELLM_OPUS_MODEL` | `deepseek-v4-flash` | Model routing key for Opus tier. |
-| `LITELLM_ANTHROPIC_BASE_URL` | (optional) | Override for `ANTHROPIC_BASE_URL` in code-ds4.cmd. When unset, falls back to `DS4_ANTHROPIC_BASE_URL` and ignores LITELLM_*_MODEL vars. |
+| `LITELLM_ANTHROPIC_BASE_URL` | (optional) | Override for `ANTHROPIC_BASE_URL` in code-ccgw.cmd. When unset, falls back to `CCGW_ANTHROPIC_BASE_URL` and ignores LITELLM_*_MODEL vars. |
 | `LITELLM_VIRTUAL_KEY` | (required for client) | Scoped virtual key for client authentication with LiteLLM. Generated from a random key (not the master key). |
 
 ### Client env vars update

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -1,4 +1,4 @@
-# LiteLLM proxy configuration for ds4-ops.
+# LiteLLM proxy configuration for ccgw (Claude Code GateWay, client side).
 # Routes Claude Code model tiers to different backends by model name.
 # Env vars are resolved at startup via os.environ/ pattern (NOT ${VAR:default}).
 # All defaults are documented in .env.example, not embedded here.
@@ -16,28 +16,31 @@ model_list:
   - model_name: os.environ/LITELLM_HAIKU_MODEL
     litellm_params:
       model: openai/Devstral-Small-2-24B-Instruct-2512-IQ4_XS
-      api_base: os.environ/LITELLM_LLAMA_SWAP_URL
+      api_base: os.environ/LITELLM_HAIKU_URL
       api_key: none                        # no auth for llama-swap local backend
       stream: true
       max_tokens: 8192
+      context_window: 32768
 
   # --- Sonnet tier: Qwen3-Coder-Next-Q4_K_M via llama-swap (OpenAI) ---
   - model_name: os.environ/LITELLM_SONNET_MODEL
     litellm_params:
       model: openai/Qwen3-Coder-Next-Q4_K_M
-      api_base: os.environ/LITELLM_LLAMA_SWAP_URL
+      api_base: os.environ/LITELLM_SONNET_URL
       api_key: none                        # no auth for llama-swap local backend
       stream: true
       max_tokens: 8192
+      context_window: 32768
 
   # --- Opus tier: DeepSeek V4 Flash via DS4 Proxy (Anthropic passthrough) ---
   - model_name: os.environ/LITELLM_OPUS_MODEL
     litellm_params:
       model: anthropic/deepseek-v4-flash
-      api_base: os.environ/LITELLM_DS4_URL
-      api_key: os.environ/LITELLM_DS4_API_KEY
+      api_base: os.environ/LITELLM_OPUS_URL
+      api_key: os.environ/LITELLM_OPUS_API_KEY
       stream: true
       max_tokens: 8192
+      context_window: 393216
 
 litellm_settings:
   # Enable virtual key authentication

--- a/litellm/docker-compose.yml
+++ b/litellm/docker-compose.yml
@@ -1,7 +1,9 @@
+name: ccgw
+
 services:
   litellm:
     image: ghcr.io/berriai/litellm:main-latest
-    container_name: ds4-litellm
+    container_name: ccgw-litellm
     depends_on:
       postgres:
         condition: service_healthy
@@ -32,9 +34,10 @@ services:
       LITELLM_HAIKU_MODEL: ${LITELLM_HAIKU_MODEL:-devstral-small-24b}
       LITELLM_SONNET_MODEL: ${LITELLM_SONNET_MODEL:-qwen3-coder-next}
       LITELLM_OPUS_MODEL: ${LITELLM_OPUS_MODEL:-deepseek-v4-flash}
-      LITELLM_LLAMA_SWAP_URL: ${LITELLM_LLAMA_SWAP_URL:-http://host.docker.internal:18080/v1}
-      LITELLM_DS4_URL: ${LITELLM_DS4_URL:-https://<mac-lan-ip>:8443}
-      LITELLM_DS4_API_KEY: ${LITELLM_DS4_API_KEY:-dsv4-local}
+      LITELLM_HAIKU_URL: ${LITELLM_HAIKU_URL:-http://host.docker.internal:18080/v1}
+      LITELLM_SONNET_URL: ${LITELLM_SONNET_URL:-http://host.docker.internal:18080/v1}
+      LITELLM_OPUS_URL: ${LITELLM_OPUS_URL:-https://<mac-lan-ip>:8443}
+      LITELLM_OPUS_API_KEY: ${LITELLM_OPUS_API_KEY:-dsv4-local}
       # PostgreSQL connection string for virtual key persistence.
       # LiteLLM main-latest requires PostgreSQL; SQLite is no longer supported.
       DATABASE_URL: ${LITELLM_DB_URL:-postgresql://litellm:litellm@postgres:5432/litellm}
@@ -63,7 +66,7 @@ services:
 
   postgres:
     image: postgres:16-alpine
-    container_name: ds4-litellm-postgres
+    container_name: ccgw-postgres
     environment:
       POSTGRES_DB: litellm
       POSTGRES_USER: litellm

--- a/scripts/code-ccgw.cmd
+++ b/scripts/code-ccgw.cmd
@@ -1,9 +1,10 @@
 @echo off
 setlocal
 
-rem ds4 client launcher (Windows). Sets the ds4 backend env, isolates the VS Code
-rem process so the env does not bleed into native subscription windows, then launches
-rem VS Code. Rationale: docs/architecture.md; procedure: docs/ops.md#client-windows.
+rem ccgw client launcher (Windows). Prefers the LiteLLM gateway (ccgw) for Claude Code
+rem model routing; falls back to the DS4 Proxy direct connection when LiteLLM is
+rem unavailable. Isolates the VS Code process so the env does not bleed into native
+rem subscription windows. Rationale: docs/architecture.md; procedure: docs/ops.md#client-windows.
 
 rem Load the repo-root .env (gitignored) so the real Mac LAN IP is never committed.
 rem Format: KEY=value, one per line, # comment lines allowed. A value already set in
@@ -23,32 +24,38 @@ rem LiteLLM's TLS endpoint. Otherwise falls back to the DS4 Proxy path.
 rem When neither is set, uses a placeholder default (localhost:8445).
 if defined LITELLM_ANTHROPIC_BASE_URL (
     set "ANTHROPIC_BASE_URL=%LITELLM_ANTHROPIC_BASE_URL%"
+) else if defined CCGW_ANTHROPIC_BASE_URL (
+    set "ANTHROPIC_BASE_URL=%CCGW_ANTHROPIC_BASE_URL%"
 ) else if defined DS4_ANTHROPIC_BASE_URL (
     set "ANTHROPIC_BASE_URL=%DS4_ANTHROPIC_BASE_URL%"
 ) else (
-    echo [code-ds4] WARNING: Neither LITELLM_ANTHROPIC_BASE_URL nor DS4_ANTHROPIC_BASE_URL set.
+    echo [code-ccgw] WARNING: Neither LITELLM_ANTHROPIC_BASE_URL nor CCGW_ANTHROPIC_BASE_URL set.
     set "ANTHROPIC_BASE_URL=https://localhost:8445"
 )
 
 rem LiteLLM authentication. Use a scoped virtual key generated from the master key,
 rem NOT the master key itself. The virtual key is set up via scripts/setup-litellm.cmd.
-rem If no virtual key is available, fall back to DS4_API_KEY for direct proxy auth.
+rem If no virtual key is available, fall back to CCGW_API_KEY for direct proxy auth.
 if defined LITELLM_VIRTUAL_KEY (
     set "ANTHROPIC_AUTH_TOKEN=%LITELLM_VIRTUAL_KEY%"
+) else if defined CCGW_API_KEY (
+    set "ANTHROPIC_AUTH_TOKEN=%CCGW_API_KEY%"
 ) else if defined DS4_API_KEY (
     set "ANTHROPIC_AUTH_TOKEN=%DS4_API_KEY%"
 ) else (
-    echo [code-ds4] WARNING: Neither LITELLM_VIRTUAL_KEY nor DS4_API_KEY set.
+    echo [code-ccgw] WARNING: Neither LITELLM_VIRTUAL_KEY nor CCGW_API_KEY set.
     set "ANTHROPIC_AUTH_TOKEN=dsv4-local"
 )
 
-rem mkcert local CA root so Node trusts the proxy TLS certificate. Set DS4_CA_CERT to
+rem mkcert local CA root so Node trusts the proxy TLS certificate. Set CCGW_CA_CERT to
 rem the path printed by "mkcert -CAROOT"/rootCA.pem. NODE_TLS_REJECT_UNAUTHORIZED=0 is
 rem NOT used.
-if defined DS4_CA_CERT (
+if defined CCGW_CA_CERT (
+    set NODE_EXTRA_CA_CERTS=%CCGW_CA_CERT%
+) else if defined DS4_CA_CERT (
     set NODE_EXTRA_CA_CERTS=%DS4_CA_CERT%
 ) else (
-    echo [code-ds4] WARNING: DS4_CA_CERT not set; TLS certificate will not be trusted.
+    echo [code-ccgw] WARNING: CCGW_CA_CERT not set; TLS certificate will not be trusted.
 )
 
 rem Model aliases for Claude Code.
@@ -96,4 +103,4 @@ set CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75
 rem Launch VS Code in an isolated process. A distinct --user-data-dir starts a separate
 rem VS Code instance; VS Code otherwise shares one process (and one environment) across
 rem all windows of a user-data-dir, which would leak the ds4 env into native windows.
-code --user-data-dir "%LOCALAPPDATA%\vscode-ds4" %*
+code --user-data-dir "%LOCALAPPDATA%\vscode-ccgw" %*

--- a/scripts/lib/launchd.sh
+++ b/scripts/lib/launchd.sh
@@ -80,7 +80,7 @@ ds4_install() {
     _ds4_write_plist "$_svc"
     launchctl unload "$_plist" 2>/dev/null || true
     launchctl load -w "$_plist"
-    echo "[ds4-ops] installed $_label"
+    echo "[ds4ctl] installed $_label"
 }
 
 ds4_uninstall() {
@@ -89,5 +89,5 @@ ds4_uninstall() {
     _label="$(_ds4_plist_label "$_svc")"
     launchctl unload -w "$_plist" 2>/dev/null || true
     rm -f "$_plist"
-    echo "[ds4-ops] uninstalled $_label"
+    echo "[ds4ctl] uninstalled $_label"
 }

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -12,7 +12,7 @@ _ds4_cmd() {
             HOST="${DS4_SERVER_HOST:-127.0.0.1}"
             case "$HOST" in
                 *[!0-9a-zA-Z:.%-]*)
-                    echo "[ds4-ops] invalid DS4_SERVER_HOST value (allowed chars: 0-9 a-z A-Z : . %)" >&2
+                    echo "[ds4ctl] invalid DS4_SERVER_HOST value (allowed chars: 0-9 a-z A-Z : . %)" >&2
                     exit 1
                     ;;
             esac
@@ -76,15 +76,15 @@ ds4_exec() {
 ds4_start() {
     _svc="$1"
     if _ds4_launchd_active "$_svc"; then
-        echo "[ds4-ops] $_svc is managed by launchd (KeepAlive). Use 'ds4ctl install $_svc' instead of 'start'." >&2
+        echo "[ds4ctl] $_svc is managed by launchd (KeepAlive). Use 'ds4ctl install $_svc' instead of 'start'." >&2
         return 0
     fi
     if _pid=$(_ds4_running "$_svc"); then
-        echo "[ds4-ops] $_svc already running (pid $_pid)"
+        echo "[ds4ctl] $_svc already running (pid $_pid)"
         return 0
     fi
     if pgrep -f "$(_ds4_pgrep_pattern "$_svc")" >/dev/null 2>&1; then
-        echo "[ds4-ops] $_svc already running (untracked)"
+        echo "[ds4ctl] $_svc already running (untracked)"
         return 0
     fi
     if [ "$_svc" = "proxy" ] && [ -z "${DS4_PROXY_AUTH_TOKEN:-}" ]; then
@@ -102,7 +102,7 @@ ds4_start() {
     fi
     echo $! > "$_pid_file"
     _started_pid=$(cat "$_pid_file")
-    echo "[ds4-ops] started $_svc (pid $_started_pid)"
+    echo "[ds4ctl] started $_svc (pid $_started_pid)"
 }
 
 _ds4_stop_pid() {
@@ -127,15 +127,15 @@ _ds4_stop_pid() {
 ds4_stop() {
     _svc="$1"
     if _ds4_launchd_active "$_svc"; then
-        echo "[ds4-ops] $_svc is managed by launchd (KeepAlive — it will restart immediately if killed). To stop: 'ds4ctl uninstall $_svc'" >&2
+        echo "[ds4ctl] $_svc is managed by launchd (KeepAlive — it will restart immediately if killed). To stop: 'ds4ctl uninstall $_svc'" >&2
         return 1
     fi
     if _pid=$(_ds4_running "$_svc"); then
         _ds4_stop_pid "$_pid" "$_svc"
         rm -f "$(_ds4_pid_file "$_svc")"
-        echo "[ds4-ops] stopped $_svc"
+        echo "[ds4ctl] stopped $_svc"
     else
-        echo "[ds4-ops] $_svc not running"
+        echo "[ds4ctl] $_svc not running"
     fi
 }
 
@@ -158,14 +158,14 @@ ds4_status() {
 ds4_logs() {
     _svc="$1"
     if [ "${DS4_LOG:-on}" != "on" ]; then
-        echo "[ds4-ops] log recording is disabled (DS4_LOG=off)" >&2
+        echo "[ds4ctl] log recording is disabled (DS4_LOG=off)" >&2
         return 1
     fi
     if [ "$_svc" = "all" ]; then
         _pf="$(_ds4_log_file proxy)"
         _sf="$(_ds4_log_file server)"
         if [ ! -f "$_pf" ] && [ ! -f "$_sf" ]; then
-            echo "[ds4-ops] no log files found" >&2
+            echo "[ds4ctl] no log files found" >&2
             return 1
         fi
         # Use only existing files
@@ -177,7 +177,7 @@ ds4_logs() {
     else
         _logfile="$(_ds4_log_file "$_svc")"
         if [ ! -f "$_logfile" ]; then
-            echo "[ds4-ops] log file not found: $_logfile" >&2
+            echo "[ds4ctl] log file not found: $_logfile" >&2
             return 1
         fi
         if [ -t 1 ] && [ "$_svc" = "server" ] && [ "${DS4_SERVER_COLOR_LOG:-on}" = "on" ]; then

--- a/scripts/lib/load-dotenv.sh
+++ b/scripts/lib/load-dotenv.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Sourced by ds4-proxy.sh. Loads KEY=VALUE pairs from DOTENV_FILE (must be set
-# by caller). Shell-existing values take precedence (matches code-ds4.cmd semantics).
+# by caller). Shell-existing values take precedence (matches code-ccgw.cmd semantics).
 # Lines starting with # and blank lines are skipped.
 
 # Return 0 if the environment variable named by $1 is already set (matches the

--- a/scripts/lib/paths.sh
+++ b/scripts/lib/paths.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SSOT for ds4-ops service paths and patterns.
+# SSOT for ds4 service paths and patterns.
 set -eu
 
 DS4_OPS_ROOT="$HOME/git/ds4-ops"

--- a/scripts/litellm-start.cmd
+++ b/scripts/litellm-start.cmd
@@ -26,12 +26,19 @@ if not defined ACTION set "ACTION=up"
 rem Compose file path (absolute Windows path)
 set "COMPOSE_FILE=%~dp0..\litellm\docker-compose.yml"
 
-rem Override LITELLM_LLAMA_SWAP_URL with host.docker.internal for container networking.
-rem Inside the Docker container, localhost resolves to the container itself, not the
-rem Windows host. Docker Desktop provides host.docker.internal to reach the Windows host.
-rem The DS4 Proxy URL (LITELLM_DS4_URL) is NOT overridden -- it uses the .env value
-rem which points at <mac-host>'s LAN IP (<mac-lan-ip>:8443). Only llama-swap needs the override.
-set "LITELLM_LLAMA_SWAP_URL=http://host.docker.internal:18080/v1"
+rem Each tier URL is independently configurable in .env. Inside the container,
+rem loopback resolves to the container itself, so rewrite loopback hosts (and only
+rem those) to host.docker.internal. Non-loopback hosts are passed through unchanged,
+rem so a tier pointed at another machine keeps working.
+rem The Opus URL (LITELLM_OPUS_URL) is NOT overridden -- it uses the .env value
+rem which points at <mac-host>'s LAN IP (<mac-lan-ip>:8443). Only llama-swap tiers
+rem need the override.
+if not defined LITELLM_HAIKU_URL set "LITELLM_HAIKU_URL=http://localhost:18080/v1"
+if not defined LITELLM_SONNET_URL set "LITELLM_SONNET_URL=http://localhost:18080/v1"
+set "LITELLM_HAIKU_URL=%LITELLM_HAIKU_URL:localhost=host.docker.internal%"
+set "LITELLM_HAIKU_URL=%LITELLM_HAIKU_URL:127.0.0.1=host.docker.internal%"
+set "LITELLM_SONNET_URL=%LITELLM_SONNET_URL:localhost=host.docker.internal%"
+set "LITELLM_SONNET_URL=%LITELLM_SONNET_URL:127.0.0.1=host.docker.internal%"
 
 if /i "%ACTION%"=="up" (
     echo [litellm] Starting LiteLLM container...
@@ -68,9 +75,9 @@ if /i "%ACTION%"=="restart" (
 )
 
 if /i "%ACTION%"=="status" (
-    docker container inspect ds4-litellm --format "{{.State.Status}}" 2>nul
+    docker container inspect ccgw-litellm --format "{{.State.Status}}" 2>nul
     if errorlevel 1 (
-        echo [litellm] Container 'ds4-litellm' does not exist or is not running.
+        echo [litellm] Container 'ccgw-litellm' does not exist or is not running.
     )
     exit /b 0
 )

--- a/scripts/setup-litellm.cmd
+++ b/scripts/setup-litellm.cmd
@@ -6,10 +6,10 @@ rem Generates master key, creates virtual key (random, NOT reusing master key),
 rem verifies TLS certs and CA cert.
 rem Procedure: docs/ops.md#litellm-setup.
 rem
-rem IMPORTANT: LiteLLM requires a database for key generation. The compose file
-rem configures SQLite by default (DATABASE_URL). The /key/generate endpoint will
-rem fail if the database is not initialised. Wait a few seconds after container
-rem start for the database tables to be created.
+rem IMPORTANT: LiteLLM requires PostgreSQL for key generation. The compose file starts a
+rem bundled postgres service and passes DATABASE_URL; /key/generate fails until postgres
+rem passes its healthcheck and LiteLLM has created its tables. Wait a few seconds after
+rem container start.
 
 rem Load repo-root .env
 set "DS4_ENV_FILE=%~dp0..\.env"
@@ -30,9 +30,9 @@ if not defined LITELLM_MASTER_KEY (
 if not defined LITELLM_PORT set "LITELLM_PORT=8445"
 
 rem Step 1: Verify LiteLLM container is running
-docker container inspect ds4-litellm --format "{{.State.Status}}" >nul 2>&1
+docker container inspect ccgw-litellm --format "{{.State.Status}}" >nul 2>&1
 if errorlevel 1 (
-    echo [setup-litellm] ERROR: LiteLLM container 'ds4-litellm' is not running.
+    echo [setup-litellm] ERROR: LiteLLM container 'ccgw-litellm' is not running.
     echo [setup-litellm] Run litellm-start.cmd up first.
     exit /b 1
 )

--- a/tests/ccgw-naming/test_no_legacy_names.py
+++ b/tests/ccgw-naming/test_no_legacy_names.py
@@ -1,0 +1,159 @@
+# Tests: litellm/docker-compose.yml, litellm/config.yaml, scripts/*.cmd, .env.example, docs/*.md
+# Tags: scope:issue-specific, layer:TL1
+#
+# TL1 gap (what this test suite does NOT catch — explicitly deferred):
+# - Whether the renamed Compose project name actually resolves the 401 auth bug
+#     (requires a live LiteLLM + Postgres stack; TL3)
+# - Whether the renamed .cmd launchers still start Claude Code successfully
+#     (requires a real Windows shell; TL3, category pwsh-required)
+# - context_window additions in config.yaml (Haiku=32768, Sonnet=32768, Opus=393216)
+#     are in the main worktree's uncommitted diff and are NOT part of this rename PR;
+#     they are separate tuning work. Coverage deferred to that PR.
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: pwsh-required
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+LEGACY_TOKENS = [
+    "ds4-litellm",
+    "ds4-litellm-postgres",
+    "LITELLM_DS4_URL",
+    "LITELLM_DS4_API_KEY",
+    "LITELLM_LLAMA_SWAP_URL",
+    "code-ds4.cmd",
+    "vscode-ds4",
+    "nirecom/ds4-ops",
+    "[ds4-ops]",
+]
+
+# docs/history.md is an append-only historical record.
+HISTORY_PATH = "docs/history.md"
+
+# This test file necessarily carries every legacy token as data.
+SELF_PATH = "tests/ccgw-naming/test_no_legacy_names.py"
+
+EXCLUDED_PATHS = {HISTORY_PATH, SELF_PATH}
+
+# These name the DS4 Proxy backend directly, not the ccgw gateway — the rename
+# must not touch them.
+RETAINED_ENV_VARS = [
+    "DS4_ANTHROPIC_BASE_URL",
+    "DS4_API_KEY",
+    "DS4_CA_CERT",
+]
+
+LAUNCHER_PATH = "scripts/code-ccgw.cmd"
+
+# New env var names that must appear in the gateway source files after rename.
+NEW_GATEWAY_ENV_VARS = [
+    "LITELLM_OPUS_URL",
+    "LITELLM_OPUS_API_KEY",
+    "LITELLM_HAIKU_URL",
+    "LITELLM_SONNET_URL",
+]
+
+# Files where the new env var names are expected to appear.
+NEW_ENV_SOURCE_FILES = [
+    "litellm/docker-compose.yml",
+    "litellm/config.yaml",
+]
+
+COMPOSE_FILE = "litellm/docker-compose.yml"
+
+
+def _repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=Path(__file__).resolve().parent,
+    )
+    return Path(result.stdout.strip())
+
+
+def _tracked_files(root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=root,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _scannable_files() -> list[tuple[str, Path]]:
+    root = _repo_root()
+    return [
+        (rel, root / rel)
+        for rel in _tracked_files(root)
+        if rel not in EXCLUDED_PATHS
+    ]
+
+
+@pytest.mark.parametrize("token", LEGACY_TOKENS)
+def test_legacy_token_absent_from_tracked_files(token):
+    hits = []
+    for rel, path in _scannable_files():
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for lineno, line in enumerate(lines, start=1):
+            if token in line:
+                hits.append(f"  {rel}:{lineno}: {line.strip()}")
+
+    assert not hits, (
+        f"legacy token {token!r} still present in {len(hits)} location(s) — "
+        f"rename to the ccgw- scheme:\n" + "\n".join(hits)
+    )
+
+
+def test_exclusion_paths_resolve():
+    root = _repo_root()
+    assert (root / HISTORY_PATH).is_file(), (
+        f"{HISTORY_PATH} does not exist — the exclusion is silently doing "
+        "nothing (moved or renamed?)"
+    )
+    assert Path(__file__).resolve() == (root / SELF_PATH).resolve(), (
+        f"SELF_PATH ({SELF_PATH}) no longer points at this test file — the "
+        "self-exclusion would break and this test would report itself"
+    )
+
+
+@pytest.mark.parametrize("env_var", RETAINED_ENV_VARS)
+def test_retained_ds4_backend_env_var_still_referenced(env_var):
+    launcher = _repo_root() / LAUNCHER_PATH
+    assert launcher.is_file(), (
+        f"{LAUNCHER_PATH} not found — the launcher must be git-mv'd from "
+        f"scripts/code-ds4.cmd as part of the ccgw rename"
+    )
+    content = launcher.read_text(encoding="utf-8", errors="replace")
+    assert env_var in content, (
+        f"{env_var} no longer appears in {LAUNCHER_PATH} — this variable names "
+        f"the DS4 Proxy backend, not the ccgw gateway, and must survive the "
+        f"rename (over-replacement bug)"
+    )
+
+
+def test_compose_project_name_pinned():
+    compose = _repo_root() / COMPOSE_FILE
+    lines = compose.read_text(encoding="utf-8", errors="replace").splitlines()
+    assert any("name: ccgw" in line for line in lines), (
+        f"{COMPOSE_FILE} must have a top-level `name: ccgw` line to pin the "
+        "Compose project name (fixes the 401 volume-mismatch root cause)"
+    )
+
+
+@pytest.mark.parametrize("env_var", NEW_GATEWAY_ENV_VARS)
+def test_new_gateway_env_var_wired_in_source_files(env_var):
+    root = _repo_root()
+    for rel in NEW_ENV_SOURCE_FILES:
+        path = root / rel
+        content = path.read_text(encoding="utf-8", errors="replace")
+        assert env_var in content, (
+            f"{env_var} must appear in {rel} after the rename — the env var "
+            "passthrough in docker-compose.yml and the os.environ/ reference in "
+            f"config.yaml must both use the new name"
+        )

--- a/tests/test_feature-13-ds4-proxy.py
+++ b/tests/test_feature-13-ds4-proxy.py
@@ -7,7 +7,7 @@
 # - End-to-end chunked transfer between real client and upstream ds4 server
 # - Proxy handler integration (server.py not yet written; auth→normalize→
 #     forward→sanitize pipeline tested post-/write-code as L2 integration tests)
-# - Launcher scripts (ds4-server.sh, code-ds4.cmd, ds4-proxy.sh not yet
+# - Launcher scripts (ds4-server.sh, code-ccgw.cmd, ds4-proxy.sh not yet
 #     written; bind address, HTTPS URL, NODE_EXTRA_CA_CERTS, KV-cache flags
 #     deferred to post-/write-code)
 # - .env.example / docs consistency (files not yet written; env var, host/port


### PR DESCRIPTION
Rename all client-facing ds4-* environment variables and references to
ccgw-*: CCGW_ANTHROPIC_BASE_URL, CCGW_API_KEY, CCGW_CA_CERT, etc.
Backward-compatible fallbacks to DS4_* names retained in the launcher.
Pin docker-compose project name to "ccgw" to fix 401 volume mismatch.
Add TL1 regression test (18 parametrized cases) for legacy token absence
and new gateway env var presence.
