### PR TITLE
perf(ds4-server): multiplex live KV slot, halve continued KV writes

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -250,8 +250,19 @@ After changing `DS4_LOG` in `.env`, run `ds4ctl install all` to regenerate the p
 
 **Stopping a launchd-managed service**: `ds4ctl stop` will refuse with an error when the
 service is launchd-managed (KeepAlive would restart it immediately anyway). Use
-`ds4ctl uninstall <svc>` to stop and disable auto-start. To restart a launchd-managed
-service: `ds4ctl uninstall <svc>` then `ds4ctl install <svc>`.
+`ds4ctl uninstall <svc>` to stop and disable auto-start.
+
+**Restarting a launchd-managed service**: `ds4ctl install <svc>` on its own is the restart —
+`ds4_install()` (`scripts/lib/launchd.sh`) runs `_ds4_write_plist` → `launchctl unload` →
+`launchctl load -w` in sequence. Do **not** do `uninstall` then `install`: the two-step form
+only opens a window in which no LaunchAgent exists, and buys nothing.
+
+**Run `install` from the checkout the plist should point at.** `_ds4_write_plist` bakes the
+absolute path `$DS4_OPS_ROOT/scripts/ds4-<svc>.sh` into `ProgramArguments`, and
+`DS4_OPS_ROOT` is derived by `scripts/lib/root.sh` from the parent directory of the script
+that was actually executed. Installing from a throwaway checkout (a git worktree, say) leaves
+the LaunchAgent pointing at a path that disappears when that checkout is removed, and the
+service then fails to start. Always run it from the everyday checkout (`~/git/cc-local-llm`).
 
 **start vs stop asymmetry**: when launchd manages a service, `ds4ctl start` is a silent
 no-op (informational — launchd's KeepAlive is already running it), while `ds4ctl stop`
@@ -340,6 +351,21 @@ returns `400 context_length_exceeded`.
 | Memory pressure / swap | `sysctl vm.swapusage` |
 | Thinking on/off per request | grep the server log for `THINKING` in the `chat ...` lines |
 | Process alive / one instance | `pgrep -fl ds4-server` |
+| KV cache report (long-prefill counts, cache-miss prefix distribution, per-reason write volume) | `~/git/cc-local-llm/scripts/kvcache-report.sh` |
+
+The report reads `~/Library/Logs/ds4-server/kvcache.log` and takes `--since` / `--until` to
+restrict the window. A SPEC is a timestamp with 4, 8 or 10 digits once separators are removed
+(`0801`, `"08-01"`, `"0801 12:00"`, `0801120000`); `--since` pads the missing part with
+`00:00:00` and `--until` with `23:59:59`. The log carries no year, so these are the only way
+to split a window — the file is appended across restarts and is never rotated on restart.
+
+The output is deterministic for a given input range, so a before/after comparison is just a
+`diff` of two runs:
+```sh
+~/git/cc-local-llm/scripts/kvcache-report.sh --until "0811 07:21:29" > /tmp/before.txt
+~/git/cc-local-llm/scripts/kvcache-report.sh --since "0811 07:21:29" > /tmp/after.txt
+diff /tmp/before.txt /tmp/after.txt
+```
 
 ## Recovery
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -14,8 +14,9 @@ incidents that produced these values in [history.md](history.md).
 | `--kv-disk-dir` | `~/Library/Caches/ds4-server/kv` | Persistent + Time Machine-excluded by macOS default. `/tmp` was rejected (non-persistent, and TM-*included* → would back up 100s of GB). Same SSD volume, so no speed loss. |
 | `--kv-disk-space-mb` | `32768` | 32 GB cap: skips pathologically large single checkpoints and bounds eviction. Not a total-write cap (eviction deletes, so churn can still exceed it). Lowered back from 64 GB (2026-07-13) — header analysis of the live cache showed only 34 total hits across 52 files, 68% of bytes never reused; the 2026-07-11 raise to 64 GB likely masked a gap in the eviction score (`(effective_hits+1) × tokens/file_size`, half-life-decayed) rather than fixing a real capacity shortfall — a brand-new unhit checkpoint scores identically to an ancient unhit one, so the larger budget mainly let dead sessions linger. Rolled back pending real `kv cache evicted`/`kv cache hit` log evidence (now persisted to `~/Library/Logs/ds4-server/kvcache.log`, see `scripts/ds4-server.sh`) on whether a live session's checkpoint is ever evicted prematurely at this budget. |
 | `--kv-cache-cold-max-tokens` | `90000` | Largest single cold-save snapshot; big enough to cache a typical CC initial context in one write, below `--ctx`. |
-| `--kv-cache-continued-interval-tokens` | `25000` | **The write-amplification lever.** Each continued checkpoint rewrites the whole live prefix (not a delta), doubled f16→f32. The default 10000 caused a 137 GB write storm; 25000 more than halved the churn. |
+| `--kv-cache-continued-interval-tokens` | `50000` | **The write-amplification lever.** Each continued checkpoint rewrites the whole live prefix (not a delta), doubled f16→f32. The default 10000 caused a 137 GB write storm; 25000 more than halved the churn. Doubled again to 50000 on 2026-08-10 (#34): over the 0713–0811 window `reason=continued` was still 317 writes / 325.94 GiB, 37% of all KV disk writes. Note the reduction is **not** linear — a longer interval means each individual checkpoint is larger, so halving the checkpoint count does not halve the bytes. |
 | `--warm-weights` | on | Page in the whole model at startup. RSS ~90.9 GB is expected, not a leak. |
+| `--batched-session` | `2` | **Number of resident KV sessions.** With a single live KV slot, the main conversation, sub-agents and one-off small prompts evict each other's prefix every time they interleave. Over the 0713–0811 window every one of the 548 live-cache misses was `token-mismatch`, and 55% of them shared under 1000 tokens of common prefix — i.e. the slot had been handed to an unrelated request. That eviction is also what produced `reason=evict` 475.00 GiB, 54% of all KV disk writes. So the single slot is the **common cause** of both the 30.7 hours of cold prefill and the bulk of the disk churn, which is why it is attacked first. Started at N=2 rather than N=3 because the premise for sizing N — "~1.3 GB per KV session" — is a derived figure that has never been measured (#34); confirm real RSS before deciding on N=3. |
 | `--host 127.0.0.1` | — | Loopback only; the proxy (scripts/ds4-proxy.sh) is the LAN endpoint. |
 
 ## Memory budget (128 GB)
@@ -29,6 +30,11 @@ Weights ~90.9 GB resident; KV grows lazily as a session fills (startup RSS ≈ w
 
 393216 fits comfortably as a dedicated server. `1M` ctx (~26 GB KV → ~117 GB peak) is too
 much — do not.
+
+The peak RSS figures above assume **one** resident KV session. With `--batched-session 2` a
+second resident session's KV can add on top, so the real headroom is smaller than the table
+says. The numbers are left unchanged until the actual RSS under N=2 is measured — update this
+section once that measurement exists rather than substituting an estimate.
 
 ## Thinking control
 

--- a/scripts/kvcache-report.sh
+++ b/scripts/kvcache-report.sh
@@ -1,0 +1,393 @@
+#!/bin/sh
+# kvcache-report — aggregate the ds4-server KV cache log into a fixed report.
+#
+# The report exists so that a before/after pair can be compared with `diff`:
+# every value printed is derived only from the log contents, never from the
+# current time, the elapsed run time, or the file size, and every column is a
+# fixed printf width so that row content never shifts neighbouring lines.
+#
+# Line kinds (the log carries `reason=` and `size=` on TWO different kinds):
+# - `kv cache stored ...`  — a WRITE into the disk cache. Counted in [3].
+# - `kv cache evicted ...` — a DELETION from the disk cache (always
+#   reason=disk-cache-full). NOT counted as write volume, and not counted in
+#   any section: scanning fields without a line predicate would roughly double
+#   the write totals and silently add `disk-cache-full` to the reason table.
+#
+# Thresholds:
+# - [1] splits prompt processing at 60s, the value issue #34 used to classify
+#   cold prefills against warm continuations.
+# - [2] buckets the common prefix length at 1000 / 10000 / 50000 tokens.
+#   `lt_1000` comes first because it is the layer that throws away almost the
+#   whole prefix (the 55% share issue #34 reported); 1000_9999 is a partial
+#   reuse; 10000_49999 is a substantial reuse; ge_50000 is a near-full hit at
+#   the scale of the configured cold-max/continued-interval token counts.
+set -eu
+
+# LC_ALL=C is pinned for two reasons: (a) it fixes awk string comparison to
+# byte order, so the self-sorted reason rows in [3] do not reorder with the
+# ambient locale, and (b) it keeps printf "%.2f" using "." as the decimal
+# separator in locales that would otherwise emit ",". Output determinism is
+# this script's contract, so the collation and the numeric format are made
+# explicit rather than inherited (CPR-UNV).
+export LC_ALL=C
+
+DS4_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/lib/root.sh
+. "$DS4_SCRIPT_DIR/lib/root.sh"     # establishes DS4_OPS_ROOT (paths.sh requires it)
+# Intentionally does NOT source lib/load-dotenv.sh: this is a read-only log
+# analyzer with no .env-derived input, so it must not read the developer's
+# real .env. Other entrypoints source it because they launch services.
+# shellcheck source=scripts/lib/paths.sh
+. "$DS4_SCRIPT_DIR/lib/paths.sh"    # _ds4_log_file server is the SSOT for the log path
+
+LOG_DEFAULT="$(_ds4_log_file server)"
+
+# Display-only: renders a leading $HOME as "~" so a pasted report (this repo
+# is public) never discloses the account name baked into the absolute path.
+# The real, untouched path is still what every functional use (-f check,
+# awk input redirection) operates on.
+_display_path() {
+    case "$1" in
+        "$HOME"/*) printf '~%s' "${1#"$HOME"}" ;;
+        *)         printf '%s' "$1" ;;
+    esac
+}
+
+_usage() {
+    cat <<EOF
+Usage: kvcache-report.sh [options]
+
+Options:
+  -f, --file PATH   Log file to analyze (default: $(_display_path "$LOG_DEFAULT"))
+      --since SPEC  Include entries at or after SPEC (default: beginning of file)
+      --until SPEC  Include entries at or before SPEC (default: end of file)
+  -h, --help        Show this help
+
+SPEC is a timestamp with 4, 8, or 10 digits after separators are removed:
+  MMDD          e.g. 0801,  "08-01"
+  MMDDHHMM      e.g. 08011200, "0801 12:00"
+  MMDDHHMMSS    e.g. 0801120000, "0801 12:00:00"
+--since pads the missing part with the earliest instant (00:00:00),
+--until with the latest (23:59:59).
+EOF
+}
+
+_usage_error() {
+    echo "[kvcache-report] $1" >&2
+    _usage >&2
+    exit 2
+}
+
+# The log timestamps are "MMDD HH:MM:SS" and carry no year, so date parsing is
+# not possible; a 10-digit key compared numerically is the only workable form.
+# Separators are stripped first so 0801 / "08-01" / "0801 12:00" normalize the
+# same way, without a per-format special case (CPR-UNV).
+#
+# Strips one leading '0' from a 2-digit field so plain shell arithmetic never
+# sees a leading zero: POSIX arithmetic parses that as octal and would reject
+# valid fields like "08"/"09". Returns via STRIPPED0 (see NORMALIZED_SPEC
+# above for why globals, not stdout).
+_strip_lead0() {
+    case "$1" in
+        0?) STRIPPED0="${1#0}" ;;
+        *)  STRIPPED0="$1" ;;
+    esac
+}
+
+# Range-checks the padded 10-digit MMDDHHMMSS key field by field, so
+# "2025-08-01" (which strips to month "20") is rejected instead of silently
+# becoming a wrong range. Field slicing mirrors _format_key above.
+_validate_spec_fields() {
+    _vf_side="$1"
+    _vf_raw="$2"
+    _vf_rest="$3"
+    _vf_mm="${_vf_rest%????????}";  _vf_rest="${_vf_rest#??}"
+    _vf_dd="${_vf_rest%??????}";    _vf_rest="${_vf_rest#??}"
+    _vf_hh="${_vf_rest%????}";      _vf_rest="${_vf_rest#??}"
+    _vf_mi="${_vf_rest%??}";        _vf_ss="${_vf_rest#??}"
+
+    _strip_lead0 "$_vf_mm"
+    [ "$STRIPPED0" -ge 1 ] && [ "$STRIPPED0" -le 12 ] || _usage_error "invalid --$_vf_side value: $_vf_raw (month $_vf_mm out of range 01-12)"
+    _strip_lead0 "$_vf_dd"
+    [ "$STRIPPED0" -ge 1 ] && [ "$STRIPPED0" -le 31 ] || _usage_error "invalid --$_vf_side value: $_vf_raw (day $_vf_dd out of range 01-31)"
+    _strip_lead0 "$_vf_hh"
+    [ "$STRIPPED0" -ge 0 ] && [ "$STRIPPED0" -le 23 ] || _usage_error "invalid --$_vf_side value: $_vf_raw (hour $_vf_hh out of range 00-23)"
+    _strip_lead0 "$_vf_mi"
+    [ "$STRIPPED0" -ge 0 ] && [ "$STRIPPED0" -le 59 ] || _usage_error "invalid --$_vf_side value: $_vf_raw (minute $_vf_mi out of range 00-59)"
+    _strip_lead0 "$_vf_ss"
+    [ "$STRIPPED0" -ge 0 ] && [ "$STRIPPED0" -le 59 ] || _usage_error "invalid --$_vf_side value: $_vf_raw (second $_vf_ss out of range 00-59)"
+}
+
+# Result is returned in NORMALIZED_SPEC rather than on stdout: _usage_error
+# exits, and an exit from inside a command substitution would only leave the
+# subshell.
+_normalize_spec() {
+    _ns_side="$1"
+    _ns_raw="$2"
+    case "$_ns_raw" in
+        *[!0-9\ :/-]*) _usage_error "invalid --$_ns_side value: $_ns_raw (only digits, space, ':', '/', '-' allowed)" ;;
+    esac
+    _ns_digits="$(printf '%s' "$_ns_raw" | tr -cd '0-9')"
+    case "${#_ns_digits}" in
+        4)
+            if [ "$_ns_side" = since ]; then _ns_digits="${_ns_digits}000000"
+            else _ns_digits="${_ns_digits}235959"; fi
+            ;;
+        8)
+            if [ "$_ns_side" = since ]; then _ns_digits="${_ns_digits}00"
+            else _ns_digits="${_ns_digits}59"; fi
+            ;;
+        10) ;;
+        *)  _usage_error "invalid --$_ns_side value: $_ns_raw (need 4, 8, or 10 digits: MMDD, MMDDHHMM, or MMDDHHMMSS)" ;;
+    esac
+    _validate_spec_fields "$_ns_side" "$_ns_raw" "$_ns_digits"
+    NORMALIZED_SPEC="$_ns_digits"
+}
+
+# 10-digit key -> "MMDD HH:MM:SS" for the "range requested" line.
+_format_key() {
+    _fk_k="$1"
+    _fk_d="${_fk_k%??????}"
+    _fk_t="${_fk_k#????}"
+    _fk_h="${_fk_t%????}"
+    _fk_rest="${_fk_t#??}"
+    printf '%s %s:%s:%s' "$_fk_d" "$_fk_h" "${_fk_rest%??}" "${_fk_rest#??}"
+}
+
+LOG_FILE="$LOG_DEFAULT"
+SINCE_KEY="0000000000"
+UNTIL_KEY="9999999999"
+REQ_SINCE="-"
+REQ_UNTIL="-"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -f|--file)
+            [ $# -ge 2 ] || _usage_error "missing value for $1"
+            LOG_FILE="$2"
+            shift 2
+            ;;
+        --since)
+            [ $# -ge 2 ] || _usage_error "missing value for $1"
+            _normalize_spec since "$2"
+            SINCE_KEY="$NORMALIZED_SPEC"
+            REQ_SINCE="$(_format_key "$SINCE_KEY")"
+            shift 2
+            ;;
+        --until)
+            [ $# -ge 2 ] || _usage_error "missing value for $1"
+            _normalize_spec until "$2"
+            UNTIL_KEY="$NORMALIZED_SPEC"
+            REQ_UNTIL="$(_format_key "$UNTIL_KEY")"
+            shift 2
+            ;;
+        -h|--help)
+            _usage
+            exit 0
+            ;;
+        *)
+            _usage_error "unknown option: $1"
+            ;;
+    esac
+done
+
+if [ ! -f "$LOG_FILE" ]; then
+    echo "[kvcache-report] log file not found: $LOG_FILE" >&2
+    exit 1
+fi
+
+# Single awk pass. The whole report (headers included) is emitted from END so
+# that line order is owned by one process: no external filter, no pipe, and
+# therefore no way for a child to write to the shared fd ahead of awk.
+# Zero matching lines is not an error — a zero-filled report is printed so that
+# the before/after diff stays line-aligned.
+LOGDISPLAY="$(_display_path "$LOG_FILE")"
+awk -v LOGPATH="$LOGDISPLAY" -v SINCE="$SINCE_KEY" -v UNTIL="$UNTIL_KEY" \
+    -v REQ_SINCE="$REQ_SINCE" -v REQ_UNTIL="$REQ_UNTIL" '
+# Insertion sort, ascending by name. Row order must be the reason NAME and
+# never a quantity: the report is meant to be diffed, and a volume ranking
+# flips between runs, filling the diff with pure reordering noise.
+# Comparison forces string context ("" x) because awk compares numeric-looking
+# strings numerically otherwise.
+function isort(a, n,    i, j, key) {
+    for (i = 2; i <= n; i++) {
+        key = a[i]
+        j = i - 1
+        while (j >= 1 && ("" a[j]) > ("" key)) {
+            a[j + 1] = a[j]
+            j--
+        }
+        a[j + 1] = key
+    }
+}
+function share(part, total) {
+    return (total > 0 ? part * 100.0 / total : 0)
+}
+function avg(sum, n) {
+    return (n > 0 ? sum / n : 0)
+}
+# Output hygiene for log-derived tokens (reason=, unit) reaching a printf
+# argument: non-printable bytes (raw ESC/CR etc.) are replaced so they never
+# reach the terminal, and the token is truncated to the reason column width
+# so an oversized value cannot shift the fixed-width diff contract.
+function sanitize(s) {
+    gsub(/[^ -~]/, "?", s)
+    if (length(s) > 14) s = substr(s, 1, 14)
+    return s
+}
+
+{ scanned++ }
+
+# Time gate. Startup banner lines carry no timestamp and are skipped silently.
+$1 ~ /^[0-9][0-9][0-9][0-9]$/ && $2 ~ /^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]$/ {
+    t = $2
+    gsub(/:/, "", t)
+    key = $1 t
+    if (key + 0 < SINCE + 0 || key + 0 > UNTIL + 0) next
+    inrange++
+    stamp = $1 " " $2
+    if (obs_n == 0) {
+        obs_min_k = key; obs_min = stamp
+        obs_max_k = key; obs_max = stamp
+    } else {
+        if (key + 0 < obs_min_k + 0) { obs_min_k = key; obs_min = stamp }
+        if (key + 0 > obs_max_k + 0) { obs_max_k = key; obs_max = stamp }
+    }
+    obs_n++
+
+    # [1] prompt processing. The field count varies (8 or 9, depending on the
+    # TOOLS token), so the duration is located by text and read as the token
+    # right after it — never by field index.
+    p = index($0, "prompt done ")
+    if (p > 0) {
+        rest = substr($0, p + 12)
+        if (split(rest, tk, " ") >= 1) {
+            v = tk[1]
+            sub(/s$/, "", v)
+            if (v ~ /^[0-9]+(\.[0-9]+)?$/) {
+                sec = v + 0
+                p_all_c++; p_all_s += sec
+                if (sec > 60) { p_over_c++; p_over_s += sec }
+                else          { p_up_c++;   p_up_s   += sec }
+            }
+        }
+    }
+
+    # [2] live kv cache miss. The source format has a variable prefix, so the
+    # values are picked up by scanning fields for their key= prefix.
+    if (index($0, "live kv cache miss") > 0) {
+        m_total++
+        r = ""; c = ""
+        for (i = 1; i <= NF; i++) {
+            if (substr($i, 1, 7) == "reason=") r = substr($i, 8)
+            else if (substr($i, 1, 7) == "common=") c = substr($i, 8)
+        }
+        if (r != "") {
+            if (!(r in mcnt)) mkeys[++mnk] = r
+            mcnt[r]++
+        }
+        if (c != "") {
+            cv = c + 0
+            if (cv < 1000)       b_lt++
+            else if (cv < 10000) b_1k++
+            else if (cv < 50000) b_10k++
+            else                 b_50k++
+        }
+    }
+
+    # [3] kv cache stored. The trailing space in the predicate keeps a future
+    # "kv cache stored-" style message from matching by accident. Evicted lines
+    # deliberately have no section: they are deletions, not writes.
+    if (index($0, "kv cache stored ") > 0) {
+        r = ""; sz = ""; unit = ""
+        for (i = 1; i <= NF; i++) {
+            if (substr($i, 1, 7) == "reason=") r = substr($i, 8)
+            else if (substr($i, 1, 5) == "size=") {
+                sz = substr($i, 6)
+                unit = (i < NF ? $(i + 1) : "(none)")
+            }
+        }
+        if (r == "") r = "(unknown)"
+        if (!(r in scnt)) skeys[++snk] = r
+        scnt[r]++
+        s_total_c++
+        if (sz != "") {
+            # Only MiB is accumulated. Any other unit is counted separately and
+            # surfaced in the warnings line, so a log format change cannot
+            # silently under-report write volume (CPR-UNV).
+            if (unit == "MiB") {
+                smib[r] += sz + 0
+                s_total_m += sz + 0
+            } else {
+                if (!(unit in ucnt)) ukeys[++unk] = unit
+                ucnt[unit]++
+            }
+        }
+    }
+}
+
+END {
+    HDR5 = "  %-14s%8s%13s%12s%13s\n"
+    ROW5 = "  %-14s%8d%13.2f%12.2f%13.2f\n"
+    HDR3 = "  %-14s%8s%11s\n"
+    ROW3 = "  %-14s%8d%10.1f%%\n"
+
+    printf("kvcache-report %s\n", LOGPATH)
+    printf("range requested : %s .. %s\n", REQ_SINCE, REQ_UNTIL)
+    if (obs_n > 0) printf("range observed  : %s .. %s\n", obs_min, obs_max)
+    else           printf("range observed  : %s .. %s\n", "-", "-")
+    printf("lines scanned   : %-7d in range: %d\n", scanned, inrange)
+    printf("\n")
+
+    printf("[1] prompt processing  (match: \"prompt done \")\n")
+    printf(HDR5, "bucket", "count", "total_s", "total_h", "avg_s")
+    printf(ROW5, "all",      p_all_c,  p_all_s,  p_all_s / 3600.0,  avg(p_all_s, p_all_c))
+    printf(ROW5, "over_60s", p_over_c, p_over_s, p_over_s / 3600.0, avg(p_over_s, p_over_c))
+    printf(ROW5, "upto_60s", p_up_c,   p_up_s,   p_up_s / 3600.0,   avg(p_up_s, p_up_c))
+    printf("\n")
+
+    printf("[2] live kv cache miss  (match: \"live kv cache miss\")\n")
+    printf("  %-14s%8d\n", "total", m_total)
+    printf(HDR3, "by_reason", "count", "share")
+    isort(mkeys, mnk)
+    for (i = 1; i <= mnk; i++) {
+        r = mkeys[i]
+        printf(ROW3, sanitize(r), mcnt[r], share(mcnt[r], m_total))
+    }
+    printf(HDR3, "by_common", "count", "share")
+    printf(ROW3, "lt_1000",     b_lt  + 0, share(b_lt  + 0, m_total))
+    printf(ROW3, "1000_9999",   b_1k  + 0, share(b_1k  + 0, m_total))
+    printf(ROW3, "10000_49999", b_10k + 0, share(b_10k + 0, m_total))
+    printf(ROW3, "ge_50000",    b_50k + 0, share(b_50k + 0, m_total))
+    printf("\n")
+
+    printf("[3] kv cache stored  (match: \"kv cache stored \", excludes \"kv cache evicted\")\n")
+    printf(HDR5, "reason", "count", "MiB", "GiB", "avg_MiB")
+    isort(skeys, snk)
+    for (i = 1; i <= snk; i++) {
+        r = skeys[i]
+        printf(ROW5, sanitize(r), scnt[r], smib[r] + 0, (smib[r] + 0) / 1024.0, avg(smib[r] + 0, scnt[r]))
+    }
+    # TOTAL is always printed, even with no rows above it, so its presence
+    # never shifts diff lines.
+    printf(ROW5, "TOTAL", s_total_c + 0, s_total_m + 0, (s_total_m + 0) / 1024.0, avg(s_total_m + 0, s_total_c + 0))
+    printf("\n")
+
+    # The warnings line is always printed ("none" when clean) for the same
+    # reason: a warning must not shift the line count of the rest of the report.
+    if (unk > 0) {
+        isort(ukeys, unk)
+        w = ""
+        for (i = 1; i <= unk; i++) {
+            w = w (i > 1 ? "; " : "") sprintf("%d line(s) with unexpected size unit: %s", ucnt[ukeys[i]], sanitize(ukeys[i]))
+        }
+        printf("warnings: %s\n", w)
+    } else {
+        printf("warnings: none\n")
+    }
+}
+' < "$LOG_FILE"
+# The log path is fed by redirection, not as a trailing operand: POSIX awk
+# treats an operand containing "=" as a name=value assignment rather than a
+# filename, so a log literally named "SINCE=..." would be silently consumed
+# as a variable override and awk would fall back to reading stdin.

--- a/scripts/kvcache-report.sh
+++ b/scripts/kvcache-report.sh
@@ -1,51 +1,31 @@
 #!/bin/sh
 # kvcache-report — aggregate the ds4-server KV cache log into a fixed report.
 #
-# The report exists so that a before/after pair can be compared with `diff`:
-# every value printed is derived only from the log contents, never from the
-# current time, the elapsed run time, or the file size, and every column is a
-# fixed printf width so that row content never shifts neighbouring lines.
+# Output is diff-friendly by contract: values come only from the log (never
+# from the clock or file size) and every column is a fixed printf width.
 #
-# Line kinds (the log carries `reason=` and `size=` on TWO different kinds):
-# - `kv cache stored ...`  — a WRITE into the disk cache. Counted in [3].
-# - `kv cache evicted ...` — a DELETION from the disk cache (always
-#   reason=disk-cache-full). NOT counted as write volume, and not counted in
-#   any section: scanning fields without a line predicate would roughly double
-#   the write totals and silently add `disk-cache-full` to the reason table.
-#
-# Thresholds:
-# - [1] splits prompt processing at 60s, the value issue #34 used to classify
-#   cold prefills against warm continuations.
-# - [2] buckets the common prefix length at 1000 / 10000 / 50000 tokens.
-#   `lt_1000` comes first because it is the layer that throws away almost the
-#   whole prefix (the 55% share issue #34 reported); 1000_9999 is a partial
-#   reuse; 10000_49999 is a substantial reuse; ge_50000 is a near-full hit at
-#   the scale of the configured cold-max/continued-interval token counts.
+# `kv cache stored` is a write and is counted in [3]; `kv cache evicted` is a
+# deletion and is counted nowhere — matching it would double the write totals.
+# Thresholds are the ones issue #34 used: 60s for [1], and 1000 / 10000 /
+# 50000 common-prefix tokens for [2].
 set -eu
 
-# LC_ALL=C is pinned for two reasons: (a) it fixes awk string comparison to
-# byte order, so the self-sorted reason rows in [3] do not reorder with the
-# ambient locale, and (b) it keeps printf "%.2f" using "." as the decimal
-# separator in locales that would otherwise emit ",". Output determinism is
-# this script's contract, so the collation and the numeric format are made
-# explicit rather than inherited (CPR-UNV).
+# Pinned so [3]'s sort stays byte-ordered and "%.2f" keeps "." as the decimal
+# separator regardless of the ambient locale (CPR-UNV).
 export LC_ALL=C
 
 DS4_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 # shellcheck source=scripts/lib/root.sh
 . "$DS4_SCRIPT_DIR/lib/root.sh"     # establishes DS4_OPS_ROOT (paths.sh requires it)
-# Intentionally does NOT source lib/load-dotenv.sh: this is a read-only log
-# analyzer with no .env-derived input, so it must not read the developer's
-# real .env. Other entrypoints source it because they launch services.
+# lib/load-dotenv.sh is deliberately not sourced: a read-only analyzer has no
+# .env-derived input and must not read the developer's real .env.
 # shellcheck source=scripts/lib/paths.sh
 . "$DS4_SCRIPT_DIR/lib/paths.sh"    # _ds4_log_file server is the SSOT for the log path
 
 LOG_DEFAULT="$(_ds4_log_file server)"
 
-# Display-only: renders a leading $HOME as "~" so a pasted report (this repo
-# is public) never discloses the account name baked into the absolute path.
-# The real, untouched path is still what every functional use (-f check,
-# awk input redirection) operates on.
+# Display only: hides the account name in a pasted report (public repo). Every
+# functional use still operates on the untouched path.
 _display_path() {
     case "$1" in
         "$HOME"/*) printf '~%s' "${1#"$HOME"}" ;;
@@ -78,15 +58,11 @@ _usage_error() {
     exit 2
 }
 
-# The log timestamps are "MMDD HH:MM:SS" and carry no year, so date parsing is
-# not possible; a 10-digit key compared numerically is the only workable form.
-# Separators are stripped first so 0801 / "08-01" / "0801 12:00" normalize the
-# same way, without a per-format special case (CPR-UNV).
+# Log timestamps are "MMDD HH:MM:SS" with no year, so a numerically compared
+# 10-digit key replaces date parsing; separators are stripped first so every
+# accepted spelling normalizes the same way (CPR-UNV).
 #
-# Strips one leading '0' from a 2-digit field so plain shell arithmetic never
-# sees a leading zero: POSIX arithmetic parses that as octal and would reject
-# valid fields like "08"/"09". Returns via STRIPPED0 (see NORMALIZED_SPEC
-# above for why globals, not stdout).
+# Drops one leading '0' so POSIX arithmetic does not read "08"/"09" as octal.
 _strip_lead0() {
     case "$1" in
         0?) STRIPPED0="${1#0}" ;;
@@ -94,9 +70,8 @@ _strip_lead0() {
     esac
 }
 
-# Range-checks the padded 10-digit MMDDHHMMSS key field by field, so
-# "2025-08-01" (which strips to month "20") is rejected instead of silently
-# becoming a wrong range. Field slicing mirrors _format_key above.
+# Field-by-field range check, so "2025-08-01" (month "20" after stripping) is
+# rejected instead of silently becoming a wrong range.
 _validate_spec_fields() {
     _vf_side="$1"
     _vf_raw="$2"
@@ -118,9 +93,8 @@ _validate_spec_fields() {
     [ "$STRIPPED0" -ge 0 ] && [ "$STRIPPED0" -le 59 ] || _usage_error "invalid --$_vf_side value: $_vf_raw (second $_vf_ss out of range 00-59)"
 }
 
-# Result is returned in NORMALIZED_SPEC rather than on stdout: _usage_error
-# exits, and an exit from inside a command substitution would only leave the
-# subshell.
+# Returns via NORMALIZED_SPEC, not stdout: _usage_error's exit inside a command
+# substitution would only leave the subshell.
 _normalize_spec() {
     _ns_side="$1"
     _ns_raw="$2"
@@ -196,19 +170,15 @@ if [ ! -f "$LOG_FILE" ]; then
     exit 1
 fi
 
-# Single awk pass. The whole report (headers included) is emitted from END so
-# that line order is owned by one process: no external filter, no pipe, and
-# therefore no way for a child to write to the shared fd ahead of awk.
-# Zero matching lines is not an error — a zero-filled report is printed so that
-# the before/after diff stays line-aligned.
+# Single awk pass; the whole report is emitted from END so one process owns
+# line order (no pipe, no child racing on the shared fd). Zero matching lines
+# prints a zero-filled report, keeping the before/after diff line-aligned.
 LOGDISPLAY="$(_display_path "$LOG_FILE")"
 awk -v LOGPATH="$LOGDISPLAY" -v SINCE="$SINCE_KEY" -v UNTIL="$UNTIL_KEY" \
     -v REQ_SINCE="$REQ_SINCE" -v REQ_UNTIL="$REQ_UNTIL" '
-# Insertion sort, ascending by name. Row order must be the reason NAME and
-# never a quantity: the report is meant to be diffed, and a volume ranking
-# flips between runs, filling the diff with pure reordering noise.
-# Comparison forces string context ("" x) because awk compares numeric-looking
-# strings numerically otherwise.
+# Insertion sort, ascending by name — never by quantity, whose ranking flips
+# between runs and fills the diff with reordering noise. ("" x) forces string
+# context, which awk would otherwise drop for numeric-looking values.
 function isort(a, n,    i, j, key) {
     for (i = 2; i <= n; i++) {
         key = a[i]
@@ -226,10 +196,8 @@ function share(part, total) {
 function avg(sum, n) {
     return (n > 0 ? sum / n : 0)
 }
-# Output hygiene for log-derived tokens (reason=, unit) reaching a printf
-# argument: non-printable bytes (raw ESC/CR etc.) are replaced so they never
-# reach the terminal, and the token is truncated to the reason column width
-# so an oversized value cannot shift the fixed-width diff contract.
+# Hygiene for log-derived tokens reaching printf: non-printable bytes never
+# reach the terminal, and truncation keeps the fixed-width columns intact.
 function sanitize(s) {
     gsub(/[^ -~]/, "?", s)
     if (length(s) > 14) s = substr(s, 1, 14)
@@ -255,9 +223,8 @@ $1 ~ /^[0-9][0-9][0-9][0-9]$/ && $2 ~ /^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]$/ {
     }
     obs_n++
 
-    # [1] prompt processing. The field count varies (8 or 9, depending on the
-    # TOOLS token), so the duration is located by text and read as the token
-    # right after it — never by field index.
+    # [1] prompt processing. Field count varies (the TOOLS token), so the
+    # duration is located by text, never by field index.
     p = index($0, "prompt done ")
     if (p > 0) {
         rest = substr($0, p + 12)
@@ -273,8 +240,7 @@ $1 ~ /^[0-9][0-9][0-9][0-9]$/ && $2 ~ /^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]$/ {
         }
     }
 
-    # [2] live kv cache miss. The source format has a variable prefix, so the
-    # values are picked up by scanning fields for their key= prefix.
+    # [2] live kv cache miss. Variable prefix, so values are found by key=.
     if (index($0, "live kv cache miss") > 0) {
         m_total++
         r = ""; c = ""
@@ -295,9 +261,8 @@ $1 ~ /^[0-9][0-9][0-9][0-9]$/ && $2 ~ /^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]$/ {
         }
     }
 
-    # [3] kv cache stored. The trailing space in the predicate keeps a future
-    # "kv cache stored-" style message from matching by accident. Evicted lines
-    # deliberately have no section: they are deletions, not writes.
+    # [3] kv cache stored. The trailing space keeps a future "kv cache stored-"
+    # message from matching. Evicted lines are deletions, so they have no row.
     if (index($0, "kv cache stored ") > 0) {
         r = ""; sz = ""; unit = ""
         for (i = 1; i <= NF; i++) {
@@ -312,9 +277,8 @@ $1 ~ /^[0-9][0-9][0-9][0-9]$/ && $2 ~ /^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]$/ {
         scnt[r]++
         s_total_c++
         if (sz != "") {
-            # Only MiB is accumulated. Any other unit is counted separately and
-            # surfaced in the warnings line, so a log format change cannot
-            # silently under-report write volume (CPR-UNV).
+            # Only MiB accumulates; other units go to the warnings line, so a
+            # format change cannot silently under-report volume (CPR-UNV).
             if (unit == "MiB") {
                 smib[r] += sz + 0
                 s_total_m += sz + 0
@@ -368,13 +332,11 @@ END {
         r = skeys[i]
         printf(ROW5, sanitize(r), scnt[r], smib[r] + 0, (smib[r] + 0) / 1024.0, avg(smib[r] + 0, scnt[r]))
     }
-    # TOTAL is always printed, even with no rows above it, so its presence
-    # never shifts diff lines.
+    # Always printed, even with no rows above it, so it never shifts the diff.
     printf(ROW5, "TOTAL", s_total_c + 0, s_total_m + 0, (s_total_m + 0) / 1024.0, avg(s_total_m + 0, s_total_c + 0))
     printf("\n")
 
-    # The warnings line is always printed ("none" when clean) for the same
-    # reason: a warning must not shift the line count of the rest of the report.
+    # Same reason: "none" when clean, so a warning never shifts the line count.
     if (unk > 0) {
         isort(ukeys, unk)
         w = ""
@@ -387,7 +349,5 @@ END {
     }
 }
 ' < "$LOG_FILE"
-# The log path is fed by redirection, not as a trailing operand: POSIX awk
-# treats an operand containing "=" as a name=value assignment rather than a
-# filename, so a log literally named "SINCE=..." would be silently consumed
-# as a variable override and awk would fall back to reading stdin.
+# Redirection, not a trailing operand: POSIX awk reads an operand containing
+# "=" as a variable assignment, so such a filename would be silently swallowed.

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -6,7 +6,7 @@ set -eu
 _ds4_cmd() {
     case "$1" in
         proxy)
-            echo "uv run python -m proxy.server"
+            echo "PYTHONUNBUFFERED=1 uv run python -m proxy.server"
             ;;
         server)
             HOST="${DS4_SERVER_HOST:-127.0.0.1}"

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -16,7 +16,7 @@ _ds4_cmd() {
                     exit 1
                     ;;
             esac
-            echo "caffeinate -ism ./ds4-server --metal --quality --ctx 393216 --kv-disk-dir \"$HOME/Library/Caches/ds4-server/kv\" --kv-disk-space-mb 32768 --kv-cache-cold-max-tokens 90000 --kv-cache-continued-interval-tokens 25000 --warm-weights --host \"$HOST\""
+            echo "caffeinate -ism ./ds4-server --metal --quality --ctx 393216 --kv-disk-dir \"$HOME/Library/Caches/ds4-server/kv\" --kv-disk-space-mb 32768 --kv-cache-cold-max-tokens 90000 --kv-cache-continued-interval-tokens 50000 --warm-weights --batched-session 2 --host \"$HOST\""
             ;;
     esac
 }

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -6,7 +6,7 @@ set -eu
 _ds4_cmd() {
     case "$1" in
         proxy)
-            echo "PYTHONUNBUFFERED=1 uv run python -m proxy.server"
+            echo "env PYTHONUNBUFFERED=1 uv run python -m proxy.server"
             ;;
         server)
             HOST="${DS4_SERVER_HOST:-127.0.0.1}"

--- a/tests/feature-18-ds4ctl/test-server-flags.sh
+++ b/tests/feature-18-ds4ctl/test-server-flags.sh
@@ -8,14 +8,14 @@
 #
 # Skips (exit 77) until scripts/lib/lifecycle.sh exists.
 # TL3 gap (what this test does NOT catch):
-# - whether the real ds4-server binary actually accepts `--batched-session 2` (an unknown option exits 2)
+# - whether the real binary accepts `--batched-session 2` (unknown option = 2)
 # - whether the running launchd LaunchAgent picks up the new flags
-# Closest-to-action mitigation: verified at user_verification via a non-destructive
-# `ds4-server --help`-based flag-acceptance check before commit, and via `ps -o args=`
-# after the post-merge restart.
+# Mitigated at user_verification by a `ds4-server --help` acceptance check, and
+# by `ps -o args=` after the post-merge restart.
 set -u
 
-# REPO is derived from $0's logical location (no symlink target resolution - see test-repo-derivation.sh); export REPO=<path> to point at another checkout.
+# REPO comes from $0's logical location (no symlink resolution — see
+# test-repo-derivation.sh); export REPO=<path> to use another checkout.
 REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
 LIFECYCLE="$REPO/scripts/lib/lifecycle.sh"
 
@@ -24,21 +24,20 @@ LIFECYCLE="$REPO/scripts/lib/lifecycle.sh"
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 WORK="$(mktemp -d)"
-# Pin DOTENV_FILE into this test's tmpdir so the real repo dotenv is never
-# read; seed it with a stub auth token so the start guard sees a value.
+# Pinned into this test's tmpdir so the real dotenv is never read; the stub
+# token is there so the start guard sees a value.
 export DOTENV_FILE="$WORK/dotenv"
 printf 'DS4_PROXY_AUTH_TOKEN=test-token\n' > "$DOTENV_FILE"
 trap 'rm -rf "$WORK"' EXIT
 
-# _ds4_cmd server interpolates $HOME (--kv-disk-dir) and $HOST (from
-# DS4_SERVER_HOST, default 127.0.0.1). Pin both so the expected literal below is
-# deterministic; unsetting DS4_SERVER_HOST exercises the default branch.
+# _ds4_cmd server interpolates $HOME and $HOST; both are pinned so the expected
+# literal is deterministic, and unsetting DS4_SERVER_HOST takes the default.
 export HOME="$WORK/home"
 mkdir -p "$HOME"
 unset DS4_SERVER_HOST
 
-# lifecycle.sh starts with `set -eu`, which would leak into this shell if sourced
-# directly — isolate it in a subshell and capture only the command string.
+# lifecycle.sh's `set -eu` would leak into this shell if sourced directly, so
+# it is isolated in a subshell and only the command string is captured.
 CMD="$(bash -c '. "$1"; _ds4_cmd server' _ "$LIFECYCLE")" || fail "_ds4_cmd server exited non-zero"
 
 EXPECT="caffeinate -ism ./ds4-server --metal --quality --ctx 393216 --kv-disk-dir \"$HOME/Library/Caches/ds4-server/kv\" --kv-disk-space-mb 32768 --kv-cache-cold-max-tokens 90000 --kv-cache-continued-interval-tokens 50000 --warm-weights --batched-session 2 --host \"127.0.0.1\""

--- a/tests/feature-18-ds4ctl/test-server-flags.sh
+++ b/tests/feature-18-ds4ctl/test-server-flags.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests: scripts/lib/lifecycle.sh
+# Tags: lifecycle, ds4ctl, scope:issue-specific
+#
+# Scenario: _ds4_cmd server emits the exact ds4-server launch flag string
+# (issue #34: --batched-session 2 added, --kv-cache-continued-interval-tokens
+# raised 25000 -> 50000); _ds4_cmd proxy is locked symmetrically.
+#
+# Skips (exit 77) until scripts/lib/lifecycle.sh exists.
+# TL3 gap (what this test does NOT catch):
+# - whether the real ds4-server binary actually accepts `--batched-session 2` (an unknown option exits 2)
+# - whether the running launchd LaunchAgent picks up the new flags
+# Closest-to-action mitigation: verified at user_verification via a non-destructive
+# `ds4-server --help`-based flag-acceptance check before commit, and via `ps -o args=`
+# after the post-merge restart.
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see test-repo-derivation.sh); export REPO=<path> to point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+LIFECYCLE="$REPO/scripts/lib/lifecycle.sh"
+
+[ -f "$LIFECYCLE" ] || { echo "SKIP: $LIFECYCLE not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+# Pin DOTENV_FILE into this test's tmpdir so the real repo dotenv is never
+# read; seed it with a stub auth token so the start guard sees a value.
+export DOTENV_FILE="$WORK/dotenv"
+printf 'DS4_PROXY_AUTH_TOKEN=test-token\n' > "$DOTENV_FILE"
+trap 'rm -rf "$WORK"' EXIT
+
+# _ds4_cmd server interpolates $HOME (--kv-disk-dir) and $HOST (from
+# DS4_SERVER_HOST, default 127.0.0.1). Pin both so the expected literal below is
+# deterministic; unsetting DS4_SERVER_HOST exercises the default branch.
+export HOME="$WORK/home"
+mkdir -p "$HOME"
+unset DS4_SERVER_HOST
+
+# lifecycle.sh starts with `set -eu`, which would leak into this shell if sourced
+# directly — isolate it in a subshell and capture only the command string.
+CMD="$(bash -c '. "$1"; _ds4_cmd server' _ "$LIFECYCLE")" || fail "_ds4_cmd server exited non-zero"
+
+EXPECT="caffeinate -ism ./ds4-server --metal --quality --ctx 393216 --kv-disk-dir \"$HOME/Library/Caches/ds4-server/kv\" --kv-disk-space-mb 32768 --kv-cache-cold-max-tokens 90000 --kv-cache-continued-interval-tokens 50000 --warm-weights --batched-session 2 --host \"127.0.0.1\""
+
+# --- A. Full-string equality lock (primary) ---------------------------------
+# Catches flag addition, removal, reordering, and value changes in one shot.
+[ "$CMD" = "$EXPECT" ] || fail "_ds4_cmd server command string does not match the expected launch flags
+  expected: $EXPECT
+  actual:   $CMD
+  If the ds4-server flags were changed intentionally, this test's expected value must be updated too."
+
+# --- B. Per-flag diagnostic assertions --------------------------------------
+# Deliberately overlapping with A: A reports the whole diff, B names the flag.
+case "$CMD" in
+    *"--batched-session 2"*) ;;
+    *) fail "--batched-session 2 is missing from the ds4-server launch command" ;;
+esac
+
+case "$CMD" in
+    *"--kv-cache-continued-interval-tokens 50000"*) ;;
+    *) fail "--kv-cache-continued-interval-tokens 50000 is missing from the ds4-server launch command" ;;
+esac
+
+case "$CMD" in
+    *"--kv-cache-continued-interval-tokens 25000"*)
+        fail "--kv-cache-continued-interval-tokens is still 25000 (expected 50000)" ;;
+esac
+
+# --- C. Sibling lock: the proxy branch (CPR-ORTH) ---------------------------
+# _ds4_cmd has exactly two branches; locking only `server` would be asymmetric.
+PROXY_CMD="$(bash -c '. "$1"; _ds4_cmd proxy' _ "$LIFECYCLE")" || fail "_ds4_cmd proxy exited non-zero"
+PROXY_EXPECT="env PYTHONUNBUFFERED=1 uv run python -m proxy.server"
+[ "$PROXY_CMD" = "$PROXY_EXPECT" ] || fail "_ds4_cmd proxy command string changed
+  expected: $PROXY_EXPECT
+  actual:   $PROXY_CMD
+  If the proxy launch command was changed intentionally, this test's expected value must be updated too."
+
+echo "PASS: test-server-flags"


### PR DESCRIPTION
## Summary

Measured over `0713 00:50:27 .. 0811 07:21:29`, ds4-server showed two problems sharing one cause. Prompt processing ran 3054 times for 34.10 h, but the 349 runs over 60 s accounted for 30.67 h — 90% of all prefill time sat in a tenth of the requests. KV disk writes totalled 879.31 GiB, of which `reason=evict` was 475.00 GiB (54%) and `reason=continued` 325.94 GiB (37%).

The link is the single live KV slot: all 548 live-cache misses were `token-mismatch` and 55.1% shared under 1000 tokens of common prefix, i.e. the slot had been handed to an unrelated request. Every time the main conversation, a sub-agent and a one-off small prompt interleave, the resident prefix is discarded — which both forces the next cold prefill and writes the evicted checkpoint to disk.

## Changes

- `scripts/lib/lifecycle.sh`: add `--batched-session 2` so a second KV session stays resident, and raise `--kv-cache-continued-interval-tokens` from 25000 to 50000.
- `scripts/kvcache-report.sh` (new): POSIX sh + BSD awk aggregator for `kvcache.log`, with `--since` / `--until` windows so before/after runs compare via `diff`.
- `tests/feature-18-ds4ctl/test-server-flags.sh` (new): locks the full `_ds4_cmd server` flag string by exact equality.
- `docs/tuning.md`, `docs/ops.md`: document both flags, add the report script to the monitoring table, and correct the launchd restart procedure.

Started at N=2 rather than N=3 because the premise for sizing N (~1.3 GB per KV session) is a derived figure that has never been measured. `--prefill-chunk`, `--quality` on/off and `--mixed-prefill-quantum` are deferred to #37 so they do not confound the measurement of these two flags.

## Cutover keys

- before: `scripts/kvcache-report.sh --until "0811 07:21:29"`
- after: `scripts/kvcache-report.sh --since <post-restart timestamp>` — recorded as a comment on #37 right after the post-merge restart.

Closes #34
<!-- issue-close-pr-of: 34 -->