### PR TITLE
fix(ccgw): model-routing keys always come from .env via DOTENV_FORCE_KEYS

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -117,3 +117,12 @@ Changes: Renamed `ds4-proxy` to `ccgw-proxy` and the shared `DS4_*` env vars to 
 ### FEATURE: PR #57 — feature/56-cc-local-llm (2026-08-18, ffdd8e882338b151f3a22e8f71d8a637f0359997, #57)
 Background: feature/56 cc local llm
 Changes: #56: Added native `#@if windows` / `#@if posix` / `#@endif` OS-conditional-block marker support to cc-local-llm's `.env` loading — the POSIX (`scripts/lib/load-dotenv.sh`) and PowerShell (`scripts/code-ccgw.ps1`) loaders now filter blocks by platform token, so a single `.env` (shared across machines via a symlink to a centrally-managed private dotfiles store) can carry both Windows and macOS/Linux values. Added SSOT spec `docs/env-conditional-blocks.md`; `.env.example`'s `CCGW_CA_CERT` entry converted to marker form as the reference example. <!-- compose-doc-append-sentinel: branch=feature/56-cc-local-llm pr=#57 -->
+
+### BUGFIX: ccgw model-routing keys always come from .env (stale shell value was overriding the opus tier on Windows) (2026-08-22)
+
+Background: The Windows launcher (scripts/code-ccgw.ps1) loaded .env with 'shell value wins over .env', so a stale inherited LITELLM_OPUS_MODEL left in the launching shell could override .env's correct value. On this machine .env carried qwen3-next-80b-a3b-thinking but the /model opus tier showed qwen3-coder-next-80b-a3b, diverging from the Mac/gateway side which used the .env value.
+
+Changes: Added an opt-in DOTENV_FORCE_KEYS (space-separated, NON-exported) to scripts/lib/load-dotenv.sh so .env always wins for listed keys; scripts/code-ccgw.sh sets it for the 5 model-routing keys (LITELLM_HAIKU_MODEL, LITELLM_SONNET_MODEL, LITELLM_FABLE_MODEL, LITELLM_OPUS_MODEL, CCGW_SUBAGENT_MODEL) and scripts/code-ccgw.ps1 mirrors it with $ModelRoutingKeys. Loaders that never set the list keep the default shell-value-wins behavior. Also fixed a pre-existing harness bug in tests/feature-18-serverctl/test-load-dotenv-os-blocks.sh: run_dotenv expanded $@ without shifting away $1/$2, leaking the dotenv-file/stub-dir into env's positional args so every case produced an empty env dump; added cases 14/15 locking the DOTENV_FORCE_KEYS opt-in behavior.
+
+Test gap: no test asserted the model-routing keys take .env over a stale shell value; the loader test's run_dotenv also had an unshifted $@ that made all its cases fail with an empty dump
+

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -323,7 +323,10 @@ the per-tier model aliases (the tier table under "Client (macOS / Linux)" applie
 direct CCGW Proxy path is retired, so an unset `LITELLM_ANTHROPIC_BASE_URL` or
 `LITELLM_CLIENT_KEY` is an error and the wrapper exits rather than falling back to a placeholder
 that would surface later as a confusing 401. A value set in the shell takes precedence over
-`.env`. `LITELLM_VIRTUAL_KEY` is still accepted in place of `LITELLM_CLIENT_KEY` for one release,
+`.env` — except for the model-routing keys (`LITELLM_HAIKU_MODEL`, `LITELLM_SONNET_MODEL`,
+`LITELLM_FABLE_MODEL`, `LITELLM_OPUS_MODEL`, `CCGW_SUBAGENT_MODEL`), which always come from `.env`
+so a stale inherited shell value (e.g. an old `LITELLM_OPUS_MODEL` from a previous launch) cannot
+override the repo's intent. `LITELLM_VIRTUAL_KEY` is still accepted in place of `LITELLM_CLIENT_KEY` for one release,
 with a warning. `CCGW_CA_CERT` must point at `<mkcert -CAROOT>\rootCA.pem` so Node trusts the
 gateway certificate (if unset the wrapper warns and TLS will not be trusted). `.env` may carry
 `#@if windows` / `#@if posix` / `#@endif` blocks so one file holds both platforms' values — see

--- a/scripts/code-ccgw.ps1
+++ b/scripts/code-ccgw.ps1
@@ -52,9 +52,13 @@ function ConvertFrom-OsConditionalLines {
 
 # Load the repo-root .env (gitignored) so the real Mac LAN IP is never committed.
 # Format: KEY=value, one per line, # comment lines allowed. A value already set in
-# the shell takes precedence over .env. See .env.example for the supported keys.
+# the shell takes precedence over .env -- EXCEPT for $ModelRoutingKeys, which must
+# always come from .env so a stale inherited shell value (e.g. an old
+# LITELLM_OPUS_MODEL from a previous launch) can never override the repo's intent.
+# See .env.example for the supported keys.
 # .env may also carry #@if windows / #@if posix / #@endif blocks (docs/env-conditional-blocks.md).
 $EnvFile = Join-Path (Join-Path $PSScriptRoot '..') '.env'
+$ModelRoutingKeys = @('LITELLM_HAIKU_MODEL', 'LITELLM_SONNET_MODEL', 'LITELLM_FABLE_MODEL', 'LITELLM_OPUS_MODEL', 'CCGW_SUBAGENT_MODEL')
 if (Test-Path -LiteralPath $EnvFile) {
     $IsWindowsPlatform = if (Test-Path variable:IsWindows) { $IsWindows } else { $true }
     $ActiveToken = if ($IsWindowsPlatform) { 'windows' } else { 'posix' }
@@ -68,8 +72,9 @@ if (Test-Path -LiteralPath $EnvFile) {
         $value = $trimmed.Substring($split + 1).Trim()
         # Shell value wins, but only when non-empty: a defined-but-empty variable is
         # indistinguishable from an unset one for every consumer below, so treating it
-        # as "already set" would silently discard the .env value.
-        if (-not [string]::IsNullOrEmpty([Environment]::GetEnvironmentVariable($key))) { continue }
+        # as "already set" would silently discard the .env value. Model-routing keys
+        # are the exception: they always take the .env value (see $ModelRoutingKeys).
+        if (-not ($ModelRoutingKeys -contains $key) -and -not [string]::IsNullOrEmpty([Environment]::GetEnvironmentVariable($key))) { continue }
         Set-Item -Path "env:$key" -Value $value
     }
 }

--- a/scripts/code-ccgw.sh
+++ b/scripts/code-ccgw.sh
@@ -19,6 +19,12 @@ SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 CCGW_SCRIPT_DIR="$SCRIPT_DIR"
 # shellcheck source=scripts/lib/root.sh
 . "$SCRIPT_DIR/lib/root.sh"
+# The model-routing keys must ALWAYS come from .env: a stale inherited shell
+# value (e.g. an old LITELLM_OPUS_MODEL left over from a previous launch) must
+# never override the repo's .env intent. DOTENV_FORCE_KEYS is deliberately
+# NON-exported -- it is consumed only by lib/load-dotenv.sh, and leaking it into
+# the child (VS Code) environment would be noise.
+DOTENV_FORCE_KEYS="LITELLM_HAIKU_MODEL LITELLM_SONNET_MODEL LITELLM_FABLE_MODEL LITELLM_OPUS_MODEL CCGW_SUBAGENT_MODEL"
 # shellcheck source=scripts/lib/load-dotenv.sh
 . "$SCRIPT_DIR/lib/load-dotenv.sh"
 

--- a/scripts/lib/load-dotenv.sh
+++ b/scripts/lib/load-dotenv.sh
@@ -45,6 +45,18 @@ _dotenv_filter_os_blocks() {
     ' "$1"
 }
 
+# Return 0 if $1 names a key in $DOTENV_FORCE_KEYS (a space-separated list the
+# caller may set, NON-exported, to make .env always win for those keys). This is
+# the opt-in escape hatch for keys that must come from .env regardless of a
+# stale shell value -- e.g. the ccgw model-routing keys. Loaders that never set
+# it keep the default "shell value wins" behavior unchanged.
+_dotenv_force_key() {
+    case " $DOTENV_FORCE_KEYS " in
+        *" $1 "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Return 0 if the environment variable named by $1 is already set (matches the
 # "shell value wins" semantics: an exported value is what the child would see).
 _dotenv_is_set() {
@@ -64,8 +76,10 @@ if [ -f "$DOTENV_FILE" ]; then
         if [ -z "$_dotenv_key" ] || [ "$_dotenv_key" = "$_dotenv_line" ]; then
             continue
         fi
-        # Export only when the variable is not already set in the environment.
-        if ! _dotenv_is_set "$_dotenv_key"; then
+        # Export only when the variable is not already set in the environment,
+        # UNLESS it is a forced key (DOTENV_FORCE_KEYS) -- those always take the
+        # .env value so a stale shell value cannot override the repo's intent.
+        if _dotenv_force_key "$_dotenv_key" || ! _dotenv_is_set "$_dotenv_key"; then
             export "$_dotenv_key=$_dotenv_val"
         fi
     done <<EOF

--- a/tests/feature-18-serverctl/test-load-dotenv-os-blocks.sh
+++ b/tests/feature-18-serverctl/test-load-dotenv-os-blocks.sh
@@ -57,12 +57,17 @@ write_fixture_crlf() { # write_fixture_crlf <path> <line>...
 # `env` (the second/final one, printing the resulting environment) is what we
 # assert against: it captures exactly what the loader exported, without
 # re-implementing any of the loader's own parsing here.
-run_dotenv() { # run_dotenv <dotenv-file> <uname-stub-dir>
+run_dotenv() { # run_dotenv <dotenv-file> <uname-stub-dir> [extra-env-args...]
+    # Capture $1/$2 and shift them away so the remaining "$@" is exactly the
+    # optional extra env args (KEY=VALUE) -- without this shift, "$@" would also
+    # carry the dotenv file and stub dir, which env would mistake for its command.
     rm -f "$DUMP"
+    local _dotenv_file="$1" _stub_dir="$2"; shift 2
     env -i \
-        PATH="$2:/usr/bin:/bin" \
+        PATH="$_stub_dir:/usr/bin:/bin" \
         HOME="$WORK/home" \
-        DOTENV_FILE="$1" \
+        DOTENV_FILE="$_dotenv_file" \
+        "$@" \
         LOADER="$LOADER" \
         sh -c '. "$LOADER"; env' > "$DUMP" 2>"$WORK/err"
     RC=$?
@@ -257,5 +262,32 @@ write_fixture "$WORK/case13.env" \
     '#@endif'
 run_dotenv "$WORK/case13.env" "$POSIX_STUB"
 assert_env DUP_KEY first_value "case 13 (posix): the first physical occurrence wins; the loader skips re-setting an already-set var"
+
+# =============================================================================
+# --- DOTENV_FORCE_KEYS: the opt-in .env-always-wins escape hatch -------------
+# Default (no DOTENV_FORCE_KEYS): shell value wins over .env.
+# With DOTENV_FORCE_KEYS: .env wins for the listed keys even when the shell
+# already has a value.
+# [dotenv-force-keys: case 14]
+write_fixture "$WORK/case14.env" \
+    'ROUTING_KEY=from_dotenv' \
+    'PLAIN_KEY=plain_dotenv'
+# Default behavior: pre-set shell value wins.
+run_dotenv "$WORK/case14.env" "$WIN_STUB" 'ROUTING_KEY=from_shell' 'PLAIN_KEY=plain_shell'
+assert_env ROUTING_KEY from_shell "case 14 (default): without DOTENV_FORCE_KEYS, a pre-set shell value still wins over .env"
+assert_env PLAIN_KEY plain_shell "case 14 (default): plain keys keep the default shell-value-wins behavior"
+
+# Forced: the listed key takes .env even though the shell also has a value.
+run_dotenv "$WORK/case14.env" "$WIN_STUB" 'ROUTING_KEY=from_shell' 'PLAIN_KEY=plain_shell' 'DOTENV_FORCE_KEYS=ROUTING_KEY'
+assert_env ROUTING_KEY from_dotenv "case 14 (forced): DOTENV_FORCE_KEYS makes .env win for the listed key despite the shell value"
+assert_env PLAIN_KEY plain_shell "case 14 (forced): a key NOT in DOTENV_FORCE_KEYS keeps shell-value-wins"
+
+# --- Case 15: a forced key absent from .env is not invented -----------------
+# [dotenv-force-keys: case 15]
+write_fixture "$WORK/case15.env" \
+    'ROUTING_KEY=from_dotenv'
+run_dotenv "$WORK/case15.env" "$WIN_STUB" 'ROUTING_KEY=from_shell' 'OTHER_KEY=other_shell' 'DOTENV_FORCE_KEYS=OTHER_KEY'
+assert_env ROUTING_KEY from_shell "case 15: forcing a key that .env does not define leaves the shell value untouched"
+assert_env OTHER_KEY other_shell "case 15: a forced-but-absent-in-.env key keeps the shell value (nothing to override)"
 
 echo "PASS: test-load-dotenv-os-blocks"


### PR DESCRIPTION
## Summary
- Windows 上で code-ccgw.ps1 経由の opus モデルが LiteLLM 側（Mac）と食い違う不具合を修正。原因は「シェル既存値が .env より優先される」ローダー仕様のもと、PowerShell の親プロセスに残っていた stale な LITELLM_OPUS_MODEL が更新済みの .env の値を上書きしていたこと。
- scripts/lib/load-dotenv.sh に DOTENV_FORCE_KEYS（opt-in・空白区切り・非export）を追加し、モデルルーティング関連キー（LITELLM_HAIKU_MODEL / LITELLM_SONNET_MODEL / LITELLM_FABLE_MODEL / LITELLM_OPUS_MODEL / CCGW_SUBAGENT_MODEL）は stale なシェル値があっても常に .env が勝つようにした。
- テストを追加（case 14/15、DOTENV_FORCE_KEYS のデフォルト挙動と opt-in 挙動）。

## Test plan
- [x] tests/feature-18-serverctl/test-load-dotenv-os-blocks.sh がグリーン