### PR TITLE
fix(ccgw): isolate local-LLM routing env vars to the launched VS Code child process

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,3 +285,18 @@ the pin opt-in, and it takes a routing key that is passed through untranslated.
 The LiteLLM router is the implementation for the "Hybrid (router)" strategy, but with
 the caveat that it does not preserve an Anthropic subscription (the Opus leg goes to
 self-hosted DS4, not real Opus).
+
+### Child-process-only environment injection
+
+`code-ccgw.ps1` used to set routing values with `$env:`, mutating the invoking
+PowerShell process itself; Windows has no `exec`, so those values outlived the launch
+and leaked into whatever ran next in that shell, including unrelated cloud sessions
+(issue #66). It now overlays a `$ChildEnv` block onto the spawned VS Code process's
+`ProcessStartInfo.Environment` only — the parent's `$env:` is never written.
+
+The child still inherits the rest of the parent's environment, so stripping only
+`ANTHROPIC_API_KEY` was not enough: `CLAUDE_CODE_OAUTH_TOKEN`, the Bedrock/Vertex
+switches and their AWS/GCP credentials, and `NODE_TLS_REJECT_UNAUTHORIZED` are cleared
+too, so a real credential can't reach the local gateway's egress path. `code-ccgw.sh`
+execs rather than spawning, but the same ambient class would otherwise reach the
+replaced process unchanged, so it clears the same set.

--- a/scripts/code-ccgw.ps1
+++ b/scripts/code-ccgw.ps1
@@ -3,14 +3,18 @@
 # LiteLLM gateway; the direct CCGW Proxy route is retired, so there is exactly one path
 # and nothing to fall back to. An unconfigured base URL or credential is therefore an
 # error rather than a dummy default -- a dummy default only defers the failure to a
-# confusing 401 at request time. Isolates the VS Code process so the env does not bleed
-# into native subscription windows.
+# confusing 401 at request time. Because PowerShell has no exec, this script never writes
+# any ccgw/LiteLLM value into its own process's $env:; every such value is collected and
+# injected only into the launched VS Code child process's environment block, so the
+# invoking shell's environment is left untouched and nothing bleeds into a later native
+# subscription session started from that same shell (issue #66).
 # Rationale: docs/architecture.md; procedure: docs/ops.md#client-windows.
 #
 # POSIX counterpart: scripts/code-ccgw.sh. The two resolve the base URL, the auth token,
 # the CA and the model tiers identically. They differ where the platform forces it: the
 # VS Code profile path and the launch itself -- the POSIX script execs VS Code, this one
-# stays resident as its parent because PowerShell has no exec.
+# has no exec to hand off to, so it stays resident as the child's parent and passes the
+# environment through the child's process environment block instead of its own.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -50,6 +54,36 @@ function ConvertFrom-OsConditionalLines {
     return $out
 }
 
+# All values destined for the launched VS Code process are collected here and applied
+# only to that child process's environment block (ProcessStartInfo.Environment) -- never
+# to this script's own $env:, which would leak into the invoking shell and into every
+# later session started from it. PowerShell has no exec, so this is the only way to avoid
+# that leak (issue #66). Ordered so the overlay is applied in the order it was resolved.
+$ChildEnv = [ordered]@{}
+function Set-ChildEnv([string]$Name, [string]$Value) {
+    $ChildEnv[$Name] = $Value
+}
+
+# Reads the effective value of a variable, treating defined-but-empty as unset. A value
+# already collected for the child wins over the ambient process env, so every consumer
+# below reads back exactly what the child will receive.
+function Get-EnvOrNull([string]$Name) {
+    if ($ChildEnv.Contains($Name)) {
+        $collected = $ChildEnv[$Name]
+        if ([string]::IsNullOrEmpty($collected)) { return $null }
+        return $collected
+    }
+    $v = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrEmpty($v)) { return $null }
+    return $v
+}
+
+# Writes to stderr without the Write-Error machinery, so the message shape is the
+# launcher's own and the exit code stays under this script's control.
+function Write-LauncherError([string]$Message) {
+    [Console]::Error.WriteLine("[code-ccgw] $Message")
+}
+
 # Load the repo-root .env (gitignored) so the real Mac LAN IP is never committed.
 # Format: KEY=value, one per line, # comment lines allowed. A value already set in
 # the shell takes precedence over .env -- EXCEPT for $ModelRoutingKeys, which must
@@ -63,6 +97,11 @@ if (Test-Path -LiteralPath $EnvFile) {
     $IsWindowsPlatform = if (Test-Path variable:IsWindows) { $IsWindows } else { $true }
     $ActiveToken = if ($IsWindowsPlatform) { 'windows' } else { 'posix' }
     $filteredLines = ConvertFrom-OsConditionalLines -Lines (Get-Content -LiteralPath $EnvFile) -ActiveToken $ActiveToken
+    # Keys already claimed by an earlier line of this same .env, so a later duplicate
+    # cannot overwrite them (matches scripts/lib/load-dotenv.sh: first occurrence wins).
+    # The POSIX sibling gets this for free by exporting as it goes; here the collected
+    # values never touch the process env, so the rule needs its own record.
+    $claimedKeys = [System.Collections.Generic.HashSet[string]]::new()
     foreach ($line in $filteredLines) {
         $trimmed = $line.Trim()
         if ($trimmed -eq '' -or $trimmed.StartsWith('#')) { continue }
@@ -74,28 +113,45 @@ if (Test-Path -LiteralPath $EnvFile) {
         # indistinguishable from an unset one for every consumer below, so treating it
         # as "already set" would silently discard the .env value. Model-routing keys
         # are the exception: they always take the .env value (see $ModelRoutingKeys).
+        # This check deliberately reads the raw process env: the rule it enforces is
+        # about the value the invoking shell really carries. Reading is safe -- only
+        # writing to this process is what issue #66 forbids.
+        if ($claimedKeys.Contains($key)) { continue }
         if (-not ($ModelRoutingKeys -contains $key) -and -not [string]::IsNullOrEmpty([Environment]::GetEnvironmentVariable($key))) { continue }
-        Set-Item -Path "env:$key" -Value $value
+        [void]$claimedKeys.Add($key)
+        Set-ChildEnv $key $value
     }
 }
 
-# Reads an env var, treating defined-but-empty as unset.
-function Get-EnvOrNull([string]$Name) {
-    $v = [Environment]::GetEnvironmentVariable($Name)
-    if ([string]::IsNullOrEmpty($v)) { return $null }
-    return $v
-}
-
-# Writes to stderr without the Write-Error machinery, so the message shape is the
-# launcher's own and the exit code stays under this script's control.
-function Write-LauncherError([string]$Message) {
-    [Console]::Error.WriteLine("[code-ccgw] $Message")
-}
-
-# Clear any real Anthropic API key so the local backend is used instead. Assigning an
-# empty string removes the variable on Windows rather than exporting an empty one; both
-# read as "no key" to the client.
-$env:ANTHROPIC_API_KEY = ''
+# Credentials and routing switches that must never reach the child. The child talks to
+# exactly one endpoint -- the local LiteLLM gateway -- so any cloud/subscription
+# credential presented to it would either be forwarded onto the gateway's egress path or
+# redirect the child away from the gateway entirely. Whatever the invoking shell happens
+# to carry is therefore removed from the child's environment block rather than merely
+# left unset (an inherited value would otherwise pass straight through the overlay).
+# An empty collected value is what performs the removal; the invoking shell's own
+# variables are never read, cleared, or copied. Adding to the class is a one-line change.
+$StrippedCredentialVars = @(
+    # Cloud API / subscription credentials for the Anthropic-compatible client.
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    # Provider switches: either would send the child's traffic somewhere other than the
+    # gateway, past every setting resolved below.
+    'CLAUDE_CODE_USE_BEDROCK',
+    'CLAUDE_CODE_USE_VERTEX',
+    # Credentials those providers would pick up.
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_PROFILE',
+    'AWS_REGION',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    # TLS verification is pinned on: the gateway's certificate is trusted through
+    # NODE_EXTRA_CA_CERTS below, so an inherited NODE_TLS_REJECT_UNAUTHORIZED=0 (common
+    # while debugging other tools) would silently disable verification for no gain.
+    'NODE_TLS_REJECT_UNAUTHORIZED'
+)
+foreach ($stripped in $StrippedCredentialVars) { Set-ChildEnv $stripped '' }
 
 # --- Base URL --------------------------------------------------------------
 # The LiteLLM gateway is the only endpoint.
@@ -105,7 +161,7 @@ if ($null -eq $BaseUrl) {
     Write-LauncherError 'Set it to the LiteLLM gateway endpoint; see docs/ops.md.'
     exit 1
 }
-$env:ANTHROPIC_BASE_URL = $BaseUrl
+Set-ChildEnv 'ANTHROPIC_BASE_URL' $BaseUrl
 
 # --- Authentication --------------------------------------------------------
 # LiteLLM runs without a database, so no virtual keys exist: the client credential is
@@ -114,10 +170,10 @@ $env:ANTHROPIC_BASE_URL = $BaseUrl
 $ClientKey = Get-EnvOrNull 'LITELLM_CLIENT_KEY'
 $LegacyKey = Get-EnvOrNull 'LITELLM_VIRTUAL_KEY'
 if ($null -ne $ClientKey) {
-    $env:ANTHROPIC_AUTH_TOKEN = $ClientKey
+    Set-ChildEnv 'ANTHROPIC_AUTH_TOKEN' $ClientKey
 } elseif ($null -ne $LegacyKey) {
     Write-Warning '[code-ccgw] LITELLM_VIRTUAL_KEY is deprecated; rename it to LITELLM_CLIENT_KEY.'
-    $env:ANTHROPIC_AUTH_TOKEN = $LegacyKey
+    Set-ChildEnv 'ANTHROPIC_AUTH_TOKEN' $LegacyKey
 } else {
     Write-LauncherError 'ERROR: LITELLM_CLIENT_KEY is not set.'
     Write-LauncherError 'Set it to the LiteLLM gateway key; see docs/ops.md.'
@@ -126,10 +182,11 @@ if ($null -ne $ClientKey) {
 
 # --- TLS trust -------------------------------------------------------------
 # Point Node at the mkcert local CA root so it trusts the gateway certificate.
-# NODE_TLS_REJECT_UNAUTHORIZED=0 is deliberately NOT used.
+# NODE_TLS_REJECT_UNAUTHORIZED=0 is deliberately NOT used -- and an inherited one is
+# stripped from the child above ($StrippedCredentialVars), so it cannot arrive by accident.
 $CaCert = Get-EnvOrNull 'CCGW_CA_CERT'
 if ($null -ne $CaCert) {
-    $env:NODE_EXTRA_CA_CERTS = $CaCert
+    Set-ChildEnv 'NODE_EXTRA_CA_CERTS' $CaCert
 } else {
     $caroot = $null
     if (Get-Command mkcert -ErrorAction SilentlyContinue) {
@@ -138,7 +195,7 @@ if ($null -ne $CaCert) {
         $caroot = (& mkcert -CAROOT 2>$null | Select-Object -First 1)
     }
     if ($caroot -and (Test-Path -LiteralPath (Join-Path $caroot 'rootCA.pem'))) {
-        $env:NODE_EXTRA_CA_CERTS = Join-Path $caroot 'rootCA.pem'
+        Set-ChildEnv 'NODE_EXTRA_CA_CERTS' (Join-Path $caroot 'rootCA.pem')
     } else {
         Write-Warning '[code-ccgw] CCGW_CA_CERT not set; TLS certificate will not be trusted.'
     }
@@ -149,17 +206,28 @@ if ($null -ne $CaCert) {
 # verbatim. The launcher owns no backend names: inventing one would address a model the
 # gateway has no entry for, and the error would surface as a 400 from LiteLLM rather
 # than as a message from here.
+# Absence of a source key means "the child must not have the derived variable at all",
+# never "keep whatever the invoking shell happened to carry": a leftover
+# ANTHROPIC_MODEL from an earlier session would otherwise pin a tier the repo's .env
+# no longer names. Hence every conditional set has an explicit clearing else branch.
 $FableModel = Get-EnvOrNull 'LITELLM_FABLE_MODEL'
-if ($null -ne $FableModel) { $env:ANTHROPIC_DEFAULT_FABLE_MODEL = $FableModel }
+if ($null -ne $FableModel) { Set-ChildEnv 'ANTHROPIC_DEFAULT_FABLE_MODEL' $FableModel }
+else { Set-ChildEnv 'ANTHROPIC_DEFAULT_FABLE_MODEL' '' }
 $OpusModel = Get-EnvOrNull 'LITELLM_OPUS_MODEL'
-if ($null -ne $OpusModel) { $env:ANTHROPIC_DEFAULT_OPUS_MODEL = $OpusModel }
+if ($null -ne $OpusModel) { Set-ChildEnv 'ANTHROPIC_DEFAULT_OPUS_MODEL' $OpusModel }
+else { Set-ChildEnv 'ANTHROPIC_DEFAULT_OPUS_MODEL' '' }
 $SonnetModel = Get-EnvOrNull 'LITELLM_SONNET_MODEL'
-if ($null -ne $SonnetModel) { $env:ANTHROPIC_DEFAULT_SONNET_MODEL = $SonnetModel }
+if ($null -ne $SonnetModel) { Set-ChildEnv 'ANTHROPIC_DEFAULT_SONNET_MODEL' $SonnetModel }
+else { Set-ChildEnv 'ANTHROPIC_DEFAULT_SONNET_MODEL' '' }
 $HaikuModel = Get-EnvOrNull 'LITELLM_HAIKU_MODEL'
-if ($null -ne $HaikuModel) { $env:ANTHROPIC_DEFAULT_HAIKU_MODEL = $HaikuModel }
+if ($null -ne $HaikuModel) { Set-ChildEnv 'ANTHROPIC_DEFAULT_HAIKU_MODEL' $HaikuModel }
+else { Set-ChildEnv 'ANTHROPIC_DEFAULT_HAIKU_MODEL' '' }
 if ($null -ne $FableModel) {
-    $env:ANTHROPIC_MODEL = $FableModel
-    $env:ANTHROPIC_CUSTOM_MODEL_OPTION = $FableModel
+    Set-ChildEnv 'ANTHROPIC_MODEL' $FableModel
+    Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION' $FableModel
+} else {
+    Set-ChildEnv 'ANTHROPIC_MODEL' ''
+    Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION' ''
 }
 
 # Subagent routing is opt-in. LiteLLM multiplexes, so pinning every subagent to one tier
@@ -167,30 +235,190 @@ if ($null -ne $FableModel) {
 # agent definition's frontmatter declares. The value is a routing key, passed through
 # untranslated.
 $SubagentModel = Get-EnvOrNull 'CCGW_SUBAGENT_MODEL'
-if ($null -ne $SubagentModel) { $env:CLAUDE_CODE_SUBAGENT_MODEL = $SubagentModel }
+if ($null -ne $SubagentModel) { Set-ChildEnv 'CLAUDE_CODE_SUBAGENT_MODEL' $SubagentModel }
+else { Set-ChildEnv 'CLAUDE_CODE_SUBAGENT_MODEL' '' }
 
-$env:ANTHROPIC_CUSTOM_MODEL_OPTION_NAME = 'Local model via ccgw'
-$env:ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION = 'Mac backend via the LiteLLM gateway, selected per request'
+Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION_NAME' 'Local model via ccgw'
+Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION' 'Mac backend via the LiteLLM gateway, selected per request'
 
-$env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = '1'
-$env:CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK = '1'
-$env:CLAUDE_STREAM_IDLE_TIMEOUT_MS = '600000'
+Set-ChildEnv 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC' '1'
+Set-ChildEnv 'CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK' '1'
+Set-ChildEnv 'CLAUDE_STREAM_IDLE_TIMEOUT_MS' '600000'
 
 # Align auto-compaction with the tightest backend ceiling (64K for Qwen on this PC).
 # The Mac backends compact earlier than necessary but do not error. A single env var
 # cannot differentiate per-tier -- 64K is the safe floor.
-$env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = '65536'
-$env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '75'
+Set-ChildEnv 'CLAUDE_CODE_AUTO_COMPACT_WINDOW' '65536'
+Set-ChildEnv 'CLAUDE_AUTOCOMPACT_PCT_OVERRIDE' '75'
 
 # Launch VS Code in an isolated process. A distinct --user-data-dir starts a separate
 # VS Code instance; VS Code otherwise shares one process (and one environment) across
 # all windows of a user-data-dir, which would leak this env into native windows.
-if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
+# Application-only resolution: a function/alias/script named "code" would not be a real
+# executable Process.Start can launch.
+# The indexing must be guarded rather than done inline: under Set-StrictMode -Version
+# Latest, [0] on the empty array Get-Command returns when "code" is absent throws a
+# terminating index-out-of-bounds error before the intended message below can run.
+$codeCmdMatches = @(Get-Command code -CommandType Application -ErrorAction SilentlyContinue)
+$codeCmd = if ($codeCmdMatches.Count -gt 0) { $codeCmdMatches[0] } else { $null }
+if (-not $codeCmd) {
     Write-LauncherError "ERROR: 'code' command not found on PATH."
     Write-LauncherError "In VS Code run: Shell Command: Install 'code' command in PATH"
     exit 1
 }
+
 # LOCALAPPDATA is always set on Windows, but a stripped service environment (or pwsh on
 # another OS) would otherwise make Join-Path throw here, after all the work is done.
 $appData = if ([string]::IsNullOrEmpty($env:LOCALAPPDATA)) { Join-Path (Join-Path $HOME '.local') 'share' } else { $env:LOCALAPPDATA }
-& code --user-data-dir (Join-Path $appData 'vscode-ccgw') @args
+$codeArgs = @('--user-data-dir', (Join-Path $appData 'vscode-ccgw')) + $args
+
+# The resolved "code" command is a .cmd on every real install (VS Code ships code.cmd),
+# and Win32 CreateProcess() implicitly re-invokes cmd.exe to interpret .cmd/.bat targets
+# (the "BatBadBut" vulnerability class). CommandLineToArgvW-style quoting, which is
+# correct for .exe targets, does NOT protect against cmd.exe metacharacters like
+# &,|,^,<,>,% -- those need a separate, cmd.exe-specific escaping scheme. Both branches
+# are kept (rather than assuming .cmd) so an .exe-resolved "code" in some other
+# environment is still handled correctly (CPR-UNV).
+$ext = [System.IO.Path]::GetExtension($codeCmd.Source)
+$isBatchTarget = ($ext -ieq '.cmd') -or ($ext -ieq '.bat')
+
+# Formats a single argument per CommandLineToArgvW quoting rules, for direct (non-cmd.exe)
+# process launches.
+function ConvertTo-ArgvQuotedArgument([string]$Arg) {
+    if ($Arg.Length -gt 0 -and $Arg -notmatch '[\s"]') { return $Arg }
+    $sb = New-Object System.Text.StringBuilder
+    [void]$sb.Append('"')
+    for ($i = 0; $i -lt $Arg.Length; $i++) {
+        $backslashes = 0
+        while ($i -lt $Arg.Length -and $Arg[$i] -eq '\') { $backslashes++; $i++ }
+        if ($i -eq $Arg.Length) {
+            [void]$sb.Append('\' * ($backslashes * 2))
+            break
+        } elseif ($Arg[$i] -eq '"') {
+            [void]$sb.Append('\' * ($backslashes * 2 + 1))
+            [void]$sb.Append('"')
+        } else {
+            [void]$sb.Append('\' * $backslashes)
+            [void]$sb.Append($Arg[$i])
+        }
+    }
+    [void]$sb.Append('"')
+    return $sb.ToString()
+}
+
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+
+if ($isBatchTarget) {
+    # cmd.exe will re-parse the command line regardless of what we pass, so every
+    # argument must be escaped for cmd.exe's own grammar (the BatBadBut-recommended
+    # recipe), not just for CommandLineToArgvW: double embedded quotes, double a
+    # run of backslashes immediately before a quote, replace % (percent expansion)
+    # with a self-referential substring expansion that always yields a literal %, and
+    # wrap the whole argument in quotes. An embedded newline cannot be escaped at all
+    # -- cmd.exe truncates its command line at the first newline and would silently run
+    # only part of it, so that case is rejected before the launch instead of being
+    # passed through partially.
+    foreach ($a in $codeArgs) {
+        if ($a -match "`r|`n") {
+            Write-LauncherError "ERROR: an argument to 'code' contains a newline, which cmd.exe cannot pass through safely."
+            exit 1
+        }
+    }
+
+    # Backslash doubling and quote doubling must happen in one left-to-right pass:
+    # CommandLineToArgvW doubles a backslash run only where it immediately precedes a
+    # quote (or the closing quote), so doubling quotes first and then patching only a
+    # trailing backslash run misses every run before an interior quote and lets the
+    # parser run past the argument boundary. The % pass stays separate -- it does not
+    # interact with backslash/quote escaping.
+    function ConvertTo-BatchSafeArgument([string]$Arg) {
+        $sb = New-Object System.Text.StringBuilder
+        for ($i = 0; $i -lt $Arg.Length; $i++) {
+            $backslashes = 0
+            while ($i -lt $Arg.Length -and $Arg[$i] -eq '\') { $backslashes++; $i++ }
+            if ($i -eq $Arg.Length) {
+                [void]$sb.Append('\' * ($backslashes * 2))
+                break
+            } elseif ($Arg[$i] -eq '"') {
+                [void]$sb.Append('\' * ($backslashes * 2))
+                [void]$sb.Append('""')
+            } else {
+                [void]$sb.Append('\' * $backslashes)
+                [void]$sb.Append($Arg[$i])
+            }
+        }
+        $s = $sb.ToString()
+        # %%cd:~,% expands to a literal % followed by the empty substring of %CD%, so a
+        # % in the value can never start an expansion of its own -- a caret cannot
+        # escape %, and percent expansion runs before caret processing anyway.
+        $s = $s.Replace('%', '%%cd:~,%')
+        return '"' + $s + '"'
+    }
+    function ConvertTo-BatchSafeCommandLine([string]$TargetPath, [string[]]$Arguments) {
+        $parts = @((ConvertTo-BatchSafeArgument $TargetPath))
+        foreach ($a in $Arguments) { $parts += (ConvertTo-BatchSafeArgument $a) }
+        return ($parts -join ' ')
+    }
+
+    $comSpec = [Environment]::GetEnvironmentVariable('ComSpec')
+    if ([string]::IsNullOrEmpty($comSpec)) { $comSpec = Join-Path $env:SystemRoot 'System32\cmd.exe' }
+    $psi.FileName = $comSpec
+    $inner = ConvertTo-BatchSafeCommandLine -TargetPath $codeCmd.Source -Arguments $codeArgs
+    # /d disables AutoRun registry-key code injection; /v:off disables delayed
+    # expansion so embedded !...! sequences in an argument cannot be misinterpreted;
+    # /s enables the documented cmd.exe /C behavior where, when the text following
+    # /C starts and ends with a quote, only that single outer quote pair is stripped
+    # and the remainder is not reinterpreted -- which is what makes wrapping $inner
+    # in one quote pair here mean what ConvertTo-BatchSafeCommandLine intended.
+    $psi.Arguments = '/d /s /v:off /c "' + $inner + '"'
+} else {
+    $psi.FileName = $codeCmd.Source
+    $psi.Arguments = ($codeArgs | ForEach-Object { ConvertTo-ArgvQuotedArgument $_ }) -join ' '
+}
+
+# cmd.exe stops reading its command line at roughly 8191 characters and truncates the
+# rest silently rather than failing, so a too-long argument list would open a path that
+# ends mid-word. The launch is fire-and-forget and never sees cmd.exe's exit code, so
+# the only place that can still catch this is here, before the launch. The ceiling
+# belongs to the cmd.exe route alone -- a direct .exe launch is bounded by
+# CreateProcess's far larger 32767 instead.
+if ($isBatchTarget) {
+    $CmdExeCommandLineLimit = 8191
+    # The command line CreateProcess assembles is the quoted FileName, a space, then
+    # Arguments -- hence the three characters added to the two lengths.
+    $commandLineLength = $psi.FileName.Length + 3 + $psi.Arguments.Length
+    if ($commandLineLength -gt $CmdExeCommandLineLimit) {
+        Write-LauncherError "ERROR: the command line is too long for cmd.exe ($commandLineLength characters; the limit is $CmdExeCommandLineLimit)."
+        Write-LauncherError "Pass fewer or shorter arguments to 'code'."
+        exit 1
+    }
+}
+
+# UseShellExecute must be false for both Arguments and Environment to be honored at all,
+# and a shell-execute launch would additionally re-introduce a shell to re-parse what was
+# just escaped.
+$psi.UseShellExecute = $false
+$psi.WorkingDirectory = if ($PWD.Provider.Name -eq 'FileSystem') { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
+
+# $psi.Environment starts pre-populated with this process's own (inherited) environment;
+# only the collected ccgw/LiteLLM values are overlaid on top of it, so the child still
+# inherits everything else -- PATH, LOCALAPPDATA, ... -- as it would with a plain
+# `& code` call. An empty collected value means "the child must not have this variable
+# at all", which is how ANTHROPIC_API_KEY is kept away from Claude Code without the
+# invoking shell's own key ever being touched.
+foreach ($name in @($ChildEnv.Keys)) {
+    if ([string]::IsNullOrEmpty($ChildEnv[$name])) { [void]$psi.Environment.Remove($name) }
+    else { $psi.Environment[$name] = $ChildEnv[$name] }
+}
+
+# Fire-and-forget: `code` without --wait hands the folder to the running VS Code instance
+# and returns at once, and this launcher must behave the same -- waiting would tie the
+# editor's lifetime to the console it was started from and hold the developer's prompt.
+# Only the failure to start is this script's to report.
+try {
+    [void][System.Diagnostics.Process]::Start($psi)
+} catch {
+    Write-LauncherError "ERROR: failed to launch '$($codeCmd.Source)': $($_.Exception.Message)"
+    exit 1
+}
+exit 0

--- a/scripts/code-ccgw.sh
+++ b/scripts/code-ccgw.sh
@@ -28,8 +28,23 @@ DOTENV_FORCE_KEYS="LITELLM_HAIKU_MODEL LITELLM_SONNET_MODEL LITELLM_FABLE_MODEL 
 # shellcheck source=scripts/lib/load-dotenv.sh
 . "$SCRIPT_DIR/lib/load-dotenv.sh"
 
-# Clear any real Anthropic API key so the local backend is used instead.
+# Clear any real Anthropic API key so the local backend is used instead. Exported
+# defined-but-empty rather than unset: every consumer reads an empty value as "no key",
+# and the exported empty makes the clearing visible to anything inspecting the child env.
 export ANTHROPIC_API_KEY=""
+
+# The rest of the credential/provider-switch class that must never reach the child
+# `exec` replaces this shell with -- see docs/architecture.md "Child-process-only
+# environment injection" for why the class is this wide and how to extend it.
+for _stripped in \
+    CLAUDE_CODE_OAUTH_TOKEN \
+    CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX \
+    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_REGION \
+    GOOGLE_APPLICATION_CREDENTIALS \
+    NODE_TLS_REJECT_UNAUTHORIZED; do
+    unset "$_stripped"
+done
+unset _stripped
 
 # --- Base URL --------------------------------------------------------------
 # The LiteLLM gateway is the only endpoint. Defined-but-empty counts as unset:
@@ -80,21 +95,37 @@ fi
 # tier verbatim. The launcher owns no backend names: inventing one would address
 # a model the gateway has no entry for, and the error would surface as a 400
 # from LiteLLM rather than as a message from here.
+#
+# Absence of a source key means "the child must not have the derived variable at all",
+# never "keep whatever the invoking shell happened to carry": a leftover ANTHROPIC_MODEL
+# from an earlier session would otherwise pin a tier the repo's .env no longer names.
+# Hence every conditional export has an explicit unsetting else branch.
 if [ -n "${LITELLM_FABLE_MODEL:-}" ]; then
     export ANTHROPIC_DEFAULT_FABLE_MODEL="$LITELLM_FABLE_MODEL"
+else
+    unset ANTHROPIC_DEFAULT_FABLE_MODEL
 fi
 if [ -n "${LITELLM_OPUS_MODEL:-}" ]; then
     export ANTHROPIC_DEFAULT_OPUS_MODEL="$LITELLM_OPUS_MODEL"
+else
+    unset ANTHROPIC_DEFAULT_OPUS_MODEL
 fi
 if [ -n "${LITELLM_SONNET_MODEL:-}" ]; then
     export ANTHROPIC_DEFAULT_SONNET_MODEL="$LITELLM_SONNET_MODEL"
+else
+    unset ANTHROPIC_DEFAULT_SONNET_MODEL
 fi
 if [ -n "${LITELLM_HAIKU_MODEL:-}" ]; then
     export ANTHROPIC_DEFAULT_HAIKU_MODEL="$LITELLM_HAIKU_MODEL"
+else
+    unset ANTHROPIC_DEFAULT_HAIKU_MODEL
 fi
 if [ -n "${LITELLM_FABLE_MODEL:-}" ]; then
     export ANTHROPIC_MODEL="$LITELLM_FABLE_MODEL"
     export ANTHROPIC_CUSTOM_MODEL_OPTION="$LITELLM_FABLE_MODEL"
+else
+    unset ANTHROPIC_MODEL
+    unset ANTHROPIC_CUSTOM_MODEL_OPTION
 fi
 
 # Subagent routing is opt-in. LiteLLM multiplexes, so pinning every subagent to
@@ -103,6 +134,8 @@ fi
 # key, passed through untranslated.
 if [ -n "${CCGW_SUBAGENT_MODEL:-}" ]; then
     export CLAUDE_CODE_SUBAGENT_MODEL="$CCGW_SUBAGENT_MODEL"
+else
+    unset CLAUDE_CODE_SUBAGENT_MODEL
 fi
 
 export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="Local model via ccgw"

--- a/tests/feature-18-serverctl/code-ccgw-windows.Tests.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows.Tests.ps1
@@ -2,6 +2,18 @@
 # Tests: scripts/code-ccgw.ps1
 # Tags: lifecycle, client-launcher, windows, scope:issue-specific
 #
+# Entry point for the Windows client-launcher suite. The cases themselves live in
+# the sibling folder code-ccgw-windows/ and are dot-sourced below, so
+# `Invoke-Pester` against THIS path still discovers and runs every one of them.
+#
+#   code-ccgw-windows/
+#     helpers-fixtures.ps1        fixture trees, the code/mkcert stubs, New-Env
+#     helpers-runners.ps1         Invoke-Launcher, Invoke-LauncherInParentShell, dumps
+#     helpers-runners-latency.ps1 Measure-LauncherLaunch (times the launcher itself)
+#     helpers-assertions.ps1      Assert-LauncherEnv and friends
+#     setup.ps1                   builds the fixtures (runs last, uses all of the above)
+#     context-NN-*.ps1            one file per group of Contexts
+#
 # Scenario (issue #41 / detail plan D5a): the direct-to-DS4-Proxy route is
 # retired, so the Windows client launcher (pwsh counterpart of
 # scripts/code-ccgw.sh) has exactly ONE path — through the Mac LiteLLM.
@@ -14,17 +26,64 @@
 # a dummy default is what turns a misconfiguration into a confusing 401 much
 # later, at request time.
 #
-# This file is the 1:1 mirror of tests/feature-18-serverctl/test-code-ccgw-posix.sh
+# This suite is the 1:1 mirror of tests/feature-18-serverctl/test-code-ccgw-posix.sh
 # (CPR-ORTH: the two launchers are symmetric members of one class, so the
 # contract asserted on one must be asserted on the other). The only intentional
 # divergences are the platform-specific ones: the VS Code profile dir lives
 # under LOCALAPPDATA rather than being derived from `uname`, and PowerShell's
 # native-command error conversion needs its own regression case.
 #
-# Method: `code` is stubbed on PATH with a code.ps1 that dumps the environment
-# it inherited plus its argv to files, so every assertion is made against the
+# Scenario (issue #66): the launcher used to write every value it resolved into
+# its OWN process environment before starting VS Code. PowerShell has no exec,
+# so the launcher survives the call and those variables stay behind in the shell
+# that invoked it — a later, unrelated cloud Claude Code session started from the
+# same shell silently inherited local-LLM routing (ANTHROPIC_BASE_URL,
+# CLAUDE_CODE_AUTO_COMPACT_WINDOW, …). The fix moves the destination, not the
+# logic: every value is computed into script-local state and injected into the
+# CHILD process's environment block only. Seven consequences are asserted here and
+# nowhere else — Context 8 (the invoking shell is byte-for-byte untouched on the
+# success paths AND on every error path, while the child still receives the
+# computed values), Context 9 (an explicit process launch of a .cmd target must
+# not let cmd.exe re-interpret argument metacharacters — the BatBadBut class —
+# including the metacharacters in the resolved path of `code` itself, and with an
+# observer faithful enough to compare an embedded quote literally), Context 11 (no
+# statement in the source writes the environment at all, on any path, reachable by
+# these tests or not), Context 12 (the argument shapes an explicit launch loses
+# silently: empty, non-ASCII, over-long — and the safely-sized ones it must not
+# refuse), Context 13 (the five model-routing keys, where ".env wins over the
+# inherited value" and "the shell keeps its own value" have to hold at once, per
+# key), Context 14 (the launcher hands over and returns instead of waiting for the
+# editor — invisible to every fast-exiting stub) and Context 15 (the same
+# metacharacter contract for the values the launcher READS, which reach the child
+# through the environment block rather than through the command line).
+#
+# Method: `code` is stubbed on PATH with a stub that dumps the environment it
+# inherited plus its argv to files, so every assertion is made against the
 # environment the launcher actually hands to Claude Code — none of the
 # launcher's branching is re-implemented here. `mkcert` is stubbed the same way.
+# On Windows the `code` stub is a **code.cmd**, because the real `code` on a
+# Windows VS Code install resolves to code.cmd: a .ps1 stub cannot be started by
+# System.Diagnostics.Process at all, and — more importantly — it would never
+# exercise the implicit cmd.exe re-parse that makes Context 9 necessary. On
+# non-Windows hosts (where cmd.exe does not exist) the stub stays a code.ps1
+# writing the identical dump format, so the platform-independent cases (the .env
+# loader, precedence, the tier map) still run there. Context 10's `code` is
+# instead a compiled .exe that reports what it received, because "the .exe branch
+# was taken" cannot be shown by the absence of an error message.
+#   Stub limitation: the .cmd stub recovers each argument through `%~1`, which
+#   does NOT collapse a doubled embedded `""` back to `"` nor halve a doubled
+#   trailing backslash. Arguments carrying an embedded quote or a trailing
+#   backslash therefore cannot be round-trip-compared literally by THAT stub;
+#   Context 9a-9c assert the weaker-but-still-decisive contract for those (no
+#   argument splitting, no injection side effect), and Context 9f removes the
+#   limitation with a second .cmd that forwards `%*` to a compiled argv observer
+#   — the shape of a real code.cmd handing off to Code.exe — where the two shapes
+#   are compared byte for byte.
+#   Two further stubs exist for contracts a fast, well-named stub cannot express:
+#   one whose DIRECTORY name carries a space, parentheses and `&` (Context 9e —
+#   the path of `code` is part of the command line too), and one that stays alive
+#   until released, so "the launcher returned" can be told apart from "the
+#   launcher waited for VS Code" (Context 14).
 # The launcher runs in a child pwsh whose environment block is cleared and
 # rebuilt from scratch, so an ambient LITELLM_*/CCGW_*/DS4_* value in the
 # developer's shell can never satisfy an assertion by accident. The script under
@@ -32,826 +91,70 @@
 # developer's real .env — which holds the actual base URL and API keys — is
 # never read.
 #
+# Which PowerShell hosts the launcher: the launcher declares
+# `#Requires -Version 5.1`, but only pwsh (7.x) ever ran it, so a 5.1-only
+# incompatibility in ProcessStartInfo.Environment or the quoting helpers would
+# ship unnoticed. CCGW_TEST_LAUNCHER_HOST selects the host binary for the child
+# launcher process (default: this session's pwsh); test-code-ccgw-windows.sh
+# runs the suite once with that variable explicitly unset and, under the RUN_TL3
+# gate, again with CCGW_TEST_LAUNCHER_HOST=powershell.exe. Only the process under
+# test moves — Pester keeps running on pwsh 7, because this harness itself needs
+# ProcessStartInfo.ArgumentList, which the .NET Framework behind 5.1 does not
+# have. The gate lives in the driver, not here: a host that was explicitly asked
+# for and is missing is a configuration error worth failing on, not a case to
+# quietly skip.
+#
 # TL3 gap: real VS Code startup and profile creation under the derived
 #   --user-data-dir; a real mkcert CA actually being trusted by Node's TLS
 #   stack; genuine end-to-end routing of the selected routing key through
-#   LiteLLM to a loaded backend; a real Windows host. Also unreachable from
-#   here: the $PSNativeCommandUseErrorActionPreference guard itself — that
-#   conversion applies only to native executables, and the mkcert stub is a
-#   .ps1, so the failing-mkcert case below exercises the resulting no-CAROOT
-#   branch rather than the exit-code conversion that would have aborted the
-#   launcher before the fix.
-
-BeforeAll {
-    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-    $script:SourceLauncher = Join-Path $script:RepoRoot 'scripts' 'code-ccgw.ps1'
-
-    if (-not (Test-Path -LiteralPath $script:SourceLauncher)) {
-        throw "$($script:SourceLauncher) not found (implementation pending)"
-    }
-
-    $script:Work = Join-Path ([IO.Path]::GetTempPath()) ("ccgw-win-" + [Guid]::NewGuid().ToString('N'))
-    New-Item -ItemType Directory -Path $script:Work -Force | Out-Null
-
-    $script:PwshPath = if ($IsWindows) { Join-Path $PSHOME 'pwsh.exe' } else { Join-Path $PSHOME 'pwsh' }
-
-    # --- Retired variable names ---------------------------------------------
-    # The cases that prove a retired variable no longer configures anything need
-    # its exact spelling, but those spellings are banned repo-wide by
-    # tests/ccgw-naming/test_no_legacy_names.py, whose scan is a raw substring
-    # match over every tracked file — this one included. The names are therefore
-    # assembled at runtime instead of appearing as literals. The cases
-    # themselves must stay: a stale .env still carrying them is precisely the
-    # situation where a surviving fallback would silently route around the new
-    # single path.
-    $script:RBaseDs4      = 'DS4_ANTHROPIC' + '_BASE_URL'
-    $script:RBaseCcgw     = 'CCGW_ANTHROPIC' + '_BASE_URL'
-    $script:RKeyDs4       = 'DS4_API' + '_KEY'
-    $script:RKeyCcgw      = 'CCGW_API' + '_KEY'
-    $script:RCaDs4        = 'DS4_CA' + '_CERT'
-    $script:RDefaultModel = 'CCGW_DEFAULT' + '_MODEL'
-
-    # --- fixture script tree -------------------------------------------------
-    # The launcher reads <script>/../.env. Copying it into a fixture tree pins
-    # that file to an empty one, so precedence is asserted from the child's
-    # environment block alone.
-    function New-FixtureTree {
-        param([string]$Name, [string[]]$DotEnvLines = @('# intentionally empty: precedence is asserted from the env alone'))
-        $root = Join-Path $script:Work $Name
-        New-Item -ItemType Directory -Path (Join-Path $root 'scripts') -Force | Out-Null
-        Copy-Item -LiteralPath $script:SourceLauncher -Destination (Join-Path $root 'scripts' 'code-ccgw.ps1') -Force
-        Set-Content -LiteralPath (Join-Path $root '.env') -Value $DotEnvLines -Encoding utf8
-        return (Join-Path $root 'scripts' 'code-ccgw.ps1')
-    }
-    $script:Launcher = New-FixtureTree -Name 'fixture-default'
-
-    # --- stubs ---------------------------------------------------------------
-    # A .ps1 on PATH is a first-class command for PowerShell's discovery, so
-    # `Get-Command code` / `& code` resolve these without any native binary.
-    $script:CodeStubBody = @'
-$dump = @{}
-foreach ($e in Get-ChildItem env:) { $dump[$e.Name] = $e.Value }
-$dump | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $env:CCGW_TEST_DUMP -Encoding utf8
-$argvOut = @($args) | ForEach-Object { [string]$_ }
-Set-Content -LiteralPath $env:CCGW_TEST_ARGV -Value $argvOut -Encoding utf8
-'@
-
-    function New-StubDir {
-        param(
-            [string]$Name,
-            [string]$MkcertCaroot,
-            [int]$MkcertExitCode = 0,
-            [switch]$NoCode,
-            [switch]$NoMkcert
-        )
-        $dir = Join-Path $script:Work $Name
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-        if (-not $NoCode) {
-            Set-Content -LiteralPath (Join-Path $dir 'code.ps1') -Value $script:CodeStubBody -Encoding utf8
-        }
-        if (-not $NoMkcert) {
-            # Prints the CAROOT it was created with; the launcher pipes it through
-            # Select-Object -First 1. A failing stub prints nothing and exits
-            # non-zero — it deliberately writes no stderr, which would otherwise
-            # contaminate the launcher's own stderr that the warning assertions read.
-            $body = if ($MkcertExitCode -ne 0) {
-                "exit $MkcertExitCode"
-            } else {
-                "Write-Output '" + ($MkcertCaroot -replace "'", "''") + "'"
-            }
-            Set-Content -LiteralPath (Join-Path $dir 'mkcert.ps1') -Value $body -Encoding utf8
-        }
-        return $dir
-    }
-
-    # Default stub dir: `code` present, no mkcert at all.
-    $script:StubDir = New-StubDir -Name 'stub' -NoMkcert
-
-    # mkcert whose CAROOT really holds a rootCA.pem.
-    $script:CarootOk = Join-Path $script:Work 'caroot-ok'
-    New-Item -ItemType Directory -Path $script:CarootOk -Force | Out-Null
-    Set-Content -LiteralPath (Join-Path $script:CarootOk 'rootCA.pem') -Value '' -Encoding utf8
-    $script:StubMkcertOk = New-StubDir -Name 'stub-mkcert-ok' -MkcertCaroot $script:CarootOk
-
-    # mkcert whose CAROOT is empty (no rootCA.pem).
-    $script:CarootEmpty = Join-Path $script:Work 'caroot-empty'
-    New-Item -ItemType Directory -Path $script:CarootEmpty -Force | Out-Null
-    $script:StubMkcertBad = New-StubDir -Name 'stub-mkcert-bad' -MkcertCaroot $script:CarootEmpty
-
-    # mkcert that exits non-zero without printing a CAROOT.
-    $script:StubMkcertFails = New-StubDir -Name 'stub-mkcert-fails' -MkcertExitCode 3
-
-    # No `code` on PATH at all.
-    $script:StubNoCode = New-StubDir -Name 'stub-nocode' -NoCode -NoMkcert
-
-    $script:LocalAppData = Join-Path $script:Work 'localappdata'
-    New-Item -ItemType Directory -Path $script:LocalAppData -Force | Out-Null
-
-    # The minimum configuration every non-configuration case needs, so that a
-    # case about (say) argv is never accidentally satisfied by the base-URL
-    # guard refusing to run at all.
-    $script:Configured = @{
-        LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1'
-        LITELLM_CLIENT_KEY         = 'ck'
-    }
-    function New-Env {
-        param([hashtable]$Extra = @{})
-        $h = @{}
-        foreach ($k in $script:Configured.Keys) { $h[$k] = $script:Configured[$k] }
-        foreach ($k in $Extra.Keys) { $h[$k] = $Extra[$k] }
-        return $h
-    }
-
-    # --- launcher runner -----------------------------------------------------
-    # The child's environment block is cleared and rebuilt: only the variables
-    # named here exist inside the launcher. PATH deliberately excludes the host's
-    # real directories, so a genuinely installed mkcert cannot turn the
-    # "no mkcert" case into a false pass.
-    function Invoke-Launcher {
-        param(
-            [hashtable]$Environment = @{},
-            [string[]]$Arguments = @(),
-            [string]$StubDir = $script:StubDir,
-            [string]$LauncherPath = $script:Launcher,
-            [switch]$NoLocalAppData
-        )
-
-        $dump = Join-Path $script:Work 'env.dump.json'
-        $argvFile = Join-Path $script:Work 'argv.dump'
-        Remove-Item -LiteralPath $dump, $argvFile -ErrorAction SilentlyContinue
-
-        $psi = [System.Diagnostics.ProcessStartInfo]::new()
-        $psi.FileName = $script:PwshPath
-        foreach ($a in @('-NoProfile', '-NonInteractive', '-File', $LauncherPath) + $Arguments) {
-            $psi.ArgumentList.Add([string]$a)
-        }
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $true
-        $psi.Environment.Clear()
-
-        $psi.Environment['PATH'] = $StubDir
-        $psi.Environment['CCGW_TEST_DUMP'] = $dump
-        $psi.Environment['CCGW_TEST_ARGV'] = $argvFile
-        if (-not $NoLocalAppData) { $psi.Environment['LOCALAPPDATA'] = $script:LocalAppData }
-        $psi.Environment['TEMP'] = $script:Work
-        $psi.Environment['TMP'] = $script:Work
-        $psi.Environment['TMPDIR'] = $script:Work
-        $psi.Environment['HOME'] = $script:Work
-        $psi.Environment['USERPROFILE'] = $script:Work
-        # .ps1 must stay a discoverable command extension for the stubs above.
-        $psi.Environment['PATHEXT'] = '.COM;.EXE;.BAT;.CMD;.PS1'
-        foreach ($passthrough in @('SystemRoot', 'ComSpec', 'windir')) {
-            $v = [Environment]::GetEnvironmentVariable($passthrough)
-            if ($v) { $psi.Environment[$passthrough] = $v }
-        }
-        foreach ($k in $Environment.Keys) {
-            $psi.Environment[[string]$k] = [string]$Environment[$k]
-        }
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $stdout = $proc.StandardOutput.ReadToEnd()
-        $stderr = $proc.StandardError.ReadToEnd()
-        if (-not $proc.WaitForExit(60000)) {
-            try { $proc.Kill($true) } catch { }
-            throw "launcher did not exit within 60s"
-        }
-
-        $envMap = @{}
-        if (Test-Path -LiteralPath $dump) {
-            $raw = Get-Content -LiteralPath $dump -Raw
-            if ($raw.Trim()) { $envMap = $raw | ConvertFrom-Json -AsHashtable }
-        }
-        $argv = @()
-        if (Test-Path -LiteralPath $argvFile) {
-            $argv = @(Get-Content -LiteralPath $argvFile)
-        }
-
-        return [pscustomobject]@{
-            ExitCode = $proc.ExitCode
-            StdOut   = $stdout
-            StdErr   = $stderr
-            Env      = $envMap
-            Argv     = $argv
-            Reached  = (Test-Path -LiteralPath $dump)
-        }
-    }
-
-    # --- assertion helpers ---------------------------------------------------
-    function Assert-LauncherEnv {
-        param($Result, [string]$Name, [string]$Expected, [string]$Context)
-        if (-not $Result.Reached) {
-            throw "$Context`: stub 'code' was never reached (no env dump); stderr: $($Result.StdErr)"
-        }
-        if (-not $Result.Env.ContainsKey($Name)) {
-            throw "$Context`: $Name was not exported at all (expected '$Expected')"
-        }
-        if ($Result.Env[$Name] -cne $Expected) {
-            throw "$Context`: $Name='$($Result.Env[$Name])', expected '$Expected'"
-        }
-    }
-
-    function Assert-LauncherEnvUnset {
-        param($Result, [string]$Name, [string]$Context)
-        # The launcher's own contract treats defined-but-empty as unset, and
-        # .NET drops an env var assigned '' on Windows — so either shape counts.
-        if ($Result.Env.ContainsKey($Name) -and -not [string]::IsNullOrEmpty($Result.Env[$Name])) {
-            throw "$Context`: $Name was exported as '$($Result.Env[$Name])' but must not be set at all"
-        }
-    }
-
-    function Assert-LauncherEnvDiffers {
-        param($Result, [string]$A, [string]$B, [string]$Context)
-        if ($Result.Env[$A] -ceq $Result.Env[$B]) {
-            throw "$Context`: $A and $B both resolved to '$($Result.Env[$A])'; the two tiers must stay on separate routing keys"
-        }
-    }
-
-    function Assert-Stderr {
-        param($Result, [string]$Pattern, [string]$Context)
-        if ($Result.StdErr -notmatch [regex]::Escape($Pattern)) {
-            throw "$Context`: expected stderr to contain '$Pattern', got: $($Result.StdErr)"
-        }
-    }
-
-    function Assert-NoCaWarning {
-        param($Result, [string]$Context)
-        if ($Result.StdErr -match 'CCGW_CA_CERT not set') {
-            throw "$Context`: unexpected CA warning: $($Result.StdErr)"
-        }
-    }
-
-    # The four /model tiers Claude Code switches between.
-    $script:TierVars = @(
-        'ANTHROPIC_DEFAULT_FABLE_MODEL'
-        'ANTHROPIC_DEFAULT_OPUS_MODEL'
-        'ANTHROPIC_DEFAULT_SONNET_MODEL'
-        'ANTHROPIC_DEFAULT_HAIKU_MODEL'
-    )
-    # The vars that name the model in play at startup. CLAUDE_CODE_SUBAGENT_MODEL
-    # is deliberately NOT here any more: it is now opt-in (section 4d).
-    $script:ActiveVars = @(
-        'ANTHROPIC_MODEL'
-        'ANTHROPIC_CUSTOM_MODEL_OPTION'
-    )
-    $script:ModelVars = $script:TierVars + $script:ActiveVars + @('CLAUDE_CODE_SUBAGENT_MODEL')
-}
-
-AfterAll {
-    if ($script:Work -and (Test-Path -LiteralPath $script:Work)) {
-        Remove-Item -LiteralPath $script:Work -Recurse -Force -ErrorAction SilentlyContinue
-    }
-}
+#   LiteLLM to a loaded backend; a real `code.cmd` from a real VS Code install
+#   (the stub is faithful about being a .cmd, not about what VS Code does with
+#   its argv). Also unreachable from here: the
+#   $PSNativeCommandUseErrorActionPreference guard itself — that conversion
+#   applies only to native executables, and the mkcert stub is a .ps1, so the
+#   failing-mkcert case exercises the resulting no-CAROOT branch rather than the
+#   exit-code conversion that would have aborted the launcher before the fix.
+#   And whether an .exe target is reached DIRECTLY or through a cmd.exe wrapper
+#   is not observable from inside the child; Context 10 asserts what it received,
+#   not how it was spawned.
 
 Describe 'code-ccgw.ps1' {
 
-    Context '1. Base URL: single source, hard failure when absent' {
-        It 'LITELLM_ANTHROPIC_BASE_URL is the only source' {
-            $r = Invoke-Launcher -Environment (New-Env)
-            $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
-            Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://lite:1' 'base-url/configured'
-        }
+    BeforeAll {
+        # Definitions first, then setup.ps1 — which is top-level code, not a
+        # function, so the $script: fixtures it builds land in this block's scope
+        # where every It below can see them.
+        $suite = Join-Path $PSScriptRoot 'code-ccgw-windows'
+        . (Join-Path $suite 'helpers-fixtures.ps1')
+        . (Join-Path $suite 'helpers-runners.ps1')
+        . (Join-Path $suite 'helpers-runners-latency.ps1')
+        . (Join-Path $suite 'helpers-assertions.ps1')
+        . (Join-Path $suite 'setup.ps1')
+    }
 
-        It 'the retired CCGW_/DS4_ base URLs must not configure the launcher' {
-            # A stale .env carrying them is exactly the situation where a silent
-            # fallback would send traffic down the route this change removed.
-            $env1 = @{ LITELLM_CLIENT_KEY = 'ck' }
-            $env1[$script:RBaseCcgw] = 'https://ccgw:2'
-            $env1[$script:RBaseDs4] = 'https://ds4:3'
-            $r = Invoke-Launcher -Environment $env1
-            $r.ExitCode | Should -Not -Be 0 -Because 'the retired base-URL variables are not a configuration source any more'
-        }
-
-        It 'an unset base URL is a hard failure, not a dummy default' {
-            $r = Invoke-Launcher -Environment @{ LITELLM_CLIENT_KEY = 'ck' }
-            $r.ExitCode | Should -Not -Be 0 -Because 'an unconfigured launcher must not silently pick a default endpoint'
-            Assert-Stderr $r 'LITELLM_ANTHROPIC_BASE_URL' 'base-url/unset: the error must name the variable to set'
-            Assert-Stderr $r 'docs/ops.md' 'base-url/unset: the error must point at the setup procedure'
-        }
-
-        It 'a defined-but-empty base URL is treated as unset' {
-            # The retired .cmd's `if defined` accepted an empty string; the port
-            # must not.
-            $r = Invoke-Launcher -Environment @{ LITELLM_ANTHROPIC_BASE_URL = ''; LITELLM_CLIENT_KEY = 'ck' }
-            $r.ExitCode | Should -Not -Be 0 -Because 'an empty value is not a configured endpoint'
+    AfterAll {
+        if ($script:Work -and (Test-Path -LiteralPath $script:Work)) {
+            Remove-Item -LiteralPath $script:Work -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 
-    Context '2. Auth token: LITELLM_CLIENT_KEY, with a one-cycle deprecated alias' {
-        # No virtual keys exist without a LiteLLM database, so the client
-        # credential is the master key itself; LITELLM_VIRTUAL_KEY survives one
-        # cycle because an existing .env carrying only the old name would
-        # otherwise 401 with no clue.
-
-        It 'LITELLM_CLIENT_KEY is the credential, and using it warns about nothing' {
-            $r = Invoke-Launcher -Environment (New-Env)
-            Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'ck' 'auth/current-name'
-            $r.StdErr | Should -Not -Match '(?i)deprecat' -Because 'the current name must not produce a deprecation warning'
-        }
-
-        It 'the deprecated LITELLM_VIRTUAL_KEY is still accepted, with a warning naming both names' {
-            $r = Invoke-Launcher -Environment @{
-                LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1'
-                LITELLM_VIRTUAL_KEY        = 'vk'
-            }
-            Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'vk' 'auth/alias'
-            Assert-Stderr $r 'LITELLM_VIRTUAL_KEY' 'auth/alias: using the deprecated name must warn'
-            Assert-Stderr $r 'LITELLM_CLIENT_KEY' 'auth/alias: the warning must name the replacement'
-        }
-
-        It 'LITELLM_CLIENT_KEY wins when both names are set' {
-            # A half-migrated .env has to behave predictably.
-            $r = Invoke-Launcher -Environment (New-Env @{ LITELLM_VIRTUAL_KEY = 'vk' })
-            Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'ck' 'auth/both-names'
-        }
-
-        It 'the retired client key variables must not configure the launcher' {
-            $env1 = @{ LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1' }
-            $env1[$script:RKeyCcgw] = 'ck'
-            $env1[$script:RKeyDs4] = 'dk'
-            $r = Invoke-Launcher -Environment $env1
-            $r.ExitCode | Should -Not -Be 0 -Because 'the proxy token is now internal to LiteLLM and no longer a client credential'
-        }
-
-        It 'an unset credential is a hard failure, not a shared dummy token' {
-            $r = Invoke-Launcher -Environment @{ LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1' }
-            $r.ExitCode | Should -Not -Be 0 -Because 'a missing credential must surface at launch, not as a 401 much later'
-            Assert-Stderr $r 'LITELLM_CLIENT_KEY' 'auth/unset: the error must name the variable to set'
-            $r.StdErr | Should -Not -Match 'dsv4-local' -Because 'the retired dummy token must be gone'
-        }
-
-        It 'a pre-existing ANTHROPIC_API_KEY must be cleared so the local backend is used' {
-            $r = Invoke-Launcher -Environment (New-Env @{ ANTHROPIC_API_KEY = 'cloud-key-must-not-survive' })
-            $r.Reached | Should -BeTrue -Because "stderr: $($r.StdErr)"
-            # Assigning '' removes the variable outright on Windows; both shapes
-            # satisfy the contract "no real cloud key reaches Claude Code".
-            $got = if ($r.Env.ContainsKey('ANTHROPIC_API_KEY')) { $r.Env['ANTHROPIC_API_KEY'] } else { $null }
-            [string]::IsNullOrEmpty($got) | Should -BeTrue -Because "ANTHROPIC_API_KEY survived as '$got'"
-        }
-    }
-
-    Context '3. TLS CA (retained: LiteLLM terminates TLS with the mkcert leaf)' {
-        It 'CCGW_CA_CERT is honored' {
-            $r = Invoke-Launcher -Environment (New-Env @{ CCGW_CA_CERT = 'C:\ca\ccgw.pem' })
-            Assert-LauncherEnv $r 'NODE_EXTRA_CA_CERTS' 'C:\ca\ccgw.pem' 'ca/explicit'
-            Assert-NoCaWarning $r 'ca/explicit'
-        }
-
-        It 'the retired direct-path CA variable must not be picked up' {
-            $r = Invoke-Launcher -Environment (New-Env @{ $script:RCaDs4 = 'C:\ca\ds4.pem' })
-            Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/retired-var'
-        }
-
-        It 'TLS verification must never be disabled' {
-            # NODE_TLS_REJECT_UNAUTHORIZED=0 must never be the launcher's answer to TLS.
-            $r = Invoke-Launcher -Environment (New-Env @{ CCGW_CA_CERT = 'C:\ca\ccgw.pem' })
-            Assert-LauncherEnvUnset $r 'NODE_TLS_REJECT_UNAUTHORIZED' 'ca/no-tls-bypass'
-        }
-
-        It '3a. mkcert -CAROOT must be derived when no CA var is set' {
-            $r = Invoke-Launcher -StubDir $script:StubMkcertOk -Environment (New-Env)
-            Assert-LauncherEnv $r 'NODE_EXTRA_CA_CERTS' (Join-Path $script:CarootOk 'rootCA.pem') 'ca/mkcert-ok'
-            Assert-NoCaWarning $r 'ca/mkcert-ok'
-        }
-
-        It 'explicit CCGW_CA_CERT must outrank the mkcert derivation' {
-            $r = Invoke-Launcher -StubDir $script:StubMkcertOk -Environment (New-Env @{ CCGW_CA_CERT = 'C:\ca\explicit.pem' })
-            Assert-LauncherEnv $r 'NODE_EXTRA_CA_CERTS' 'C:\ca\explicit.pem' 'ca/explicit-over-mkcert'
-        }
-
-        It '3b. a CAROOT without rootCA.pem must not yield a bogus NODE_EXTRA_CA_CERTS' {
-            $r = Invoke-Launcher -StubDir $script:StubMkcertBad -Environment (New-Env)
-            Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/mkcert-empty'
-            Assert-Stderr $r 'CCGW_CA_CERT not set' 'ca/mkcert-empty'
-        }
-
-        It '3c. mkcert absent entirely must warn and export nothing' {
-            $r = Invoke-Launcher -Environment (New-Env)
-            Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/no-mkcert'
-            Assert-Stderr $r 'CCGW_CA_CERT not set' 'ca/no-mkcert'
-        }
-
-        It '3d. a failing mkcert warns and still launches instead of aborting' {
-            # Under PowerShell 7.4+ a non-zero native exit used to become a
-            # terminating error while ErrorActionPreference is Stop, killing the
-            # launcher outright; the script disables that conversion, so the run
-            # must reach `code`. See the TL3 note in the header: a .ps1 stub is
-            # not a native command, so this reaches the warning through the
-            # no-CAROOT branch rather than through the conversion itself.
-            $r = Invoke-Launcher -StubDir $script:StubMkcertFails -Environment (New-Env)
-            $r.Reached | Should -BeTrue -Because "a failing mkcert must not abort the launcher; stderr: $($r.StdErr)"
-            $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
-            Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/mkcert-fails'
-            Assert-Stderr $r 'CCGW_CA_CERT not set' 'ca/mkcert-fails'
-        }
-    }
-
-    Context '4. Model selection (unconditional LiteLLM routing keys)' {
-        # With the direct path gone there is no branch left: each
-        # LITELLM_*_MODEL is a LiteLLM routing key and goes onto its own /model
-        # tier verbatim. The launcher owns no backend names of its own —
-        # inventing one would route to a model the gateway has no entry for, and
-        # the error would surface as a 400 from LiteLLM rather than as a
-        # launcher message.
-
-        BeforeAll {
-            $script:AllKeys = @{
-                LITELLM_FABLE_MODEL  = 'lite-fable'
-                LITELLM_OPUS_MODEL   = 'lite-opus'
-                LITELLM_SONNET_MODEL = 'lite-sonnet'
-                LITELLM_HAIKU_MODEL  = 'lite-haiku'
-            }
-        }
-
-        It '4a. all four routing keys land verbatim on their own tiers' {
-            $r = Invoke-Launcher -Environment (New-Env $script:AllKeys)
-            $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
-            Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'lite-fable' 'models: fable routing key'
-            Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models: opus routing key'
-            Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_SONNET_MODEL' 'lite-sonnet' 'models: sonnet routing key'
-            Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_HAIKU_MODEL' 'lite-haiku' 'models: haiku routing key'
-            Assert-LauncherEnv $r 'ANTHROPIC_MODEL' 'lite-fable' 'models: startup model follows the fable tier'
-            Assert-LauncherEnv $r 'ANTHROPIC_CUSTOM_MODEL_OPTION' 'lite-fable' 'models: custom model option follows the fable tier'
-            # Stated as an inequality too: a regression that collapses the tiers
-            # onto one key would still satisfy each literal individually if all
-            # literals moved.
-            Assert-LauncherEnvDiffers $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'ANTHROPIC_DEFAULT_OPUS_MODEL' `
-                'models: fable and opus must address different routing keys or /model cannot switch'
-        }
-
-        It '4b. no retired direct-path backend name may appear in any model var' {
-            # The launcher is not allowed to know them any more.
-            $r = Invoke-Launcher -Environment (New-Env $script:AllKeys)
-            foreach ($v in $script:ModelVars) {
-                $val = if ($r.Env.ContainsKey($v)) { $r.Env[$v] } else { '' }
-                $val | Should -Not -Match '(?i)deepseek' -Because "models: $v='$val' is a backend name, not a LiteLLM routing key"
-                $val | Should -Not -Match '(?i)laguna' -Because "models: $v='$val' is a backend name, not a LiteLLM routing key"
-            }
-        }
-
-        It '4c. the retired startup-model variable must change nothing at all' {
-            $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ $script:RDefaultModel = 'laguna-s-2.1' }))
-            Assert-LauncherEnv $r 'ANTHROPIC_MODEL' 'lite-fable' 'models/retired-default: the retired startup-model variable must be ignored'
-            Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models/retired-default: the tier map must be unaffected'
-        }
-
-        # 4d. Subagent contract (three cases).
-        #
-        # Why it changed: the old launcher pinned CLAUDE_CODE_SUBAGENT_MODEL to
-        # the fable tier so a subagent could not evict the resident backend.
-        # Routing now goes through LiteLLM, which multiplexes, so the pin is no
-        # longer needed — and it actively harms, because it silently overrides
-        # the model an agent definition's frontmatter declares. Default is
-        # therefore "say nothing"; CCGW_SUBAGENT_MODEL exists only for the case
-        # where a user deliberately wants every subagent confined to one route.
-
-        It '4d-i. by default the subagent model is not exported at all' {
-            $r = Invoke-Launcher -Environment (New-Env $script:AllKeys)
-            Assert-LauncherEnvUnset $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'subagent/default: an unconditional value overrides agent frontmatter'
-        }
-
-        It '4d-ii. CCGW_SUBAGENT_MODEL is exported verbatim' {
-            $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ CCGW_SUBAGENT_MODEL = 'lite-haiku' }))
-            Assert-LauncherEnv $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'lite-haiku' 'subagent/opt-in'
-        }
-
-        It '4d-iii. an arbitrary routing key passes through untranslated' {
-            # A key the launcher has never heard of must survive intact, and a
-            # tier name must NOT be mapped to that tier's value.
-            $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ CCGW_SUBAGENT_MODEL = 'some-other-routing-key' }))
-            Assert-LauncherEnv $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'some-other-routing-key' 'subagent/domain'
-        }
-
-        It 'a defined-but-empty CCGW_SUBAGENT_MODEL counts as unset' {
-            # Exporting an empty model name would make Claude Code request ""
-            # and fail at the gateway.
-            $r = Invoke-Launcher -Environment (New-Env @{ LITELLM_FABLE_MODEL = 'lite-fable'; CCGW_SUBAGENT_MODEL = '' })
-            Assert-LauncherEnvUnset $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'subagent/empty'
-        }
-
-        It '4e. no routing keys at all: nothing may be invented' {
-            $r = Invoke-Launcher -Environment (New-Env)
-            foreach ($v in $script:ModelVars) {
-                Assert-LauncherEnvUnset $r $v 'models/no-keys: the launcher must substitute no model name of its own'
-            }
-        }
-
-        It '4f. partial keys: the fable tier drives the startup vars, so its absence leaves them unset' {
-            $r = Invoke-Launcher -Environment (New-Env @{
-                LITELLM_OPUS_MODEL   = 'lite-opus'
-                LITELLM_SONNET_MODEL = 'lite-sonnet'
-                LITELLM_HAIKU_MODEL  = 'lite-haiku'
-            })
-            Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models/no-fable: opus routing key still applies'
-            Assert-LauncherEnvUnset $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'models/no-fable: no fable key means no fable tier'
-            foreach ($v in $script:ActiveVars) {
-                Assert-LauncherEnvUnset $r $v 'models/no-fable: the launcher must invent no model name of its own'
-            }
-        }
-    }
-
-    Context '5. VS Code profile isolation and argv passthrough' {
-        It 'passes an isolated --user-data-dir under LOCALAPPDATA plus the caller argv' {
-            $r = Invoke-Launcher -Environment (New-Env) -Arguments @('C:\some\project', '--new-window')
-            $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
-            $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'), 'C:\some\project', '--new-window')
-            @($r.Argv) | Should -Be $expected
-        }
-
-        It 'passes only the --user-data-dir pair when the caller supplied no argv' {
-            $r = Invoke-Launcher -Environment (New-Env)
-            $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'))
-            @($r.Argv) | Should -Be $expected
-        }
-
-        It 'falls back to a home-relative profile dir when LOCALAPPDATA is unset' {
-            # LOCALAPPDATA is always set on a normal Windows session, but a
-            # stripped service environment would otherwise make the final
-            # Join-Path throw after every env var had already been resolved.
-            # The exact fallback spelling is the script's business; what must
-            # hold is that it still launches, still isolates, and still roots the
-            # profile under the user's home.
-            $r = Invoke-Launcher -Environment (New-Env) -NoLocalAppData
-            $r.Reached | Should -BeTrue -Because "an unset LOCALAPPDATA must not abort the launcher; stderr: $($r.StdErr)"
-            $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
-            @($r.Argv).Count | Should -Be 2
-            $r.Argv[0] | Should -Be '--user-data-dir'
-            $r.Argv[1] | Should -BeLike "$($script:Work)*"
-            $r.Argv[1] | Should -BeLike '*vscode-ccgw'
-            # Still isolated: the fallback must not be the LOCALAPPDATA path, and
-            # must not be the bare home dir either.
-            $r.Argv[1] | Should -Not -Be (Join-Path $script:Work 'vscode-ccgw')
-        }
-    }
-
-    Context '6. Missing code on PATH' {
-        It 'is a hard failure that names both the problem and the remedy' {
-            $r = Invoke-Launcher -StubDir $script:StubNoCode -Environment (New-Env)
-            $r.ExitCode | Should -Not -Be 0 -Because 'a missing code command must not exit 0'
-            Assert-Stderr $r "'code' command not found on PATH" 'missing-code: must name the problem'
-            Assert-Stderr $r "Install 'code' command in PATH" 'missing-code: must state the remedy'
-        }
-    }
-
-    Context '7. Repo-root .env loading' {
-        # The launcher composes the path as Join-Path (Join-Path $PSScriptRoot '..') '.env',
-        # so the separator is the platform's own and these cases run everywhere
-        # pwsh does — they are not Windows-gated.
-
-        BeforeAll {
-            $script:DotEnvLauncher = New-FixtureTree -Name 'fixture-dotenv' -DotEnvLines @(
-                '# comment line must be ignored'
-                ''
-                'LITELLM_ANTHROPIC_BASE_URL=https://from-dotenv:9'
-                'LITELLM_CLIENT_KEY=dotenv-token'
-                '  LITELLM_FABLE_MODEL = lite-fable  '
-                'MALFORMED_NO_EQUALS'
-            )
-        }
-
-        It 'loads KEY=value lines and ignores comments and blanks' {
-            $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher
-            Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://from-dotenv:9' 'dotenv: base URL comes from .env'
-            Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'dotenv-token' 'dotenv: auth token comes from .env'
-        }
-
-        It 'trims surrounding whitespace around key and value' {
-            $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher
-            Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'lite-fable' 'dotenv: whitespace-padded KEY = value is trimmed'
-        }
-
-        It 'a non-empty shell value outranks .env' {
-            $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher `
-                -Environment @{ LITELLM_ANTHROPIC_BASE_URL = 'https://from-shell:1' }
-            Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://from-shell:1' 'dotenv: shell wins over .env'
-        }
-
-        It 'a defined-but-empty shell value is treated as unset, so .env still applies' {
-            # Every consumer below treats empty as unset, so honouring the empty
-            # shell value would silently discard the .env entry.
-            $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher `
-                -Environment @{ LITELLM_ANTHROPIC_BASE_URL = '' }
-            Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://from-dotenv:9' 'dotenv: empty shell value must not shadow .env'
-        }
-
-        It 'a missing .env is not an error when the shell supplies the configuration' {
-            $bare = Join-Path $script:Work 'fixture-no-dotenv'
-            New-Item -ItemType Directory -Path (Join-Path $bare 'scripts') -Force | Out-Null
-            Copy-Item -LiteralPath $script:SourceLauncher -Destination (Join-Path $bare 'scripts' 'code-ccgw.ps1') -Force
-            $r = Invoke-Launcher -LauncherPath (Join-Path $bare 'scripts' 'code-ccgw.ps1') -Environment (New-Env)
-            $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
-            Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://lite:1' 'dotenv/absent: launcher still runs'
-        }
-
-        # --- OS-conditional blocks (issue #56): `#@if windows` / `#@if posix` /
-        # `#@endif` in the repo-root .env. `ConvertFrom-OsConditionalLines` does
-        # NOT exist yet in scripts/code-ccgw.ps1 as of this writing -- written
-        # FIRST against the 13-case reference spec in the issue #56 detail plan,
-        # so the follow-up implementation has a red suite to turn green.
-        #
-        # This suite runs wherever pwsh happens to execute, not necessarily on
-        # Windows, and the launcher's own platform-token resolution ($IsWindows,
-        # falling back to 'windows' only when that variable does not exist at
-        # all) is a property of whatever REAL host runs the child launcher
-        # process below -- it cannot be mocked without touching the source. So
-        # every assertion here is phrased in terms of $script:OsBlockToken,
-        # resolved the same way, rather than hardcoding an assumption that the
-        # host is Windows.
-        BeforeAll {
-            $script:OsBlockToken = if (Test-Path variable:IsWindows) { if ($IsWindows) { 'windows' } else { 'posix' } } else { 'windows' }
-            $script:OsBlockOtherToken = if ($script:OsBlockToken -eq 'windows') { 'posix' } else { 'windows' }
-
-            function Get-OsBlockExpected {
-                param([string]$WindowsValue, [string]$PosixValue)
-                if ($script:OsBlockToken -eq 'windows') { return $WindowsValue }
-                return $PosixValue
-            }
-
-            $script:OsBlockCase1 = New-FixtureTree -Name 'fixture-osblock-case1' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                '#@if windows'
-                'BASIC_KEY=win_value'
-                '#@endif'
-                '#@if posix'
-                'BASIC_KEY=posix_value'
-                '#@endif'
-            )
-            $script:OsBlockCase3 = New-FixtureTree -Name 'fixture-osblock-case3' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                '# a plain comment'
-                'PLAIN_KEY=plain_value'
-            )
-            $script:OsBlockCase4 = New-FixtureTree -Name 'fixture-osblock-case4' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                'BEFORE_KEY=before_value'
-                ''
-                'AFTER_KEY=after_value'
-            )
-            $script:OsBlockCase5 = New-FixtureTree -Name 'fixture-osblock-case5' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                "#@if $($script:OsBlockOtherToken)"
-                'OUTER_KEY=outer_should_not_appear'
-                "#@if $($script:OsBlockToken)"
-                'INNER_KEY=inner_should_not_appear'
-                '#@endif'
-                '#@endif'
-            )
-            $script:OsBlockCase6 = New-FixtureTree -Name 'fixture-osblock-case6' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                "#@if $($script:OsBlockToken)"
-                'BEFORE_KEY=before_value'
-                "#@if $($script:OsBlockOtherToken)"
-                'NESTED_KEY=nested_should_not_appear'
-                '#@endif'
-                'AFTER_KEY=after_value'
-                '#@endif'
-            )
-            $script:OsBlockCase7 = New-FixtureTree -Name 'fixture-osblock-case7' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                '#@if darwin'
-                'UNKNOWN_TOKEN_KEY=should_never_appear'
-                '#@endif'
-            )
-            $script:OsBlockCase8 = New-FixtureTree -Name 'fixture-osblock-case8' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                '#@ifwindows'
-                'FOLLOW_KEY=should_always_appear'
-                '#@endif'
-            )
-            $script:OsBlockCase9 = New-FixtureTree -Name 'fixture-osblock-case9' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                'BEFORE_KEY=before_value'
-                '#@endif'
-                'AFTER_KEY=after_value'
-            )
-            $script:OsBlockCase10 = New-FixtureTree -Name 'fixture-osblock-case10' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                "#@if $($script:OsBlockOtherToken)"
-                'INSIDE_KEY=inside_value'
-                '#@endif foo'
-                'AFTER_KEY=after_value'
-            )
-
-            $script:OsBlockCase11 = New-FixtureTree -Name 'fixture-osblock-case11'
-            $osBlockCase11Root = Split-Path (Split-Path $script:OsBlockCase11 -Parent) -Parent
-            $osBlockCase11Lines = @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                '#@if windows'
-                'BASIC_KEY=win_value'
-                '#@endif'
-                '#@if posix'
-                'BASIC_KEY=posix_value'
-                '#@endif'
-            )
-            # Explicit CRLF write: New-FixtureTree's Set-Content uses this host's
-            # default newline, which is already LF on macOS/Linux -- this case
-            # exists specifically to prove a CRLF-authored .env (e.g. edited on a
-            # real Windows box) resolves identically regardless of host.
-            [System.IO.File]::WriteAllText((Join-Path $osBlockCase11Root '.env'), (($osBlockCase11Lines -join "`r`n") + "`r`n"))
-
-            $script:OsBlockCase12 = New-FixtureTree -Name 'fixture-osblock-case12' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                '  #@if windows  '
-                'PAD_KEY=win_value'
-                '  #@endif  '
-                '  #@if posix  '
-                'PAD_KEY=posix_value'
-                '  #@endif  '
-            )
-            $script:OsBlockCase13 = New-FixtureTree -Name 'fixture-osblock-case13' -DotEnvLines @(
-                'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
-                'LITELLM_CLIENT_KEY=ck'
-                'DUP_KEY=first_value'
-                "#@if $($script:OsBlockToken)"
-                'DUP_KEY=second_value_inside_active_block'
-                '#@endif'
-            )
-        }
-
-        It '[env-conditional-blocks: case 1] only the active platform block''s value survives' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase1
-            $expected = Get-OsBlockExpected -WindowsValue 'win_value' -PosixValue 'posix_value'
-            Assert-LauncherEnv $r 'BASIC_KEY' $expected "os-block/case1 (host token: $($script:OsBlockToken))"
-        }
-
-        It '[env-conditional-blocks: case 2] marker lines never leak into the loaded env' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase1
-            $leaked = @($r.Env.Keys | Where-Object { $r.Env[$_] -match '#@if|#@endif' })
-            $leaked.Count | Should -Be 0 -Because "marker syntax must never appear in an exported value; found in: $($leaked -join ', ')"
-        }
-
-        It '[env-conditional-blocks: case 3] plain lines outside any block are unconditional' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase3
-            Assert-LauncherEnv $r 'PLAIN_KEY' 'plain_value' 'os-block/case3'
-        }
-
-        It '[env-conditional-blocks: case 4] blank lines outside marker blocks are preserved' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase4
-            Assert-LauncherEnv $r 'BEFORE_KEY' 'before_value' 'os-block/case4'
-            Assert-LauncherEnv $r 'AFTER_KEY' 'after_value' 'os-block/case4'
-        }
-
-        It '[env-conditional-blocks: case 5] nesting does not leak -- an inactive outer block suppresses a would-be-active nested block' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase5
-            Assert-LauncherEnvUnset $r 'OUTER_KEY' "os-block/case5 (host token: $($script:OsBlockToken))"
-            Assert-LauncherEnvUnset $r 'INNER_KEY' 'os-block/case5: suppressDepth must pin at the outer depth'
-        }
-
-        It '[env-conditional-blocks: case 6] nesting does not leak the other way -- an active outer block only removes the nested inactive block' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase6
-            Assert-LauncherEnv $r 'BEFORE_KEY' 'before_value' "os-block/case6 (host token: $($script:OsBlockToken))"
-            Assert-LauncherEnvUnset $r 'NESTED_KEY' 'os-block/case6: the nested inactive block must be removed'
-            Assert-LauncherEnv $r 'AFTER_KEY' 'after_value' 'os-block/case6: content after the nested block, still inside the active outer block, must load'
-        }
-
-        It '[env-conditional-blocks: case 7] an unrecognized token suppresses its block on any host' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase7
-            Assert-LauncherEnvUnset $r 'UNKNOWN_TOKEN_KEY' "os-block/case7 (host token: $($script:OsBlockToken))"
-        }
-
-        It '[env-conditional-blocks: case 8] non-strict spelling ("#@ifwindows", no space) opens no block' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase8
-            Assert-LauncherEnv $r 'FOLLOW_KEY' 'should_always_appear' "os-block/case8 (host token: $($script:OsBlockToken))"
-        }
-
-        It '[env-conditional-blocks: case 9] an orphan #@endif is a no-op' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase9
-            Assert-LauncherEnv $r 'BEFORE_KEY' 'before_value' 'os-block/case9'
-            Assert-LauncherEnv $r 'AFTER_KEY' 'after_value' 'os-block/case9'
-        }
-
-        It '[env-conditional-blocks: case 10] "#@endif foo" (trailing text) never closes the block -- deliberately non-lenient' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase10
-            Assert-LauncherEnvUnset $r 'INSIDE_KEY' "os-block/case10: #@if $($script:OsBlockOtherToken) is inactive on this host (token: $($script:OsBlockToken))"
-            Assert-LauncherEnvUnset $r 'AFTER_KEY' 'os-block/case10: "#@endif foo" does not close the block, so suppression never lifts'
-        }
-
-        It '[env-conditional-blocks: case 11] CRLF-saved markers resolve identically to LF' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase11
-            $expected = Get-OsBlockExpected -WindowsValue 'win_value' -PosixValue 'posix_value'
-            Assert-LauncherEnv $r 'BASIC_KEY' $expected "os-block/case11 (host token: $($script:OsBlockToken))"
-        }
-
-        It '[env-conditional-blocks: case 12] whitespace-padded marker lines are still recognized' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase12
-            $expected = Get-OsBlockExpected -WindowsValue 'win_value' -PosixValue 'posix_value'
-            Assert-LauncherEnv $r 'PAD_KEY' $expected "os-block/case12 (host token: $($script:OsBlockToken))"
-        }
-
-        It '[env-conditional-blocks: case 13] duplicate keys -- first occurrence wins' {
-            $r = Invoke-Launcher -LauncherPath $script:OsBlockCase13
-            Assert-LauncherEnv $r 'DUP_KEY' 'first_value' "os-block/case13: the loader skips re-setting an already-set var (host token: $($script:OsBlockToken))"
-        }
+    # Dot-sourced during Pester's DISCOVERY phase, which is when a Describe body
+    # runs — each file's Context/It blocks are registered as if written here.
+    # Enumerated rather than globbed so the order is the reading order and a new
+    # file has to be added deliberately.
+    foreach ($contextFile in @(
+            'context-01-04-configuration.ps1'
+            'context-05-06-launch.ps1'
+            'context-07-dotenv.ps1'
+            'context-08-parent-env.ps1'
+            'context-09-metacharacters.ps1'
+            'context-10-exe-branch.ps1'
+            'context-11-source-contract.ps1'
+            'context-12-argument-boundaries.ps1'
+            'context-13-routing-precedence.ps1'
+            'context-14-launch-responsiveness.ps1'
+            'context-15-config-value-injection.ps1'
+        )) {
+        . (Join-Path (Join-Path $PSScriptRoot 'code-ccgw-windows') $contextFile)
     }
 }

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-01-04-configuration.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-01-04-configuration.ps1
@@ -1,0 +1,271 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe:
+# what the launcher resolves before it launches anything -- the single-source base
+# URL, the credential, the TLS CA, and the model tier map.
+
+Context '1. Base URL: single source, hard failure when absent' {
+    It 'LITELLM_ANTHROPIC_BASE_URL is the only source' {
+        $r = Invoke-Launcher -Environment (New-Env)
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://lite:1' 'base-url/configured'
+    }
+
+    It 'the retired CCGW_/DS4_ base URLs must not configure the launcher' {
+        # A stale .env carrying them is exactly the situation where a silent
+        # fallback would send traffic down the route this change removed.
+        $env1 = @{ LITELLM_CLIENT_KEY = 'ck' }
+        $env1[$script:RBaseCcgw] = 'https://ccgw:2'
+        $env1[$script:RBaseDs4] = 'https://ds4:3'
+        $r = Invoke-Launcher -Environment $env1
+        $r.ExitCode | Should -Not -Be 0 -Because 'the retired base-URL variables are not a configuration source any more'
+    }
+
+    It 'an unset base URL is a hard failure, not a dummy default' {
+        $r = Invoke-Launcher -Environment @{ LITELLM_CLIENT_KEY = 'ck' }
+        $r.ExitCode | Should -Not -Be 0 -Because 'an unconfigured launcher must not silently pick a default endpoint'
+        Assert-Stderr $r 'LITELLM_ANTHROPIC_BASE_URL' 'base-url/unset: the error must name the variable to set'
+        Assert-Stderr $r 'docs/ops.md' 'base-url/unset: the error must point at the setup procedure'
+    }
+
+    It 'a defined-but-empty base URL is treated as unset' {
+        # The retired .cmd's `if defined` accepted an empty string; the port must
+        # not.
+        $r = Invoke-Launcher -Environment @{ LITELLM_ANTHROPIC_BASE_URL = ''; LITELLM_CLIENT_KEY = 'ck' }
+        $r.ExitCode | Should -Not -Be 0 -Because 'an empty value is not a configured endpoint'
+    }
+}
+
+Context '2. Auth token: LITELLM_CLIENT_KEY, with a one-cycle deprecated alias' {
+    # No virtual keys exist without a LiteLLM database, so the client credential
+    # is the master key itself; LITELLM_VIRTUAL_KEY survives one cycle because an
+    # existing .env carrying only the old name would otherwise 401 with no clue.
+
+    It 'LITELLM_CLIENT_KEY is the credential, and using it warns about nothing' {
+        $r = Invoke-Launcher -Environment (New-Env)
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'ck' 'auth/current-name'
+        # Both streams: the warning stream's destination is host-dependent (see
+        # Assert-LauncherWarning), so checking stderr alone would pass by accident
+        # on a host that routes warnings to stdout.
+        ([string]$r.StdErr + [string]$r.StdOut) | Should -Not -Match '(?i)deprecat' -Because 'the current name must not produce a deprecation warning'
+    }
+
+    It 'the deprecated LITELLM_VIRTUAL_KEY is still accepted, with a warning naming both names' {
+        # The credential is a distinctive string rather than 'vk' because this
+        # path is the one that PRINTS something about it. A deprecation warning is
+        # written to help, and "here is the value I found" is the most natural
+        # unhelpful thing to add to one -- which would put the gateway credential
+        # into terminal scrollback and CI logs (OWASP ASVS V8). The name belongs
+        # in the message; the value never does.
+        $secret = 'vk-alias-secret-must-not-be-echoed'
+        $r = Invoke-Launcher -Environment @{
+            LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1'
+            LITELLM_VIRTUAL_KEY        = $secret
+        }
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' $secret 'auth/alias'
+        Assert-LauncherWarning $r 'LITELLM_VIRTUAL_KEY' 'auth/alias: using the deprecated name must warn'
+        Assert-LauncherWarning $r 'LITELLM_CLIENT_KEY' 'auth/alias: the warning must name the replacement'
+        Assert-NoSecretInOutput $r @($secret) 'auth/alias: the deprecation warning must name the variable, not its value'
+    }
+
+    It 'LITELLM_CLIENT_KEY wins when both names are set' {
+        # A half-migrated .env has to behave predictably.
+        $r = Invoke-Launcher -Environment (New-Env @{ LITELLM_VIRTUAL_KEY = 'vk' })
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'ck' 'auth/both-names'
+    }
+
+    It 'the retired client key variables must not configure the launcher' {
+        $env1 = @{ LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1' }
+        $env1[$script:RKeyCcgw] = 'ck'
+        $env1[$script:RKeyDs4] = 'dk'
+        $r = Invoke-Launcher -Environment $env1
+        $r.ExitCode | Should -Not -Be 0 -Because 'the proxy token is now internal to LiteLLM and no longer a client credential'
+    }
+
+    It 'an unset credential is a hard failure, not a shared dummy token' {
+        # A credential IS present here, under names the launcher no longer accepts
+        # -- the shape a half-migrated .env actually has. That makes this the
+        # error path with a secret in scope: an error message that helpfully
+        # reported "I found <the old CCGW-prefixed API key>=... but I want LITELLM_CLIENT_KEY" would
+        # leak it, and the refusal is exactly where such a message gets written.
+        $attempted = 'retired-name-secret-must-not-be-echoed'
+        $env1 = @{ LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1' }
+        $env1[$script:RKeyCcgw] = $attempted
+        $env1[$script:RKeyDs4] = $attempted
+        $r = Invoke-Launcher -Environment $env1
+        $r.ExitCode | Should -Not -Be 0 -Because 'a missing credential must surface at launch, not as a 401 much later'
+        Assert-Stderr $r 'LITELLM_CLIENT_KEY' 'auth/unset: the error must name the variable to set'
+        $r.StdErr | Should -Not -Match 'dsv4-local' -Because 'the retired dummy token must be gone'
+        Assert-NoSecretInOutput $r @($attempted) 'auth/unset: a refusal must not echo the credential it rejected'
+    }
+
+    It 'a pre-existing ANTHROPIC_API_KEY must be cleared so the local backend is used' {
+        $r = Invoke-Launcher -Environment (New-Env @{ ANTHROPIC_API_KEY = 'cloud-key-must-not-survive' })
+        $r.Reached | Should -BeTrue -Because "stderr: $($r.StdErr)"
+        # Assigning '' removes the variable outright on Windows; both shapes
+        # satisfy the contract "no real cloud key reaches Claude Code".
+        $got = if ($r.Env.ContainsKey('ANTHROPIC_API_KEY')) { $r.Env['ANTHROPIC_API_KEY'] } else { $null }
+        [string]::IsNullOrEmpty($got) | Should -BeTrue -Because "ANTHROPIC_API_KEY survived as '$got'"
+    }
+}
+
+Context '3. TLS CA (retained: LiteLLM terminates TLS with the mkcert leaf)' {
+    It 'CCGW_CA_CERT is honored' {
+        $r = Invoke-Launcher -Environment (New-Env @{ CCGW_CA_CERT = 'C:\ca\ccgw.pem' })
+        Assert-LauncherEnv $r 'NODE_EXTRA_CA_CERTS' 'C:\ca\ccgw.pem' 'ca/explicit'
+        Assert-NoCaWarning $r 'ca/explicit'
+    }
+
+    It 'the retired direct-path CA variable must not be picked up' {
+        $r = Invoke-Launcher -Environment (New-Env @{ $script:RCaDs4 = 'C:\ca\ds4.pem' })
+        Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/retired-var'
+    }
+
+    It 'TLS verification must never be disabled' {
+        # NODE_TLS_REJECT_UNAUTHORIZED=0 must never be the launcher's answer to TLS.
+        $r = Invoke-Launcher -Environment (New-Env @{ CCGW_CA_CERT = 'C:\ca\ccgw.pem' })
+        Assert-LauncherEnvUnset $r 'NODE_TLS_REJECT_UNAUTHORIZED' 'ca/no-tls-bypass'
+    }
+
+    It '3a. mkcert -CAROOT must be derived when no CA var is set' {
+        $r = Invoke-Launcher -StubDir $script:StubMkcertOk -Environment (New-Env)
+        Assert-LauncherEnv $r 'NODE_EXTRA_CA_CERTS' (Join-Path $script:CarootOk 'rootCA.pem') 'ca/mkcert-ok'
+        Assert-NoCaWarning $r 'ca/mkcert-ok'
+    }
+
+    It 'explicit CCGW_CA_CERT must outrank the mkcert derivation' {
+        $r = Invoke-Launcher -StubDir $script:StubMkcertOk -Environment (New-Env @{ CCGW_CA_CERT = 'C:\ca\explicit.pem' })
+        Assert-LauncherEnv $r 'NODE_EXTRA_CA_CERTS' 'C:\ca\explicit.pem' 'ca/explicit-over-mkcert'
+    }
+
+    It '3b. a CAROOT without rootCA.pem must not yield a bogus NODE_EXTRA_CA_CERTS' {
+        $r = Invoke-Launcher -StubDir $script:StubMkcertBad -Environment (New-Env)
+        Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/mkcert-empty'
+        Assert-LauncherWarning $r 'CCGW_CA_CERT not set' 'ca/mkcert-empty'
+    }
+
+    It '3c. mkcert absent entirely must warn and export nothing' {
+        $r = Invoke-Launcher -Environment (New-Env)
+        Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/no-mkcert'
+        Assert-LauncherWarning $r 'CCGW_CA_CERT not set' 'ca/no-mkcert'
+    }
+
+    It '3d. a failing mkcert warns and still launches instead of aborting' {
+        # Under PowerShell 7.4+ a non-zero native exit used to become a
+        # terminating error while ErrorActionPreference is Stop, killing the
+        # launcher outright; the script disables that conversion, so the run must
+        # reach `code`. See the TL3 note in the suite header: a .ps1 stub is not a
+        # native command, so this reaches the warning through the no-CAROOT branch
+        # rather than through the conversion itself.
+        $r = Invoke-Launcher -StubDir $script:StubMkcertFails -Environment (New-Env)
+        $r.Reached | Should -BeTrue -Because "a failing mkcert must not abort the launcher; stderr: $($r.StdErr)"
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        Assert-LauncherEnvUnset $r 'NODE_EXTRA_CA_CERTS' 'ca/mkcert-fails'
+        Assert-LauncherWarning $r 'CCGW_CA_CERT not set' 'ca/mkcert-fails'
+    }
+}
+
+Context '4. Model selection (unconditional LiteLLM routing keys)' {
+    # With the direct path gone there is no branch left: each LITELLM_*_MODEL is a
+    # LiteLLM routing key and goes onto its own /model tier verbatim. The launcher
+    # owns no backend names of its own -- inventing one would route to a model the
+    # gateway has no entry for, and the error would surface as a 400 from LiteLLM
+    # rather than as a launcher message.
+
+    BeforeAll {
+        $script:AllKeys = @{
+            LITELLM_FABLE_MODEL  = 'lite-fable'
+            LITELLM_OPUS_MODEL   = 'lite-opus'
+            LITELLM_SONNET_MODEL = 'lite-sonnet'
+            LITELLM_HAIKU_MODEL  = 'lite-haiku'
+        }
+    }
+
+    It '4a. all four routing keys land verbatim on their own tiers' {
+        $r = Invoke-Launcher -Environment (New-Env $script:AllKeys)
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'lite-fable' 'models: fable routing key'
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models: opus routing key'
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_SONNET_MODEL' 'lite-sonnet' 'models: sonnet routing key'
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_HAIKU_MODEL' 'lite-haiku' 'models: haiku routing key'
+        Assert-LauncherEnv $r 'ANTHROPIC_MODEL' 'lite-fable' 'models: startup model follows the fable tier'
+        Assert-LauncherEnv $r 'ANTHROPIC_CUSTOM_MODEL_OPTION' 'lite-fable' 'models: custom model option follows the fable tier'
+        # Stated as an inequality too: a regression that collapses the tiers onto
+        # one key would still satisfy each literal individually if all literals
+        # moved.
+        Assert-LauncherEnvDiffers $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'ANTHROPIC_DEFAULT_OPUS_MODEL' `
+            'models: fable and opus must address different routing keys or /model cannot switch'
+    }
+
+    It '4b. no retired direct-path backend name may appear in any model var' {
+        # The launcher is not allowed to know them any more.
+        $r = Invoke-Launcher -Environment (New-Env $script:AllKeys)
+        foreach ($v in $script:ModelVars) {
+            $val = if ($r.Env.ContainsKey($v)) { $r.Env[$v] } else { '' }
+            $val | Should -Not -Match '(?i)deepseek' -Because "models: $v='$val' is a backend name, not a LiteLLM routing key"
+            $val | Should -Not -Match '(?i)laguna' -Because "models: $v='$val' is a backend name, not a LiteLLM routing key"
+        }
+    }
+
+    It '4c. the retired startup-model variable must change nothing at all' {
+        $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ $script:RDefaultModel = 'laguna-s-2.1' }))
+        Assert-LauncherEnv $r 'ANTHROPIC_MODEL' 'lite-fable' 'models/retired-default: the retired startup-model variable must be ignored'
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models/retired-default: the tier map must be unaffected'
+    }
+
+    # 4d. Subagent contract (three cases).
+    #
+    # Why it changed: the old launcher pinned CLAUDE_CODE_SUBAGENT_MODEL to the
+    # fable tier so a subagent could not evict the resident backend. Routing now
+    # goes through LiteLLM, which multiplexes, so the pin is no longer needed --
+    # and it actively harms, because it silently overrides the model an agent
+    # definition's frontmatter declares. Default is therefore "say nothing";
+    # CCGW_SUBAGENT_MODEL exists only for the case where a user deliberately wants
+    # every subagent confined to one route.
+
+    It '4d-i. by default the subagent model is not exported at all' {
+        $r = Invoke-Launcher -Environment (New-Env $script:AllKeys)
+        Assert-LauncherEnvUnset $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'subagent/default: an unconditional value overrides agent frontmatter'
+    }
+
+    It '4d-ii. CCGW_SUBAGENT_MODEL is exported verbatim' {
+        $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ CCGW_SUBAGENT_MODEL = 'lite-haiku' }))
+        Assert-LauncherEnv $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'lite-haiku' 'subagent/opt-in'
+    }
+
+    It '4d-iii. an arbitrary routing key passes through untranslated' {
+        # A key the launcher has never heard of must survive intact, and a tier
+        # name must NOT be mapped to that tier's value.
+        $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ CCGW_SUBAGENT_MODEL = 'some-other-routing-key' }))
+        Assert-LauncherEnv $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'some-other-routing-key' 'subagent/domain'
+    }
+
+    It 'a defined-but-empty CCGW_SUBAGENT_MODEL counts as unset' {
+        # Exporting an empty model name would make Claude Code request "" and fail
+        # at the gateway.
+        $r = Invoke-Launcher -Environment (New-Env @{ LITELLM_FABLE_MODEL = 'lite-fable'; CCGW_SUBAGENT_MODEL = '' })
+        Assert-LauncherEnvUnset $r 'CLAUDE_CODE_SUBAGENT_MODEL' 'subagent/empty'
+    }
+
+    It '4e. no routing keys at all: nothing may be invented' {
+        $r = Invoke-Launcher -Environment (New-Env)
+        foreach ($v in $script:ModelVars) {
+            Assert-LauncherEnvUnset $r $v 'models/no-keys: the launcher must substitute no model name of its own'
+        }
+    }
+
+    It '4f. partial keys: the fable tier drives the startup vars, so its absence leaves them unset' {
+        $r = Invoke-Launcher -Environment (New-Env @{
+                LITELLM_OPUS_MODEL   = 'lite-opus'
+                LITELLM_SONNET_MODEL = 'lite-sonnet'
+                LITELLM_HAIKU_MODEL  = 'lite-haiku'
+            })
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models/no-fable: opus routing key still applies'
+        Assert-LauncherEnvUnset $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'models/no-fable: no fable key means no fable tier'
+        foreach ($v in $script:ActiveVars) {
+            Assert-LauncherEnvUnset $r $v 'models/no-fable: the launcher must invent no model name of its own'
+        }
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-05-06-launch.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-05-06-launch.ps1
@@ -1,0 +1,67 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe:
+# the launch itself -- the isolated VS Code profile, argv passthrough, the working
+# directory, and the missing-`code` refusal.
+
+Context '5. VS Code profile isolation and argv passthrough' {
+    It 'passes an isolated --user-data-dir under LOCALAPPDATA plus the caller argv' {
+        $r = Invoke-Launcher -Environment (New-Env) -Arguments @('C:\some\project', '--new-window')
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'), 'C:\some\project', '--new-window')
+        @($r.Argv) | Should -Be $expected
+    }
+
+    It 'passes only the --user-data-dir pair when the caller supplied no argv' {
+        $r = Invoke-Launcher -Environment (New-Env)
+        $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'))
+        @($r.Argv) | Should -Be $expected
+    }
+
+    It 'falls back to a home-relative profile dir when LOCALAPPDATA is unset' {
+        # LOCALAPPDATA is always set on a normal Windows session, but a stripped
+        # service environment would otherwise make the final Join-Path throw after
+        # every env var had already been resolved. The exact fallback spelling is
+        # the script's business; what must hold is that it still launches, still
+        # isolates, and still roots the profile under the user's home.
+        $r = Invoke-Launcher -Environment (New-Env) -NoLocalAppData
+        $r.Reached | Should -BeTrue -Because "an unset LOCALAPPDATA must not abort the launcher; stderr: $($r.StdErr)"
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        @($r.Argv).Count | Should -Be 2
+        $r.Argv[0] | Should -Be '--user-data-dir'
+        $r.Argv[1] | Should -BeLike "$($script:Work)*"
+        $r.Argv[1] | Should -BeLike '*vscode-ccgw'
+        # Still isolated: the fallback must not be the LOCALAPPDATA path, and must
+        # not be the bare home dir either.
+        $r.Argv[1] | Should -Not -Be (Join-Path $script:Work 'vscode-ccgw')
+    }
+
+    It 'resolves .env and the profile dir from the script''s own location, not the caller''s cwd' {
+        # The launcher composes its .env path from $PSScriptRoot. Switching to an
+        # explicit Process.Start makes the child's working directory a thing the
+        # launcher now sets deliberately, so the invariant is worth pinning: a
+        # developer running the launcher from anywhere must get the same
+        # configuration, and the child must actually start in the caller's
+        # directory (VS Code resolves relative file arguments there).
+        $elsewhere = Join-Path $script:Work 'cwd-elsewhere'
+        New-Item -ItemType Directory -Path $elsewhere -Force | Out-Null
+        $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncherForCwd -WorkingDirectory $elsewhere
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://from-dotenv-cwd:9' 'cwd: .env is resolved from $PSScriptRoot, not the cwd'
+        $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'))
+        @($r.Argv) | Should -Be $expected -Because 'the profile dir must not depend on the cwd either'
+        (Resolve-Path -LiteralPath $r.Cwd).Path | Should -Be (Resolve-Path -LiteralPath $elsewhere).Path `
+            -Because 'the child must inherit the caller''s directory so relative file arguments still resolve'
+    }
+}
+
+Context '6. Missing code on PATH' {
+    It 'is a hard failure that names both the problem and the remedy' {
+        $r = Invoke-Launcher -StubDir $script:StubNoCode -Environment (New-Env)
+        $r.ExitCode | Should -Not -Be 0 -Because 'a missing code command must not exit 0'
+        Assert-Stderr $r "'code' command not found on PATH" 'missing-code: must name the problem'
+        Assert-Stderr $r "Install 'code' command in PATH" 'missing-code: must state the remedy'
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-07-dotenv.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-07-dotenv.ps1
@@ -1,0 +1,268 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe:
+# the repo-root .env loader, including the #@if windows / #@if posix conditional
+# blocks (issue #56).
+
+Context '7. Repo-root .env loading' {
+    # The launcher composes the path as Join-Path (Join-Path $PSScriptRoot '..') '.env',
+    # so the separator is the platform's own and these cases run everywhere pwsh
+    # does -- they are not Windows-gated.
+
+    # One BeforeAll for the whole Context, deliberately: Pester 5 keeps only the
+    # LAST BeforeAll of a block, so a second one silently discards the first --
+    # which is how the .env fixtures below came to be $null and the four
+    # plain-.env cases to fail on an empty -File path. The OS-conditional fixtures
+    # therefore live here rather than in a block of their own.
+    BeforeAll {
+        $script:DotEnvLauncher = New-FixtureTree -Name 'fixture-dotenv' -DotEnvLines @(
+            '# comment line must be ignored'
+            ''
+            'LITELLM_ANTHROPIC_BASE_URL=https://from-dotenv:9'
+            'LITELLM_CLIENT_KEY=dotenv-token'
+            '  LITELLM_FABLE_MODEL = lite-fable  '
+            'MALFORMED_NO_EQUALS'
+        )
+
+        # --- OS-conditional blocks (issue #56): `#@if windows` / `#@if posix` /
+        # `#@endif` in the repo-root .env.
+        #
+        # This suite runs wherever pwsh happens to execute, not necessarily on
+        # Windows, and the launcher's own platform-token resolution ($IsWindows,
+        # falling back to 'windows' only when that variable does not exist at all)
+        # is a property of whatever REAL host runs the child launcher process
+        # below -- it cannot be mocked without touching the source. So every
+        # assertion here is phrased in terms of $script:OsBlockToken, resolved the
+        # same way, rather than hardcoding an assumption that the host is Windows.
+        $script:OsBlockToken = if (Test-Path variable:IsWindows) { if ($IsWindows) { 'windows' } else { 'posix' } } else { 'windows' }
+        $script:OsBlockOtherToken = if ($script:OsBlockToken -eq 'windows') { 'posix' } else { 'windows' }
+
+        function Get-OsBlockExpected {
+            param([string]$WindowsValue, [string]$PosixValue)
+            if ($script:OsBlockToken -eq 'windows') { return $WindowsValue }
+            return $PosixValue
+        }
+
+        $script:OsBlockCase1 = New-FixtureTree -Name 'fixture-osblock-case1' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            '#@if windows'
+            'BASIC_KEY=win_value'
+            '#@endif'
+            '#@if posix'
+            'BASIC_KEY=posix_value'
+            '#@endif'
+        )
+        $script:OsBlockCase3 = New-FixtureTree -Name 'fixture-osblock-case3' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            '# a plain comment'
+            'PLAIN_KEY=plain_value'
+        )
+        $script:OsBlockCase4 = New-FixtureTree -Name 'fixture-osblock-case4' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            'BEFORE_KEY=before_value'
+            ''
+            'AFTER_KEY=after_value'
+        )
+        $script:OsBlockCase5 = New-FixtureTree -Name 'fixture-osblock-case5' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            "#@if $($script:OsBlockOtherToken)"
+            'OUTER_KEY=outer_should_not_appear'
+            "#@if $($script:OsBlockToken)"
+            'INNER_KEY=inner_should_not_appear'
+            '#@endif'
+            '#@endif'
+        )
+        $script:OsBlockCase6 = New-FixtureTree -Name 'fixture-osblock-case6' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            "#@if $($script:OsBlockToken)"
+            'BEFORE_KEY=before_value'
+            "#@if $($script:OsBlockOtherToken)"
+            'NESTED_KEY=nested_should_not_appear'
+            '#@endif'
+            'AFTER_KEY=after_value'
+            '#@endif'
+        )
+        $script:OsBlockCase7 = New-FixtureTree -Name 'fixture-osblock-case7' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            '#@if darwin'
+            'UNKNOWN_TOKEN_KEY=should_never_appear'
+            '#@endif'
+        )
+        $script:OsBlockCase8 = New-FixtureTree -Name 'fixture-osblock-case8' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            '#@ifwindows'
+            'FOLLOW_KEY=should_always_appear'
+            '#@endif'
+        )
+        $script:OsBlockCase9 = New-FixtureTree -Name 'fixture-osblock-case9' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            'BEFORE_KEY=before_value'
+            '#@endif'
+            'AFTER_KEY=after_value'
+        )
+        $script:OsBlockCase10 = New-FixtureTree -Name 'fixture-osblock-case10' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            "#@if $($script:OsBlockOtherToken)"
+            'INSIDE_KEY=inside_value'
+            '#@endif foo'
+            'AFTER_KEY=after_value'
+        )
+
+        $script:OsBlockCase11 = New-FixtureTree -Name 'fixture-osblock-case11'
+        $osBlockCase11Root = Split-Path (Split-Path $script:OsBlockCase11 -Parent) -Parent
+        $osBlockCase11Lines = @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            '#@if windows'
+            'BASIC_KEY=win_value'
+            '#@endif'
+            '#@if posix'
+            'BASIC_KEY=posix_value'
+            '#@endif'
+        )
+        # Explicit CRLF write: New-FixtureTree's Set-Content uses this host's
+        # default newline, which is already LF on macOS/Linux -- this case exists
+        # specifically to prove a CRLF-authored .env (e.g. edited on a real
+        # Windows box) resolves identically regardless of host.
+        [System.IO.File]::WriteAllText((Join-Path $osBlockCase11Root '.env'), (($osBlockCase11Lines -join "`r`n") + "`r`n"))
+
+        $script:OsBlockCase12 = New-FixtureTree -Name 'fixture-osblock-case12' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            '  #@if windows  '
+            'PAD_KEY=win_value'
+            '  #@endif  '
+            '  #@if posix  '
+            'PAD_KEY=posix_value'
+            '  #@endif  '
+        )
+        $script:OsBlockCase13 = New-FixtureTree -Name 'fixture-osblock-case13' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://lite:1'
+            'LITELLM_CLIENT_KEY=ck'
+            'DUP_KEY=first_value'
+            "#@if $($script:OsBlockToken)"
+            'DUP_KEY=second_value_inside_active_block'
+            '#@endif'
+        )
+    }
+
+    It 'loads KEY=value lines and ignores comments and blanks' {
+        $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://from-dotenv:9' 'dotenv: base URL comes from .env'
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'dotenv-token' 'dotenv: auth token comes from .env'
+    }
+
+    It 'trims surrounding whitespace around key and value' {
+        $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_FABLE_MODEL' 'lite-fable' 'dotenv: whitespace-padded KEY = value is trimmed'
+    }
+
+    It 'a non-empty shell value outranks .env' {
+        $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher `
+            -Environment @{ LITELLM_ANTHROPIC_BASE_URL = 'https://from-shell:1' }
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://from-shell:1' 'dotenv: shell wins over .env'
+    }
+
+    It 'a defined-but-empty shell value is treated as unset, so .env still applies' {
+        # Every consumer below treats empty as unset, so honouring the empty shell
+        # value would silently discard the .env entry.
+        $r = Invoke-Launcher -LauncherPath $script:DotEnvLauncher `
+            -Environment @{ LITELLM_ANTHROPIC_BASE_URL = '' }
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://from-dotenv:9' 'dotenv: empty shell value must not shadow .env'
+    }
+
+    It 'a missing .env is not an error when the shell supplies the configuration' {
+        $bare = Join-Path $script:Work 'fixture-no-dotenv'
+        New-Item -ItemType Directory -Path (Join-Path $bare 'scripts') -Force | Out-Null
+        Copy-Item -LiteralPath $script:SourceLauncher -Destination (Join-Path $bare 'scripts' 'code-ccgw.ps1') -Force
+        $r = Invoke-Launcher -LauncherPath (Join-Path $bare 'scripts' 'code-ccgw.ps1') -Environment (New-Env)
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://lite:1' 'dotenv/absent: launcher still runs'
+    }
+
+    It '[env-conditional-blocks: case 1] only the active platform block''s value survives' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase1
+        $expected = Get-OsBlockExpected -WindowsValue 'win_value' -PosixValue 'posix_value'
+        Assert-LauncherEnv $r 'BASIC_KEY' $expected "os-block/case1 (host token: $($script:OsBlockToken))"
+    }
+
+    It '[env-conditional-blocks: case 2] marker lines never leak into the loaded env' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase1
+        $leaked = @($r.Env.Keys | Where-Object { $r.Env[$_] -match '#@if|#@endif' })
+        $leaked.Count | Should -Be 0 -Because "marker syntax must never appear in an exported value; found in: $($leaked -join ', ')"
+    }
+
+    It '[env-conditional-blocks: case 3] plain lines outside any block are unconditional' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase3
+        Assert-LauncherEnv $r 'PLAIN_KEY' 'plain_value' 'os-block/case3'
+    }
+
+    It '[env-conditional-blocks: case 4] blank lines outside marker blocks are preserved' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase4
+        Assert-LauncherEnv $r 'BEFORE_KEY' 'before_value' 'os-block/case4'
+        Assert-LauncherEnv $r 'AFTER_KEY' 'after_value' 'os-block/case4'
+    }
+
+    It '[env-conditional-blocks: case 5] nesting does not leak -- an inactive outer block suppresses a would-be-active nested block' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase5
+        Assert-LauncherEnvUnset $r 'OUTER_KEY' "os-block/case5 (host token: $($script:OsBlockToken))"
+        Assert-LauncherEnvUnset $r 'INNER_KEY' 'os-block/case5: suppressDepth must pin at the outer depth'
+    }
+
+    It '[env-conditional-blocks: case 6] nesting does not leak the other way -- an active outer block only removes the nested inactive block' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase6
+        Assert-LauncherEnv $r 'BEFORE_KEY' 'before_value' "os-block/case6 (host token: $($script:OsBlockToken))"
+        Assert-LauncherEnvUnset $r 'NESTED_KEY' 'os-block/case6: the nested inactive block must be removed'
+        Assert-LauncherEnv $r 'AFTER_KEY' 'after_value' 'os-block/case6: content after the nested block, still inside the active outer block, must load'
+    }
+
+    It '[env-conditional-blocks: case 7] an unrecognized token suppresses its block on any host' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase7
+        Assert-LauncherEnvUnset $r 'UNKNOWN_TOKEN_KEY' "os-block/case7 (host token: $($script:OsBlockToken))"
+    }
+
+    It '[env-conditional-blocks: case 8] non-strict spelling ("#@ifwindows", no space) opens no block' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase8
+        Assert-LauncherEnv $r 'FOLLOW_KEY' 'should_always_appear' "os-block/case8 (host token: $($script:OsBlockToken))"
+    }
+
+    It '[env-conditional-blocks: case 9] an orphan #@endif is a no-op' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase9
+        Assert-LauncherEnv $r 'BEFORE_KEY' 'before_value' 'os-block/case9'
+        Assert-LauncherEnv $r 'AFTER_KEY' 'after_value' 'os-block/case9'
+    }
+
+    It '[env-conditional-blocks: case 10] "#@endif foo" (trailing text) never closes the block -- deliberately non-lenient' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase10
+        Assert-LauncherEnvUnset $r 'INSIDE_KEY' "os-block/case10: #@if $($script:OsBlockOtherToken) is inactive on this host (token: $($script:OsBlockToken))"
+        Assert-LauncherEnvUnset $r 'AFTER_KEY' 'os-block/case10: "#@endif foo" does not close the block, so suppression never lifts'
+    }
+
+    It '[env-conditional-blocks: case 11] CRLF-saved markers resolve identically to LF' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase11
+        $expected = Get-OsBlockExpected -WindowsValue 'win_value' -PosixValue 'posix_value'
+        Assert-LauncherEnv $r 'BASIC_KEY' $expected "os-block/case11 (host token: $($script:OsBlockToken))"
+    }
+
+    It '[env-conditional-blocks: case 12] whitespace-padded marker lines are still recognized' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase12
+        $expected = Get-OsBlockExpected -WindowsValue 'win_value' -PosixValue 'posix_value'
+        Assert-LauncherEnv $r 'PAD_KEY' $expected "os-block/case12 (host token: $($script:OsBlockToken))"
+    }
+
+    It '[env-conditional-blocks: case 13] duplicate keys -- first occurrence wins' {
+        $r = Invoke-Launcher -LauncherPath $script:OsBlockCase13
+        Assert-LauncherEnv $r 'DUP_KEY' 'first_value' "os-block/case13: the loader skips re-setting an already-set var (host token: $($script:OsBlockToken))"
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-08-parent-env.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-08-parent-env.ps1
@@ -5,36 +5,16 @@
 # Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
 
 Context '8. The invoking shell keeps its own environment (issue #66)' {
-    # Contexts 1-7 all read the CHILD's environment, and the defect reported in
-    # #66 lives in the PARENT's: PowerShell has no exec, so a launcher that
-    # assigns to `$env:` outlives the VS Code launch and leaves those values in
-    # the shell the developer typed the command into. The next, unrelated cloud
-    # Claude Code session started from that same shell then inherits local-LLM
-    # routing. Only Invoke-LauncherInParentShell can see it: it interposes a
-    # wrapper that runs the launcher in its own process and snapshots its
-    # environment on either side.
-    #
-    # Why every variable the launcher sets carries a sentinel rather than just
-    # ANTHROPIC_API_KEY (which is all the suite used to pre-seed): the two failure
-    # shapes are different and each hides on a different variable. "Assigned, then
-    # never cleaned up" leaves the launcher's value behind; "assigned, then
-    # removed" deletes a value the shell already had. 8b names the offending
-    # variable in its own message so either shape points straight at the
-    # assignment that caused it.
-    #
-    # 8b and 8e are deliberately a pair, and read the SAME run: "the parent is
-    # untouched" is satisfied just as well by a launcher that computes nothing at
-    # all, so the child must be shown to have received the correctly-computed
-    # values in the very same launch (CPR-E2E).
-    #
-    # 8g-8j carry the same contract onto the paths that do NOT reach a launch.
-    # Every one of them fails partway through the resolution sequence, which is
-    # precisely where a half-applied environment would be abandoned in the shell:
-    # a launcher that unwound its own writes only on the happy path would satisfy
-    # 8a and still poison the shell of every developer who mistyped a variable
-    # name. They also assert the negative that a snapshot comparison cannot see --
-    # no VS Code was started -- and that the refusal message did not echo the
-    # credential back.
+    # Contexts 1-7 read the CHILD's environment; #66 lives in the PARENT's:
+    # PowerShell has no exec, so `$env:` assignments outlive the VS Code launch
+    # and leak into the developer's shell, inherited by the next unrelated
+    # cloud session as local-LLM routing. Invoke-LauncherInParentShell wraps
+    # the launcher and snapshots the environment on either side. Every
+    # variable carries a sentinel (not just the old ANTHROPIC_API_KEY
+    # pre-seed) since "never cleaned up" vs. "assigned then removed" hide on
+    # different names, and 8b names the offender. 8b/8e read the SAME run
+    # (CPR-E2E: an untouched parent alone also fits a launcher that computes
+    # nothing). 8g-8j repeat the contract on paths that never launch.
 
     BeforeAll {
         # One map, two roles (CPR-SSOT): its keys are the variables that must

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-08-parent-env.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-08-parent-env.ps1
@@ -1,0 +1,227 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '8. The invoking shell keeps its own environment (issue #66)' {
+    # Contexts 1-7 all read the CHILD's environment, and the defect reported in
+    # #66 lives in the PARENT's: PowerShell has no exec, so a launcher that
+    # assigns to `$env:` outlives the VS Code launch and leaves those values in
+    # the shell the developer typed the command into. The next, unrelated cloud
+    # Claude Code session started from that same shell then inherits local-LLM
+    # routing. Only Invoke-LauncherInParentShell can see it: it interposes a
+    # wrapper that runs the launcher in its own process and snapshots its
+    # environment on either side.
+    #
+    # Why every variable the launcher sets carries a sentinel rather than just
+    # ANTHROPIC_API_KEY (which is all the suite used to pre-seed): the two failure
+    # shapes are different and each hides on a different variable. "Assigned, then
+    # never cleaned up" leaves the launcher's value behind; "assigned, then
+    # removed" deletes a value the shell already had. 8b names the offending
+    # variable in its own message so either shape points straight at the
+    # assignment that caused it.
+    #
+    # 8b and 8e are deliberately a pair, and read the SAME run: "the parent is
+    # untouched" is satisfied just as well by a launcher that computes nothing at
+    # all, so the child must be shown to have received the correctly-computed
+    # values in the very same launch (CPR-E2E).
+    #
+    # 8g-8j carry the same contract onto the paths that do NOT reach a launch.
+    # Every one of them fails partway through the resolution sequence, which is
+    # precisely where a half-applied environment would be abandoned in the shell:
+    # a launcher that unwound its own writes only on the happy path would satisfy
+    # 8a and still poison the shell of every developer who mistyped a variable
+    # name. They also assert the negative that a snapshot comparison cannot see --
+    # no VS Code was started -- and that the refusal message did not echo the
+    # credential back.
+
+    BeforeAll {
+        # One map, two roles (CPR-SSOT): its keys are the variables that must
+        # survive untouched in the parent, its values are what the child must
+        # receive for each of them given the fixture .env below.
+        $script:Ctx8ExpectedChild = [ordered]@{
+            ANTHROPIC_BASE_URL                        = 'https://ctx8-lite:1'
+            ANTHROPIC_AUTH_TOKEN                      = 'ctx8-client-key'
+            NODE_EXTRA_CA_CERTS                       = 'C:\ctx8\ca.pem'
+            ANTHROPIC_DEFAULT_FABLE_MODEL             = 'ctx8-fable'
+            ANTHROPIC_DEFAULT_OPUS_MODEL              = 'ctx8-opus'
+            ANTHROPIC_DEFAULT_SONNET_MODEL            = 'ctx8-sonnet'
+            ANTHROPIC_DEFAULT_HAIKU_MODEL             = 'ctx8-haiku'
+            ANTHROPIC_MODEL                           = 'ctx8-fable'
+            ANTHROPIC_CUSTOM_MODEL_OPTION             = 'ctx8-fable'
+            ANTHROPIC_CUSTOM_MODEL_OPTION_NAME        = 'Local model via ccgw'
+            ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION = 'Mac backend via the LiteLLM gateway, selected per request'
+            CLAUDE_CODE_SUBAGENT_MODEL                = 'ctx8-subagent'
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC  = '1'
+            CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK = '1'
+            CLAUDE_STREAM_IDLE_TIMEOUT_MS             = '600000'
+            CLAUDE_CODE_AUTO_COMPACT_WINDOW           = '65536'
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE           = '75'
+        }
+        # ANTHROPIC_API_KEY is deliberately NOT in that map: its contract is the
+        # opposite shape ("the child must see no key at all"), so it gets its own
+        # case, 8d.
+        $script:MustVars = @($script:Ctx8ExpectedChild.Keys)
+
+        # Every routing key set, so each variable above is genuinely computed to
+        # something OTHER than its sentinel -- a launcher that quietly stopped
+        # exporting anything must not be able to pass 8b.
+        $script:Ctx8Launcher = New-FixtureTree -Name 'fixture-ctx8' -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://ctx8-lite:1'
+            'LITELLM_CLIENT_KEY=ctx8-client-key'
+            'CCGW_CA_CERT=C:\ctx8\ca.pem'
+            'LITELLM_FABLE_MODEL=ctx8-fable'
+            'LITELLM_OPUS_MODEL=ctx8-opus'
+            'LITELLM_SONNET_MODEL=ctx8-sonnet'
+            'LITELLM_HAIKU_MODEL=ctx8-haiku'
+            'CCGW_SUBAGENT_MODEL=ctx8-subagent'
+            'BASIC_KEY=ctx8-basic'
+        )
+        # Keys the .env introduces that the shell never had. They exist to prove
+        # the loader's own writes do not land in the shell either (8c).
+        $script:Ctx8DotEnvOnlyKeys = @(
+            'BASIC_KEY', 'LITELLM_ANTHROPIC_BASE_URL', 'LITELLM_CLIENT_KEY',
+            'CCGW_CA_CERT', 'LITELLM_FABLE_MODEL', 'LITELLM_OPUS_MODEL',
+            'LITELLM_SONNET_MODEL', 'LITELLM_HAIKU_MODEL', 'CCGW_SUBAGENT_MODEL'
+        )
+
+        $script:Ctx8ApiKey = 'cloud-key-must-survive-in-parent'
+
+        # The shell the developer typed the command into: every variable the
+        # launcher touches already holds a value of the user's own. Reused by the
+        # failure cases so they police the same names as 8b.
+        function New-Ctx8ParentEnv {
+            param([hashtable]$Config = @{})
+            $h = @{ ANTHROPIC_API_KEY = $script:Ctx8ApiKey }
+            foreach ($n in $script:MustVars) { $h[$n] = "PARENT-SENTINEL-$n-KEEP" }
+            foreach ($k in $Config.Keys) { $h[$k] = $Config[$k] }
+            return $h
+        }
+
+        # The credential the failure cases hand in. Distinct from the happy path's
+        # so a leak assertion cannot be satisfied by the wrong run's value.
+        $script:Ctx8ErrKey = 'ctx8-error-path-secret-key'
+
+        # One launch, read by every case below, so the cases cannot disagree about
+        # what happened (CPR-SSOT) and the suite pays for it once.
+        $script:Ctx8 = Invoke-LauncherInParentShell `
+            -Environment (New-Ctx8ParentEnv) -LauncherPath $script:Ctx8Launcher
+    }
+
+    It '8a. the invoking shell''s environment is byte-for-byte identical before and after' {
+        # Stated as a zero-difference contract rather than as a list of forbidden
+        # names: a variable nobody thought to enumerate is exactly the one a future
+        # assignment would leak (CPR-UNV).
+        Assert-ParentEnvUnchanged $script:Ctx8 'ctx8/happy-path'
+    }
+
+    It '8b. every variable the launcher sets keeps its pre-existing value in the invoking shell' {
+        $after = $script:Ctx8.AfterEnv
+        $bad = New-Object System.Collections.Generic.List[string]
+        foreach ($name in $script:MustVars) {
+            $expected = "PARENT-SENTINEL-$name-KEEP"
+            if (-not $after.ContainsKey($name)) {
+                $bad.Add("$name was REMOVED from the invoking shell")
+            } elseif ($after[$name] -cne $expected) {
+                $bad.Add("$name = '$($after[$name])' (expected the untouched '$expected')")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "issue #66: $($bad -join '; ')"
+    }
+
+    It '8c. keys the launcher loaded from .env do not land in the invoking shell either' {
+        $after = $script:Ctx8.AfterEnv
+        $leaked = @($script:Ctx8DotEnvOnlyKeys | Where-Object { $after.ContainsKey($_) })
+        $leaked.Count | Should -Be 0 -Because "the .env loader must populate the child's block, not the shell's; leaked: $($leaked -join ', ')"
+    }
+
+    It '8d. a real cloud ANTHROPIC_API_KEY survives in the shell but never reaches the child' {
+        # Two halves of one contract, and the launcher used to get both wrong in
+        # the same statement: `$env:ANTHROPIC_API_KEY = ''` destroyed the
+        # developer's real key in their own shell while it was blanking it for VS
+        # Code.
+        $script:Ctx8.AfterEnv['ANTHROPIC_API_KEY'] | Should -BeExactly $script:Ctx8ApiKey `
+            -Because 'blanking the key for VS Code must not blank it for the shell'
+        $got = if ($script:Ctx8.Env.ContainsKey('ANTHROPIC_API_KEY')) { $script:Ctx8.Env['ANTHROPIC_API_KEY'] } else { $null }
+        [string]::IsNullOrEmpty($got) | Should -BeTrue -Because "ANTHROPIC_API_KEY reached the child as '$got'"
+    }
+
+    It '8e. the same launch still hands the computed values to the child' {
+        $script:Ctx8.Reached | Should -BeTrue -Because "stderr: $($script:Ctx8.StdErr)"
+        $bad = New-Object System.Collections.Generic.List[string]
+        foreach ($name in $script:MustVars) {
+            $expected = [string]$script:Ctx8ExpectedChild[$name]
+            if (-not $script:Ctx8.Env.ContainsKey($name)) {
+                $bad.Add("$name never reached the child (expected '$expected')")
+            } elseif ($script:Ctx8.Env[$name] -cne $expected) {
+                $bad.Add("$name = '$($script:Ctx8.Env[$name])' (expected '$expected')")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "protecting the parent must not mean starving the child: $($bad -join '; ')"
+    }
+
+    It '8f. the gateway credential never appears in the launcher''s own output' {
+        # The credential is the one secret the launcher handles; a diagnostic that
+        # echoes it would put it into terminal scrollback and CI logs (OWASP ASVS
+        # V8).
+        Assert-NoSecretInOutput $script:Ctx8 @('ctx8-client-key', $script:Ctx8ApiKey) 'ctx8/happy-path'
+    }
+
+    It '8g. an unset base URL refuses without touching the invoking shell' {
+        # The earliest exit there is: it happens after ANTHROPIC_API_KEY has
+        # already been dealt with, which is exactly the write that used to destroy
+        # the developer's own key on the way out.
+        $r = Invoke-LauncherInParentShell -LauncherPath $script:Launcher `
+            -Environment (New-Ctx8ParentEnv @{ LITELLM_CLIENT_KEY = $script:Ctx8ErrKey })
+        $r.LauncherExitCode | Should -Not -Be '0' -Because "an unconfigured base URL must not exit 0; stderr: $($r.StdErr)"
+        Assert-ParentEnvUnchanged $r 'ctx8/base-url-unset'
+        Assert-NoChildLaunched $r 'ctx8/base-url-unset'
+        Assert-NoSecretInOutput $r @($script:Ctx8ErrKey, $script:Ctx8ApiKey) 'ctx8/base-url-unset'
+    }
+
+    It '8h. an unset credential refuses without touching the invoking shell' {
+        # One statement further in: the base URL has been resolved, so a launcher
+        # that writes as it goes has already made its first assignment when this
+        # guard fires.
+        #
+        # Two credentials are in scope on this path even though neither is
+        # accepted: the shell's own ANTHROPIC_API_KEY, which the launcher has
+        # already handled by the time the guard fires, and a value under a retired
+        # name -- the half-migrated .env that produces this error in real life.
+        # The refusal is written precisely when the launcher is trying to be
+        # helpful about credentials, so both must be shown to stay out of it.
+        $ctx8hEnv = New-Ctx8ParentEnv @{ LITELLM_ANTHROPIC_BASE_URL = 'https://ctx8-err:1' }
+        $ctx8hEnv[$script:RKeyCcgw] = $script:Ctx8ErrKey
+        $r = Invoke-LauncherInParentShell -LauncherPath $script:Launcher -Environment $ctx8hEnv
+        $r.LauncherExitCode | Should -Not -Be '0' -Because "a missing credential must not exit 0; stderr: $($r.StdErr)"
+        Assert-ParentEnvUnchanged $r 'ctx8/credential-unset'
+        Assert-NoChildLaunched $r 'ctx8/credential-unset'
+        Assert-NoSecretInOutput $r @($script:Ctx8ErrKey, $script:Ctx8ApiKey) 'ctx8/credential-unset'
+    }
+
+    It '8i. a missing `code` refuses without touching the invoking shell' {
+        # The far end of the resolution sequence: every value has been computed by
+        # the time this guard fires, so this is the case that leaks the MOST if
+        # the values went into the launcher's own process.
+        $r = Invoke-LauncherInParentShell -LauncherPath $script:Ctx8Launcher -StubDir $script:StubNoCode `
+            -Environment (New-Ctx8ParentEnv)
+        $r.LauncherExitCode | Should -Not -Be '0' -Because "a missing code command must not exit 0; stderr: $($r.StdErr)"
+        Assert-ParentEnvUnchanged $r 'ctx8/missing-code'
+        Assert-NoChildLaunched $r 'ctx8/missing-code'
+        Assert-NoSecretInOutput $r @('ctx8-client-key', $script:Ctx8ApiKey) 'ctx8/missing-code'
+    }
+
+    It '8j. a `code` that cannot be started refuses without touching the invoking shell' -Skip:(-not $IsWindows) {
+        # Past the last guard: `code` resolves, so the launcher commits to the
+        # launch and CreateProcess is what fails. Nothing after this point can be
+        # rolled back, which is why the environment must never have been written
+        # in the first place.
+        $r = Invoke-LauncherInParentShell -LauncherPath $script:Ctx8Launcher -StubDir $script:StubBrokenExe `
+            -Environment (New-Ctx8ParentEnv)
+        $r.LauncherExitCode | Should -Not -Be '0' -Because "a failed process start must be reported, not swallowed; stderr: $($r.StdErr)"
+        Assert-ParentEnvUnchanged $r 'ctx8/process-start-failure'
+        Assert-NoChildLaunched $r 'ctx8/process-start-failure'
+        Assert-NoSecretInOutput $r @('ctx8-client-key', $script:Ctx8ApiKey) 'ctx8/process-start-failure'
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-09-metacharacters.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-09-metacharacters.ps1
@@ -5,17 +5,15 @@
 # Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
 
 Context '9. Argument metacharacters stay data, never cmd.exe operators (issue #66)' -Skip:(-not $IsWindows) {
-    # Windows-only by nature: the hazard is cmd.exe, and the stub that observes it
-    # is a .cmd. `code` resolves to code.cmd on a real VS Code install, and Win32
-    # CreateProcess given a .cmd/.bat silently re-launches cmd.exe to interpret it
-    # -- so an argument carrying &, |, ^, <, > or % is re-read as shell syntax even
-    # when it contains no whitespace at all (the BatBadBut class).
-    # CommandLineToArgvW-style quoting, which is what an .exe target needs, does
-    # not defend against this.
-    #
-    # These cases depend on the stub echoing `ARG="%~1"` with the expansion
-    # already inside quotes; see the Method note in the suite header for why an
-    # unquoted stub would misreport exactly the inputs under test.
+    # Windows-only by nature: the hazard is cmd.exe, observed via a .cmd stub.
+    # `code` resolves to code.cmd on a real VS Code install, and Win32
+    # CreateProcess given a .cmd/.bat silently re-launches cmd.exe to
+    # interpret it, so an argument carrying &, |, ^, <, > or % is re-read as
+    # shell syntax even with no whitespace at all (the BatBadBut class);
+    # CommandLineToArgvW-style quoting, what an .exe target needs, does not
+    # defend against this. Cases depend on the stub echoing `ARG="%~1"` with
+    # the expansion already inside quotes -- see the suite header's Method
+    # note for why an unquoted stub would misreport these inputs.
 
     BeforeAll {
         # One class, one table (CPR-E2C): each of these is "a value the shell would
@@ -110,19 +108,16 @@ Context '9. Argument metacharacters stay data, never cmd.exe operators (issue #6
     }
 
     It '9d. an argument containing a newline is refused before anything is launched, and its payload never runs' {
-        # cmd.exe truncates its command line at a newline, so the tail of such an
-        # argument would run as a separate command. No escaping makes that safe,
-        # which leaves refusing it as the only honest option -- and refusing BEFORE
-        # the launch, so there is no half-executed state.
-        #
-        # Refusing is asserted three ways, because each alone is satisfiable by
-        # the wrong implementation: a non-zero exit alone would also be produced by
-        # a launcher that ran the payload and then failed; "the stub was never
-        # reached" alone would also hold if the payload had run INSTEAD of VS Code.
-        # The marker file is the one that closes it -- the second line of every
-        # payload below is a complete cmd command that creates a file, so if the
-        # newline ever reached cmd.exe the file exists, whatever else happened
-        # (CWE-78).
+        # cmd.exe truncates its command line at a newline, so the tail of such
+        # an argument would run as a separate command; no escaping makes that
+        # safe, so refusing BEFORE the launch is the only honest option, with
+        # no half-executed state. Refusing is asserted three ways since each
+        # alone is satisfiable by a wrong implementation: non-zero exit alone
+        # also fits a launcher that ran the payload and then failed; "stub
+        # never reached" alone also fits the payload running INSTEAD of VS
+        # Code. The marker file closes it -- each payload's second line is a
+        # complete cmd command creating a file, so if the newline reached
+        # cmd.exe the file exists regardless of anything else (CWE-78).
         $bad = New-Object System.Collections.Generic.List[string]
         $i = 0
         foreach ($template in @(
@@ -154,19 +149,15 @@ Context '9. Argument metacharacters stay data, never cmd.exe operators (issue #6
 
     It '9e. a `code.cmd` whose own directory contains a space and metacharacters is still launched correctly' {
         # Everything above escapes the ARGUMENTS. The resolved path of `code`
-        # itself goes onto the very same command line and needs the very same
-        # treatment -- and it is the half that no stub directory in this suite
-        # would have caught, because they are all shell-safe names under TEMP.
-        #
-        # The real world is not: "C:\Program Files (x86)\Microsoft VS Code\bin\code.cmd"
-        # already carries a space and parentheses, and `&` is legal in a directory
-        # name. Unquoted, cmd.exe splits the path at the space and treats what
-        # follows `&` as a second command; quoted but not escaped, the `&` inside
-        # the quotes is safe while an unquoted `(` is not.
-        # Every argument here is deliberately shell-safe: 9a already owns the
-        # argument axis, and reusing a metacharacter argument would make this case
-        # fail for 9a's reason and say nothing about the path (CPR-SC -- one
-        # variable at a time).
+        # goes onto the same command line and needs the same treatment -- the
+        # half no stub directory in this suite would catch, since they're all
+        # shell-safe names under TEMP. Real world: "C:\Program Files (x86)\...
+        # \code.cmd" already has a space and parentheses, and `&` is legal in a
+        # directory name; unquoted, cmd.exe splits at the space and runs what
+        # follows `&` as a second command, while quoted-but-unescaped leaves an
+        # unquoted `(` unsafe. Arguments here stay shell-safe on purpose: 9a
+        # owns the argument axis, and reusing a metachar argument would fail
+        # for 9a's reason and say nothing about the path (CPR-SC).
         $r = Invoke-Launcher -StubDir $script:StubMetacharDir -Environment (New-Env) `
             -Arguments @('C:\some\project', '--new-window')
 
@@ -186,21 +177,16 @@ Context '9. Argument metacharacters stay data, never cmd.exe operators (issue #6
     }
 
     It '9f. an embedded quote and a trailing backslash round-trip byte for byte' {
-        # 9b and 9c settle for "not split, not injected" on these two shapes for a
-        # reason that is about the OBSERVER, not about the contract: the default
-        # stub recovers each argument with `%~1`, which undoes neither the doubled
-        # "" nor the doubled trailing backslash that correct quoting produces, so
-        # a literal comparison there would fail on a correct launcher.
-        #
-        # This case removes that limitation instead of living with it: `code` is a
-        # code.cmd that forwards %* to a real executable -- which is exactly what a
-        # genuine VS Code install does -- and the executable reports the argv
-        # CommandLineToArgvW handed it. Both hops therefore run for real, and what
-        # comes out can be compared against what went in with no allowance made.
-        #
-        # These are the two shapes quoting gets wrong in opposite directions: a
-        # doubled quote arrives as two quotes, and a trailing backslash that is not
-        # doubled escapes the closing quote and swallows the argument after it.
+        # 9b/9c settle for "not split, not injected" here for an OBSERVER
+        # reason: `%~1` undoes neither a doubled "" nor a doubled trailing
+        # backslash, so literal comparison fails there even on a correct
+        # launcher. This case removes that limit: `code` is a code.cmd
+        # forwarding %* to a real executable (as a genuine install does),
+        # which reports the argv CommandLineToArgvW handed it, so both hops
+        # run for real and output compares to input with no allowance made.
+        # Opposite-direction failure shapes: a doubled quote arrives as two
+        # quotes; an undoubled trailing backslash escapes the closing quote
+        # and swallows the next argument.
         if (-not $script:HaveObserverExe) {
             Set-ItResult -Skipped -Because 'no C# compiler was available to build the argv observer that code.cmd forwards to'
             return

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-09-metacharacters.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-09-metacharacters.ps1
@@ -1,0 +1,232 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '9. Argument metacharacters stay data, never cmd.exe operators (issue #66)' -Skip:(-not $IsWindows) {
+    # Windows-only by nature: the hazard is cmd.exe, and the stub that observes it
+    # is a .cmd. `code` resolves to code.cmd on a real VS Code install, and Win32
+    # CreateProcess given a .cmd/.bat silently re-launches cmd.exe to interpret it
+    # -- so an argument carrying &, |, ^, <, > or % is re-read as shell syntax even
+    # when it contains no whitespace at all (the BatBadBut class).
+    # CommandLineToArgvW-style quoting, which is what an .exe target needs, does
+    # not defend against this.
+    #
+    # These cases depend on the stub echoing `ARG="%~1"` with the expansion
+    # already inside quotes; see the Method note in the suite header for why an
+    # unquoted stub would misreport exactly the inputs under test.
+
+    BeforeAll {
+        # One class, one table (CPR-E2C): each of these is "a value the shell would
+        # treat as syntax", not a separate feature.
+        $script:MetacharValues = @(
+            'plain-arg'
+            'has space'
+            'a&b'
+            'a|b'
+            'a^b'
+            'a<b'
+            'a>b'
+            '100%done'
+            '%PATH%'
+            'a(b)c'
+            'a;b'
+            'a,b'
+            '!bang!'
+            'a&&b||c'
+        )
+        $script:ProfileArg = Join-Path $script:LocalAppData 'vscode-ccgw'
+    }
+
+    It '9a. a metacharacter in an argument reaches the child as the literal string' {
+        $bad = New-Object System.Collections.Generic.List[string]
+        foreach ($value in $script:MetacharValues) {
+            $r = Invoke-Launcher -Environment (New-Env) -Arguments @('C:\some\project', $value)
+            $expected = @('--user-data-dir', $script:ProfileArg, 'C:\some\project', $value)
+            if ($r.ExitCode -ne 0) {
+                $bad.Add("'$value': exit $($r.ExitCode); stderr: $($r.StdErr)")
+            } elseif (-not $r.Reached) {
+                $bad.Add("'$value': the stub was never reached; stderr: $($r.StdErr)")
+            } elseif ((@($r.Argv) -join "`u{1}") -cne ($expected -join "`u{1}")) {
+                $bad.Add("'$value': argv was [$(@($r.Argv) -join '][')], expected [$($expected -join '][')]")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "argument splitting or corruption by cmd.exe: $($bad -join ' // ')"
+    }
+
+    It '9b. a value shaped like a command injection creates nothing and runs nothing' {
+        # The decisive assertion is the marker file, not the argv: if a
+        # metacharacter were still an operator, the text after it would run as a
+        # second command with the launcher's own privileges (CWE-78).
+        $bad = New-Object System.Collections.Generic.List[string]
+        $i = 0
+        foreach ($template in @(
+                '& type nul > "{0}"'
+                '| type nul > "{0}"'
+                'x&type nul>{0}'
+                '"" & type nul > "{0}" & echo ""'
+            )) {
+            $i++
+            $marker = Join-Path $script:Work "injection-marker-$i.txt"
+            Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+            $value = [string]::Format($template, $marker)
+            $r = Invoke-Launcher -Environment (New-Env) -Arguments @('C:\some\project', $value)
+            if (Test-Path -LiteralPath $marker) {
+                $bad.Add("'$value': the injected command RAN (marker created)")
+            }
+            # "Nothing ran" is only half the contract: an argument mangled badly
+            # enough to abort the launch also creates no marker, and that is a
+            # broken launcher, not a safe one. The child must be reached, exit
+            # cleanly, and see exactly four arguments.
+            if ($r.ExitCode -ne 0) {
+                $bad.Add("'$value': exit $($r.ExitCode); stderr: $($r.StdErr)")
+            } elseif (-not $r.Reached) {
+                $bad.Add("'$value': the stub was never reached; stderr: $($r.StdErr)")
+            } elseif (@($r.Argv).Count -ne 4) {
+                $bad.Add("'$value': argv was [$(@($r.Argv) -join '][')]")
+            } elseif ($value -notmatch '"' -and (@($r.Argv)[-1] -cne $value)) {
+                # Argv equality is only checked for the values the stub can
+                # round-trip: %~1 does not collapse the doubled "" an embedded
+                # quote becomes, so a quoted template stops at the count check.
+                $bad.Add("'$value': reached the child as '$(@($r.Argv)[-1])'")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "cmd.exe re-interpreted an argument: $($bad -join ' // ')"
+    }
+
+    It '9c. an argument ending in a backslash is neither split nor truncated' {
+        # A trailing backslash is the other half of the BatBadBut recipe: it would
+        # otherwise escape the closing quote and swallow the next argument. The
+        # stub cannot show the doubling being undone (%~1 does not halve it), so
+        # the contract asserted here is "same argument count, same value up to
+        # backslash doubling".
+        $r = Invoke-Launcher -Environment (New-Env) -Arguments @('C:\trailing\dir\', 'C:\some\project')
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        $r.Reached | Should -BeTrue -Because "stderr: $($r.StdErr)"
+        @($r.Argv).Count | Should -Be 4 -Because "the trailing backslash must not swallow the next argument; argv: [$(@($r.Argv) -join '][')]"
+        ($r.Argv[2] -replace '\\+$', '\') | Should -BeExactly 'C:\trailing\dir\'
+        $r.Argv[3] | Should -BeExactly 'C:\some\project'
+    }
+
+    It '9d. an argument containing a newline is refused before anything is launched, and its payload never runs' {
+        # cmd.exe truncates its command line at a newline, so the tail of such an
+        # argument would run as a separate command. No escaping makes that safe,
+        # which leaves refusing it as the only honest option -- and refusing BEFORE
+        # the launch, so there is no half-executed state.
+        #
+        # Refusing is asserted three ways, because each alone is satisfiable by
+        # the wrong implementation: a non-zero exit alone would also be produced by
+        # a launcher that ran the payload and then failed; "the stub was never
+        # reached" alone would also hold if the payload had run INSTEAD of VS Code.
+        # The marker file is the one that closes it -- the second line of every
+        # payload below is a complete cmd command that creates a file, so if the
+        # newline ever reached cmd.exe the file exists, whatever else happened
+        # (CWE-78).
+        $bad = New-Object System.Collections.Generic.List[string]
+        $i = 0
+        foreach ($template in @(
+                "C:\some\project`ntype nul > `"{0}`""
+                "C:\some\project`r`ntype nul > `"{0}`""
+                "`ntype nul>{0}"
+            )) {
+            $i++
+            $marker = Join-Path $script:Work "newline-marker-$i.txt"
+            Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+            $value = [string]::Format($template, $marker)
+            $rendered = $value -replace "`r", '<CR>' -replace "`n", '<LF>'
+            $r = Invoke-Launcher -Environment (New-Env) -Arguments @($value)
+            if (Test-Path -LiteralPath $marker) {
+                $bad.Add("'$rendered': the payload after the newline RAN (marker created)")
+            }
+            if ($r.ExitCode -eq 0) {
+                $bad.Add("'$rendered': exit 0 -- an unrepresentable argument must not be silently truncated")
+            }
+            if ($r.Reached) {
+                $bad.Add("'$rendered': VS Code was launched anyway; the refusal must precede the launch")
+            }
+            if ($r.StdErr -notmatch 'newline') {
+                $bad.Add("'$rendered': the error must say what is wrong with the argument; stderr: $($r.StdErr)")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "metachars/newline: $($bad -join ' // ')"
+    }
+
+    It '9e. a `code.cmd` whose own directory contains a space and metacharacters is still launched correctly' {
+        # Everything above escapes the ARGUMENTS. The resolved path of `code`
+        # itself goes onto the very same command line and needs the very same
+        # treatment -- and it is the half that no stub directory in this suite
+        # would have caught, because they are all shell-safe names under TEMP.
+        #
+        # The real world is not: "C:\Program Files (x86)\Microsoft VS Code\bin\code.cmd"
+        # already carries a space and parentheses, and `&` is legal in a directory
+        # name. Unquoted, cmd.exe splits the path at the space and treats what
+        # follows `&` as a second command; quoted but not escaped, the `&` inside
+        # the quotes is safe while an unquoted `(` is not.
+        # Every argument here is deliberately shell-safe: 9a already owns the
+        # argument axis, and reusing a metacharacter argument would make this case
+        # fail for 9a's reason and say nothing about the path (CPR-SC -- one
+        # variable at a time).
+        $r = Invoke-Launcher -StubDir $script:StubMetacharDir -Environment (New-Env) `
+            -Arguments @('C:\some\project', '--new-window')
+
+        $r.ExitCode | Should -Be 0 -Because "the launcher must find and start a code.cmd under an unfriendly path; stderr: $($r.StdErr)"
+        $r.Reached | Should -BeTrue -Because "stderr: $($r.StdErr)"
+        # A path split at a metacharacter produces cmd's own complaint rather than
+        # a launcher error, so it is asserted by name: it is the signature of the
+        # tail of the path having been run as a command.
+        $r.StdErr | Should -Not -Match '(?i)is not recognized as an internal or external command' `
+            -Because "part of the stub's own path was executed as a command: $($r.StdErr)"
+
+        $expected = @('--user-data-dir', $script:ProfileArg, 'C:\some\project', '--new-window')
+        (@($r.Argv) -join "`u{1}") | Should -BeExactly ($expected -join "`u{1}") `
+            -Because "argv must survive an unfriendly path to code.cmd; got [$(@($r.Argv) -join '][')]"
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://lite:1' 'metachars/unfriendly-code-path'
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'ck' 'metachars/unfriendly-code-path'
+    }
+
+    It '9f. an embedded quote and a trailing backslash round-trip byte for byte' {
+        # 9b and 9c settle for "not split, not injected" on these two shapes for a
+        # reason that is about the OBSERVER, not about the contract: the default
+        # stub recovers each argument with `%~1`, which undoes neither the doubled
+        # "" nor the doubled trailing backslash that correct quoting produces, so
+        # a literal comparison there would fail on a correct launcher.
+        #
+        # This case removes that limitation instead of living with it: `code` is a
+        # code.cmd that forwards %* to a real executable -- which is exactly what a
+        # genuine VS Code install does -- and the executable reports the argv
+        # CommandLineToArgvW handed it. Both hops therefore run for real, and what
+        # comes out can be compared against what went in with no allowance made.
+        #
+        # These are the two shapes quoting gets wrong in opposite directions: a
+        # doubled quote arrives as two quotes, and a trailing backslash that is not
+        # doubled escapes the closing quote and swallows the argument after it.
+        if (-not $script:HaveObserverExe) {
+            Set-ItResult -Skipped -Because 'no C# compiler was available to build the argv observer that code.cmd forwards to'
+            return
+        }
+        $bad = New-Object System.Collections.Generic.List[string]
+        foreach ($value in @(
+                'a"b'
+                'say "hi" now'
+                '"leading-quote'
+                'trailing-quote"'
+                'C:\trailing\dir\'
+                'C:\my dir\'
+                'two-backslashes\\'
+                '"quoted path\"'
+            )) {
+            $r = Invoke-Launcher -StubDir $script:StubCmdForward -Environment (New-Env) `
+                -Arguments @($value, 'TAIL-SENTINEL')
+            $expected = @('--user-data-dir', $script:ProfileArg, $value, 'TAIL-SENTINEL')
+            if ($r.ExitCode -ne 0) {
+                $bad.Add("'$value': exit $($r.ExitCode); stderr: $($r.StdErr)")
+            } elseif (-not $r.Reached) {
+                $bad.Add("'$value': the observer was never reached; stderr: $($r.StdErr)")
+            } elseif ((@($r.Argv) -join "`u{1}") -cne ($expected -join "`u{1}")) {
+                $bad.Add("'$value': argv was [$(@($r.Argv) -join '][')], expected [$($expected -join '][')]")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "quoting corrupted an argument on the .cmd path: $($bad -join ' // ')"
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-10-exe-branch.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-10-exe-branch.ps1
@@ -5,24 +5,16 @@
 # Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
 
 Context '10. The non-batch (.exe) launch path' {
-    # `code` resolves to code.cmd on every real Windows VS Code install, so the
-    # .exe branch has to be driven through a purpose-built stand-in. It is covered
-    # at the two points where it can fail: the quoting rule it applies (10a,
-    # against the real function, extracted from the source rather than
-    # re-implemented here) and what an .exe target actually receives (10b).
-    #
-    # 10b used to assert only that two error strings were ABSENT, which a launcher
-    # that started no process at all would also satisfy -- absence of an error is
-    # not evidence of a launch. It now runs a compiled stub that reports what it
-    # got: a marker file (a process really started), its argv, and its inherited
-    # environment. The stub writes through File.WriteAllLines, so unlike the .cmd
-    # stub it is code-page-independent and can carry the non-ASCII case too.
-    #
-    # TL3 gap: whether the .exe was reached DIRECTLY or through a cmd.exe wrapper
-    #   is not observable from inside the child -- both deliver the same argv when
-    #   the wrapper quotes correctly. What is observable, and asserted, is that a
-    #   .cmd target IS re-parsed by cmd.exe (Context 9) and that an .exe target
-    #   receives its argv and environment intact.
+    # `code` resolves to code.cmd on every real install, so the .exe branch is
+    # driven through a stand-in, covered at its two failure points: the
+    # quoting rule (10a, against the real function extracted from source) and
+    # what an .exe target receives (10b). 10b used to assert only that two
+    # error strings were ABSENT -- also true of a launcher that started
+    # nothing -- so it now runs a compiled stub reporting a marker file, argv,
+    # and inherited environment via File.WriteAllLines (code-page-independent,
+    # carries non-ASCII). TL3 gap: DIRECT vs. cmd.exe-wrapper reach is
+    # unobservable when quoting is correct; asserted instead: .cmd IS
+    # re-parsed (Context 9), .exe gets argv/env intact.
 
     It '10a. ConvertTo-ArgvQuotedArgument follows the CommandLineToArgvW rules' {
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:SourceLauncher, [ref]$null, [ref]$null)

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-10-exe-branch.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-10-exe-branch.ps1
@@ -1,0 +1,80 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '10. The non-batch (.exe) launch path' {
+    # `code` resolves to code.cmd on every real Windows VS Code install, so the
+    # .exe branch has to be driven through a purpose-built stand-in. It is covered
+    # at the two points where it can fail: the quoting rule it applies (10a,
+    # against the real function, extracted from the source rather than
+    # re-implemented here) and what an .exe target actually receives (10b).
+    #
+    # 10b used to assert only that two error strings were ABSENT, which a launcher
+    # that started no process at all would also satisfy -- absence of an error is
+    # not evidence of a launch. It now runs a compiled stub that reports what it
+    # got: a marker file (a process really started), its argv, and its inherited
+    # environment. The stub writes through File.WriteAllLines, so unlike the .cmd
+    # stub it is code-page-independent and can carry the non-ASCII case too.
+    #
+    # TL3 gap: whether the .exe was reached DIRECTLY or through a cmd.exe wrapper
+    #   is not observable from inside the child -- both deliver the same argv when
+    #   the wrapper quotes correctly. What is observable, and asserted, is that a
+    #   .cmd target IS re-parsed by cmd.exe (Context 9) and that an .exe target
+    #   receives its argv and environment intact.
+
+    It '10a. ConvertTo-ArgvQuotedArgument follows the CommandLineToArgvW rules' {
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:SourceLauncher, [ref]$null, [ref]$null)
+        $fn = @($ast.FindAll({
+                    $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $args[0].Name -eq 'ConvertTo-ArgvQuotedArgument'
+                }, $true))
+        # AST rather than a regex: the body nests braces, which a regex cannot
+        # balance.
+        $fn.Count | Should -Be 1 -Because 'the .exe branch must quote through one named helper the tests can reach'
+        . ([scriptblock]::Create($fn[0].Extent.Text))
+
+        $cases = @(
+            @{ In = 'plain'; Out = 'plain' }
+            @{ In = ''; Out = '""' }
+            @{ In = 'has space'; Out = '"has space"' }
+            @{ In = 'a"b'; Out = '"a\"b"' }
+            @{ In = 'a\"b'; Out = '"a\\\"b"' }
+            @{ In = 'C:\dir\'; Out = 'C:\dir\' }
+            @{ In = 'C:\my dir\'; Out = '"C:\my dir\\"' }
+        )
+        foreach ($c in $cases) {
+            (ConvertTo-ArgvQuotedArgument $c.In) | Should -BeExactly $c.Out -Because "input '$($c.In)'"
+        }
+    }
+
+    It '10b. a `code` that resolves to a real .exe is launched, and receives its argv and environment intact' {
+        if (-not ($IsWindows -and $script:HaveExeStub)) {
+            Set-ItResult -Skipped -Because 'no C# compiler was available to build the dumping code.exe stub on this host'
+            return
+        }
+        # A metacharacter and a non-ASCII value ride along: they are the two
+        # classes of value a quoting helper corrupts, and the .exe branch quotes by
+        # different rules than the .cmd branch does (CommandLineToArgvW, not
+        # cmd.exe's re-parse), so each branch has to be shown to carry them.
+        $meta = 'a&b|c^d'
+        $unicode = "$([char]0x30D7)$([char]0x30ED)$([char]0x30B8)-caf$([char]0x00E9)"
+        $r = Invoke-Launcher -StubDir $script:StubExe -Environment (New-Env) `
+            -Arguments @('C:\some\project', $meta, $unicode)
+
+        $r.StdErr | Should -Not -Match ([regex]::Escape("'code' command not found on PATH")) -Because 'an .exe on PATH is a valid code'
+        $r.ExitCode | Should -Be 0 -Because "the .exe branch must start the process; stderr: $($r.StdErr)"
+        $r.ExeMarker | Should -BeTrue -Because "the stub must actually have run; a launcher that starts nothing passes every absence-of-error check. stderr: $($r.StdErr)"
+        $r.Reached | Should -BeTrue -Because "stderr: $($r.StdErr)"
+
+        $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'), 'C:\some\project', $meta, $unicode)
+        (@($r.Argv) -join "`u{1}") | Should -BeExactly ($expected -join "`u{1}") `
+            -Because "the .exe branch must deliver argv verbatim; got [$(@($r.Argv) -join '][')]"
+
+        # The environment half of the same launch: a branch that launches but
+        # hands over nothing routes Claude Code straight back to the cloud.
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://lite:1' 'exe-branch/env'
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'ck' 'exe-branch/env'
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-11-source-contract.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-11-source-contract.ps1
@@ -1,0 +1,117 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '11. The zero-pollution contract, asserted against the source itself' {
+    # Context 8 observes the parent environment before and after a launch, which
+    # catches pollution only on the paths the tests happen to walk. This context
+    # closes the gap from the other side: it reads scripts/code-ccgw.ps1 and
+    # requires that NO statement anywhere in it writes to the process environment,
+    # on any path, reachable or not (CPR-UNV -- the contract holds over the whole
+    # input domain, not the sampled one).
+    #
+    # Why this is the load-bearing assertion for issue #66: PowerShell has no
+    # exec(), so every `$env:X = ...` the launcher performs lands in the shell the
+    # developer is still sitting in and outlives the VS Code it launched. The fix
+    # is not "unset it afterwards" -- an interrupted launcher never reaches the
+    # cleanup -- it is "never write to this process at all", and instead hand the
+    # values to the child through ProcessStartInfo.Environment. That is a
+    # structural property of the source, so the test is structural too.
+    #
+    # AST, not regex: a regex over the text cannot tell `$env:X = 'v'` (a write)
+    # from `$env:X` inside a string (a read), nor see through line breaks and
+    # continuations. The parser already knows the difference.
+    #
+    # Reads stay legal, and are expected -- the launcher must still consult
+    # LOCALAPPDATA, USERPROFILE and PATH.
+
+    BeforeAll {
+        $script:EnvWriteScan = {
+            param([string]$Path)
+
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$null)
+            $offenders = New-Object System.Collections.Generic.List[string]
+            $add = {
+                param($Node, $Why)
+                $text = $Node.Extent.Text
+                if ($text.Length -gt 90) { $text = $text.Substring(0, 90) + '...' }
+                $text = $text -replace '\r?\n', ' '
+                $offenders.Add("line $($Node.Extent.StartLineNumber): $Why -- $text")
+            }
+
+            # 1. `$env:X = ...`, `${env:X} = ...`, `$env:X += ...`
+            foreach ($node in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true)) {
+                $target = $node.Left
+                while ($target -is [System.Management.Automation.Language.AttributedExpressionAst]) { $target = $target.Child }
+                if ($target -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                    $target.VariablePath.IsDriveQualified -and
+                    $target.VariablePath.DriveName -eq 'env') {
+                    & $add $node 'assigns to the parent process environment'
+                }
+            }
+
+            # 2. The provider cmdlets and their aliases, aimed at the env: drive.
+            $itemCmdlets = @('set-item', 'new-item', 'remove-item', 'clear-item', 'rename-item', 'copy-item',
+                'set-content', 'add-content', 'clear-content', 'si', 'ni', 'ri', 'rni', 'cpi', 'sc', 'ac', 'rd', 'del', 'erase')
+            foreach ($node in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+                $name = $node.GetCommandName()
+                if ($null -eq $name -or $itemCmdlets -notcontains $name.ToLowerInvariant()) { continue }
+                $touchesEnv = $false
+                foreach ($el in $node.CommandElements) {
+                    if ($el.Extent.Text -match '(?i)(^|[^a-z0-9_])env:') { $touchesEnv = $true }
+                }
+                if ($touchesEnv) { & $add $node "calls $name against the env: drive" }
+            }
+
+            # 3. [Environment]::SetEnvironmentVariable(...) -- with no scope argument
+            #    this writes the current process too, so it is the same defect.
+            foreach ($node in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.InvokeMemberExpressionAst] }, $true)) {
+                if ("$($node.Member)" -match '(?i)^SetEnvironmentVariable$') {
+                    & $add $node 'writes the environment through the .NET API'
+                }
+            }
+
+            return $offenders
+        }
+    }
+
+    It '11a. no statement in the launcher writes to the environment of the shell that invoked it' {
+        $offenders = & $script:EnvWriteScan $script:SourceLauncher
+        $offenders.Count | Should -Be 0 -Because @"
+scripts/code-ccgw.ps1 must hand its configuration to the child process (ProcessStartInfo.Environment),
+never to its own -- PowerShell has no exec(), so every write below survives in the caller's shell after
+the launcher exits (issue #66). Offending statements:
+  $($offenders -join "`n  ")
+"@
+    }
+
+    It '11b. the scan itself detects each shape of environment write' {
+        # A static assertion that cannot fail is worse than no assertion: it reads
+        # as green forever. This pins the detector against one sample per shape,
+        # plus a read that must NOT be flagged.
+        $probe = Join-Path $script:Work 'env-write-probe.ps1'
+        $lines = @(
+            '$env:A = ''1'''
+            '${env:B} = ''2'''
+            '$env:C += ''3'''
+            'Set-Item -Path "env:D" -Value ''4'''
+            'Remove-Item -Path env:E'
+            '[Environment]::SetEnvironmentVariable(''F'', ''6'')'
+        )
+        Set-Content -LiteralPath $probe -Value $lines -Encoding utf8
+        $found = & $script:EnvWriteScan $probe
+        $found.Count | Should -Be $lines.Count -Because "the scan missed a write shape; it found: $($found -join ' // ')"
+
+        $clean = Join-Path $script:Work 'env-read-probe.ps1'
+        Set-Content -LiteralPath $clean -Encoding utf8 -Value @(
+            '$local = $env:LOCALAPPDATA'
+            '$p = Join-Path $env:USERPROFILE ''x'''
+            'if ($env:PATH -match ''x'') { Write-Host "env:PATH mentioned in a string" }'
+            '$copy = Get-Item -Path env:PATH'
+        )
+        $readOnly = & $script:EnvWriteScan $clean
+        $readOnly.Count | Should -Be 0 -Because "reading the environment is legal and must not be flagged; got: $($readOnly -join ' // ')"
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-11-source-contract.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-11-source-contract.ps1
@@ -5,27 +5,16 @@
 # Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
 
 Context '11. The zero-pollution contract, asserted against the source itself' {
-    # Context 8 observes the parent environment before and after a launch, which
-    # catches pollution only on the paths the tests happen to walk. This context
-    # closes the gap from the other side: it reads scripts/code-ccgw.ps1 and
-    # requires that NO statement anywhere in it writes to the process environment,
-    # on any path, reachable or not (CPR-UNV -- the contract holds over the whole
-    # input domain, not the sampled one).
-    #
-    # Why this is the load-bearing assertion for issue #66: PowerShell has no
-    # exec(), so every `$env:X = ...` the launcher performs lands in the shell the
-    # developer is still sitting in and outlives the VS Code it launched. The fix
-    # is not "unset it afterwards" -- an interrupted launcher never reaches the
-    # cleanup -- it is "never write to this process at all", and instead hand the
-    # values to the child through ProcessStartInfo.Environment. That is a
-    # structural property of the source, so the test is structural too.
-    #
-    # AST, not regex: a regex over the text cannot tell `$env:X = 'v'` (a write)
-    # from `$env:X` inside a string (a read), nor see through line breaks and
-    # continuations. The parser already knows the difference.
-    #
-    # Reads stay legal, and are expected -- the launcher must still consult
-    # LOCALAPPDATA, USERPROFILE and PATH.
+    # Context 8 observes the parent environment before/after a launch, which
+    # catches pollution only on paths the tests walk. This closes the gap the
+    # other way: it reads scripts/code-ccgw.ps1 and requires NO statement
+    # anywhere write to the process environment, reachable or not (CPR-UNV --
+    # whole input domain, not the sampled one). Load-bearing for #66: no
+    # exec() in PowerShell means every `$env:X = ...` lands in the developer's
+    # own shell and outlives the launch, so the fix is "never write to this
+    # process" (values go to the child via ProcessStartInfo.Environment
+    # instead) -- structural, tested via AST (a regex can't tell a write from
+    # a read inside a string). Reads (LOCALAPPDATA etc.) stay legal.
 
     BeforeAll {
         $script:EnvWriteScan = {

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-12-argument-boundaries.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-12-argument-boundaries.ps1
@@ -14,16 +14,14 @@ Context '12. Argument boundaries: empty, non-ASCII, and over-long' {
     # each case asserts on what the child RECEIVED, never on the exit code alone.
 
     It '12a. an empty argument is preserved in place, not dropped' {
-        # `code -g file:1:1 "" --wait` is a real shape: an empty string is how a
-        # caller passes "this optional positional is blank", and dropping it
-        # shifts every later argument one slot left -- VS Code then reads the next
-        # argument as the value of the previous flag. Nothing about that failure is
-        # visible in the exit code.
-        #
-        # The default .cmd stub cannot observe this: `if "%~1"==""` is its
-        # end-of-argv test, so an empty argument ends the dump early and the
-        # remaining arguments look dropped even when they were delivered. This case
-        # therefore uses the positional stub, which dumps a fixed number of slots
+        # `code -g file:1:1 "" --wait` is a real shape: an empty string means
+        # "this optional positional is blank", and dropping it shifts every
+        # later argument one slot left -- VS Code then reads the next
+        # argument as the value of the previous flag, invisibly in the exit
+        # code. The default .cmd stub can't observe this: `if "%~1"==""` is
+        # its end-of-argv test, so an empty argument ends the dump early and
+        # later arguments look dropped even when delivered. This case uses
+        # the positional stub instead, which dumps a fixed number of slots
         # whether or not they are empty.
         $r = Invoke-Launcher -StubDir $script:StubPositional -Environment (New-Env) `
             -Arguments @('SENTINEL-A', '', 'SENTINEL-B')
@@ -102,22 +100,15 @@ Context '12. Argument boundaries: empty, non-ASCII, and over-long' {
     }
 
     It '12c-ii. an over-long command line is delivered whole or refused outright, never truncated' -Skip:(-not $IsWindows) {
-        # cmd.exe stops reading its command line at roughly 8191 characters. Since
-        # a .cmd target is reached THROUGH cmd.exe (see Context 9), a long argument
-        # list crosses that ceiling long before the 32767-character CreateProcess
-        # limit -- and cmd.exe truncates rather than failing, so the launcher exits
-        # 0 while VS Code opens a path that ends mid-word.
-        #
-        # Two outcomes are acceptable and one is not. Delivering the whole thing is
-        # correct. Refusing before the launch, with an error that says what is
-        # wrong, is also correct -- the transport genuinely cannot carry it. Exiting
-        # 0 having launched nothing, or having launched something that received a
-        # truncated argument, is the failure this case exists to catch.
-        #
-        # The exact ceiling depends on the length of the stub's own path, so the
-        # lengths below bracket it rather than sitting on it: just under, and
-        # clearly over. The comfortably-under lengths live in 12c-i, where a
-        # refusal is NOT one of the acceptable answers.
+        # cmd.exe stops reading at ~8191 chars. A .cmd target is reached
+        # THROUGH cmd.exe (Context 9), so a long argument list crosses that
+        # well before the 32767-char CreateProcess limit, truncating rather
+        # than failing -- exit 0, path ending mid-word. Acceptable:
+        # delivering the whole thing, or refusing before launch with an
+        # explanatory error. Not acceptable: exit 0 with nothing launched, or
+        # a truncated delivery. Ceiling depends on the stub's own path
+        # length, so lengths below bracket it; comfortably-under lengths live
+        # in 12c-i, where refusal is NOT acceptable.
         $bad = New-Object System.Collections.Generic.List[string]
         foreach ($len in @(7000, 9000)) {
             # Sentinels at both ends: truncation of any amount changes the tail,

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-12-argument-boundaries.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-12-argument-boundaries.ps1
@@ -1,0 +1,149 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+# lang-check: ignore (non-ASCII path fixtures are the test subject)
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '12. Argument boundaries: empty, non-ASCII, and over-long' {
+    # Context 9 covers the values a shell would treat as SYNTAX. This one covers
+    # the values a quoting layer loses without ever looking like an attack: an
+    # argument that is empty, one that is not ASCII, and one that is longer than
+    # the transport can carry. All three are silent corruptions -- the launcher
+    # exits 0 and VS Code simply opens the wrong thing (or nothing) -- which is why
+    # each case asserts on what the child RECEIVED, never on the exit code alone.
+
+    It '12a. an empty argument is preserved in place, not dropped' {
+        # `code -g file:1:1 "" --wait` is a real shape: an empty string is how a
+        # caller passes "this optional positional is blank", and dropping it
+        # shifts every later argument one slot left -- VS Code then reads the next
+        # argument as the value of the previous flag. Nothing about that failure is
+        # visible in the exit code.
+        #
+        # The default .cmd stub cannot observe this: `if "%~1"==""` is its
+        # end-of-argv test, so an empty argument ends the dump early and the
+        # remaining arguments look dropped even when they were delivered. This case
+        # therefore uses the positional stub, which dumps a fixed number of slots
+        # whether or not they are empty.
+        $r = Invoke-Launcher -StubDir $script:StubPositional -Environment (New-Env) `
+            -Arguments @('SENTINEL-A', '', 'SENTINEL-B')
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        $r.Reached | Should -BeTrue -Because "stderr: $($r.StdErr)"
+
+        $argv = @($r.Argv)
+        $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'), 'SENTINEL-A', '', 'SENTINEL-B')
+        for ($i = 0; $i -lt $expected.Count; $i++) {
+            $got = if ($i -lt $argv.Count) { $argv[$i] } else { '<missing>' }
+            $got | Should -BeExactly $expected[$i] -Because "argument $($i + 1) of [$($argv -join '][')] -- an empty argument must occupy its own slot, not vanish"
+        }
+        # The other half of "not dropped": nothing may have shifted up into the
+        # slot after the last real argument either.
+        if ($argv.Count -gt $expected.Count) {
+            $argv[$expected.Count] | Should -BeExactly '' -Because "argv must end after SENTINEL-B; got [$($argv -join '][')]"
+        }
+    }
+
+    It '12b. a non-ASCII path, argument and profile directory survive byte for byte' {
+        # A Japanese or accented directory name is the normal case for a large part
+        # of the user base (OneDrive\\ドキュメント, C:\\Users\\Müller), and every
+        # transport in play here can mangle it: cmd.exe renders through the console
+        # code page, a .NET command line is UTF-16, and a naive quoting helper that
+        # counts bytes instead of chars splits a surrogate pair.
+        #
+        # Three non-ASCII things are exercised in ONE run, because they fail
+        # independently: the launcher's own location (so $PSScriptRoot and the .env
+        # beside it are non-ASCII), the profile directory it composes, and an
+        # argument it forwards.
+        $uniLocalAppData = Join-Path $script:Work ("localappdata-$([char]0x30C6)$([char]0x30B9)$([char]0x30C8)")
+        New-Item -ItemType Directory -Path $uniLocalAppData -Force | Out-Null
+        $uniArg = "C:\$([char]0x30D7)$([char]0x30ED)$([char]0x30B8)\caf$([char]0x00E9)-$([char]0x00DF)$([char]0x4E2D)$([char]0x6587).txt"
+
+        $r = Invoke-Launcher -LauncherPath $script:UnicodeLauncher `
+            -Environment @{ LOCALAPPDATA = $uniLocalAppData } `
+            -Arguments @($uniArg, '--new-window')
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        $r.Reached | Should -BeTrue -Because "stderr: $($r.StdErr)"
+
+        # The launcher found its own .env through a non-ASCII $PSScriptRoot.
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://unicode-lite:1' 'unicode: .env beside a non-ASCII script dir'
+
+        $expected = @('--user-data-dir', (Join-Path $uniLocalAppData 'vscode-ccgw'), $uniArg, '--new-window')
+        (@($r.Argv) -join "`u{1}") | Should -BeExactly ($expected -join "`u{1}") `
+            -Because "a non-ASCII argument or profile path must reach VS Code unchanged; got [$(@($r.Argv) -join '][')]"
+    }
+
+    It '12c-i. a command line comfortably under the limit must simply launch' -Skip:(-not $IsWindows) {
+        # The allow half of the length guard, and the only half that pins the
+        # guard's other edge. 12c-ii below accepts a refusal as one correct
+        # outcome, which on its own sanctions a launcher that refuses EVERYTHING
+        # long-ish -- a 2,000-character workspace path list is ordinary (a handful
+        # of deep OneDrive paths gets there), and refusing it would be a
+        # regression dressed up as caution. Nothing may be refused here: cmd.exe's
+        # ceiling is around 8,191 characters, so these are not close to it.
+        $bad = New-Object System.Collections.Generic.List[string]
+        foreach ($len in @(200, 2000)) {
+            $value = 'L' + ('x' * ($len - 2)) + 'Z'
+            $r = Invoke-Launcher -Environment (New-Env) -Arguments @($value)
+            $tag = "length $len"
+            if ($r.ExitCode -ne 0) {
+                $bad.Add("${tag}: refused a command line the transport can carry; stderr: $($r.StdErr)")
+                continue
+            }
+            if (-not $r.Reached) {
+                $bad.Add("${tag}: exit 0 but nothing was launched; stderr: $($r.StdErr)")
+                continue
+            }
+            $delivered = @($r.Argv)[-1]
+            if ($delivered -cne $value) {
+                $bad.Add("${tag}: the child received $($delivered.Length) chars instead of $($value.Length)")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "a safely-sized command line must be delivered, not refused: $($bad -join ' // ')"
+    }
+
+    It '12c-ii. an over-long command line is delivered whole or refused outright, never truncated' -Skip:(-not $IsWindows) {
+        # cmd.exe stops reading its command line at roughly 8191 characters. Since
+        # a .cmd target is reached THROUGH cmd.exe (see Context 9), a long argument
+        # list crosses that ceiling long before the 32767-character CreateProcess
+        # limit -- and cmd.exe truncates rather than failing, so the launcher exits
+        # 0 while VS Code opens a path that ends mid-word.
+        #
+        # Two outcomes are acceptable and one is not. Delivering the whole thing is
+        # correct. Refusing before the launch, with an error that says what is
+        # wrong, is also correct -- the transport genuinely cannot carry it. Exiting
+        # 0 having launched nothing, or having launched something that received a
+        # truncated argument, is the failure this case exists to catch.
+        #
+        # The exact ceiling depends on the length of the stub's own path, so the
+        # lengths below bracket it rather than sitting on it: just under, and
+        # clearly over. The comfortably-under lengths live in 12c-i, where a
+        # refusal is NOT one of the acceptable answers.
+        $bad = New-Object System.Collections.Generic.List[string]
+        foreach ($len in @(7000, 9000)) {
+            # Sentinels at both ends: truncation of any amount changes the tail,
+            # and comparing the whole string keeps a partial delivery from passing.
+            $value = 'L' + ('x' * ($len - 2)) + 'Z'
+            $r = Invoke-Launcher -Environment (New-Env) -Arguments @($value)
+            $tag = "length $len"
+
+            if ($r.ExitCode -eq 0) {
+                if (-not $r.Reached) {
+                    $bad.Add("${tag}: exit 0 but nothing was launched -- a command line that cannot be delivered must fail loudly; stderr: $($r.StdErr)")
+                    continue
+                }
+                $delivered = @($r.Argv)[-1]
+                if ($delivered -cne $value) {
+                    $bad.Add("${tag}: the child received $($delivered.Length) chars instead of $($value.Length) -- silently truncated")
+                }
+            } else {
+                if ($r.Reached) {
+                    $bad.Add("${tag}: VS Code was launched and the launcher still failed; the refusal must precede the launch")
+                }
+                if ($r.StdErr -notmatch '(?i)(too long|length|limit|8191)') {
+                    $bad.Add("${tag}: refused with no explanation of the length limit; stderr: $($r.StdErr)")
+                }
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "command-line length: $($bad -join ' // ')"
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-13-routing-precedence.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-13-routing-precedence.ps1
@@ -5,29 +5,11 @@
 # Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
 
 Context '13. Routing keys: .env outranks the inherited shell, and the shell keeps its own value' {
-    # Two rules meet on exactly these five keys, and nowhere else.
-    #
-    # The first is the precedence inversion of PR #63: for every other key an
-    # already-set shell value wins over .env, but a model-routing key must always
-    # come FROM .env -- a stale LITELLM_OPUS_MODEL left in a shell by an earlier
-    # launch would otherwise silently re-point a tier the repo has since moved.
-    # Context 7 asserts the general rule; only this Context asserts the exception,
-    # and it has to be asserted per key, because the exception is a membership
-    # test against a literal list ($ModelRoutingKeys) and a list is exactly the
-    # kind of thing that loses an entry in a rename (CPR-ORTH).
-    #
-    # The second is issue #66: overriding the inherited value must not mean
-    # OVERWRITING it. The launcher reaches its .env value by assigning the key --
-    # today into its own process, which is the invoking shell's -- so the run that
-    # proves .env won is the same run that would destroy the developer's own
-    # LITELLM_OPUS_MODEL. Both halves therefore ride on ONE launch per key: a
-    # child-side-only check could be satisfied by a launcher that trashes the
-    # shell, and a parent-side-only check by one that ignores .env entirely
-    # (CPR-E2E).
-    #
-    # One fixture per key rather than one .env carrying all five: a launcher that
-    # applied the exception to only the first key it met would still satisfy a
-    # combined run for that key, and each row here names the key that failed.
+    # Two rules, five keys only: PR #63's inversion (.env always wins here,
+    # unlike every other key -- per-key since $ModelRoutingKeys can lose an
+    # entry in a rename, CPR-ORTH) and issue #66 (winning must not mean
+    # OVERWRITING the shell's value -- one launch proves both, CPR-E2E).
+    # One fixture per key: a partial fix would still pass a combined run.
 
     $ctx13Rows = @(
         @{ Key = 'LITELLM_HAIKU_MODEL'; Child = 'ANTHROPIC_DEFAULT_HAIKU_MODEL' }

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-13-routing-precedence.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-13-routing-precedence.ps1
@@ -1,0 +1,67 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '13. Routing keys: .env outranks the inherited shell, and the shell keeps its own value' {
+    # Two rules meet on exactly these five keys, and nowhere else.
+    #
+    # The first is the precedence inversion of PR #63: for every other key an
+    # already-set shell value wins over .env, but a model-routing key must always
+    # come FROM .env -- a stale LITELLM_OPUS_MODEL left in a shell by an earlier
+    # launch would otherwise silently re-point a tier the repo has since moved.
+    # Context 7 asserts the general rule; only this Context asserts the exception,
+    # and it has to be asserted per key, because the exception is a membership
+    # test against a literal list ($ModelRoutingKeys) and a list is exactly the
+    # kind of thing that loses an entry in a rename (CPR-ORTH).
+    #
+    # The second is issue #66: overriding the inherited value must not mean
+    # OVERWRITING it. The launcher reaches its .env value by assigning the key --
+    # today into its own process, which is the invoking shell's -- so the run that
+    # proves .env won is the same run that would destroy the developer's own
+    # LITELLM_OPUS_MODEL. Both halves therefore ride on ONE launch per key: a
+    # child-side-only check could be satisfied by a launcher that trashes the
+    # shell, and a parent-side-only check by one that ignores .env entirely
+    # (CPR-E2E).
+    #
+    # One fixture per key rather than one .env carrying all five: a launcher that
+    # applied the exception to only the first key it met would still satisfy a
+    # combined run for that key, and each row here names the key that failed.
+
+    $ctx13Rows = @(
+        @{ Key = 'LITELLM_HAIKU_MODEL'; Child = 'ANTHROPIC_DEFAULT_HAIKU_MODEL' }
+        @{ Key = 'LITELLM_SONNET_MODEL'; Child = 'ANTHROPIC_DEFAULT_SONNET_MODEL' }
+        @{ Key = 'LITELLM_FABLE_MODEL'; Child = 'ANTHROPIC_DEFAULT_FABLE_MODEL' }
+        @{ Key = 'LITELLM_OPUS_MODEL'; Child = 'ANTHROPIC_DEFAULT_OPUS_MODEL' }
+        @{ Key = 'CCGW_SUBAGENT_MODEL'; Child = 'CLAUDE_CODE_SUBAGENT_MODEL' }
+    )
+
+    It '13a. <Key>: .env drives <Child> in the child, and the invoking shell keeps its own value' -ForEach $ctx13Rows {
+        $dotEnvValue = "ctx13-dotenv-$Key"
+        $inherited = "INHERITED-$Key-MUST-NOT-WIN-AND-MUST-SURVIVE"
+
+        $fixture = New-FixtureTree -Name "fixture-ctx13-$Key" -DotEnvLines @(
+            'LITELLM_ANTHROPIC_BASE_URL=https://ctx13-lite:1'
+            'LITELLM_CLIENT_KEY=ctx13-client-key'
+            "$Key=$dotEnvValue"
+        )
+
+        # The invoking shell already holds a conflicting value for this key, the
+        # way a shell that launched an older revision of the repo would.
+        $r = Invoke-LauncherInParentShell -LauncherPath $fixture -Environment @{ $Key = $inherited }
+        $r.LauncherExitCode | Should -Be '0' -Because "stderr: $($r.StdErr)"
+
+        # Half one: .env won on the way to the child.
+        Assert-LauncherEnv $r $Child $dotEnvValue "ctx13/$Key`: a routing key must always come from .env, never from an inherited shell value"
+
+        # Half two: winning did not cost the shell its own value.
+        $after = $r.AfterEnv
+        $after.ContainsKey($Key) | Should -BeTrue -Because "issue #66: $Key was REMOVED from the shell that invoked the launcher"
+        $after[$Key] | Should -BeExactly $inherited -Because "issue #66: the launcher overwrote $Key in the shell that invoked it"
+
+        # And no other name was disturbed either -- the per-key check above cannot
+        # see a value the launcher pushed onto some neighbouring variable.
+        Assert-ParentEnvUnchanged $r "ctx13/$Key"
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-14-launch-responsiveness.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-14-launch-responsiveness.ps1
@@ -1,0 +1,66 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '14. The launch is fire-and-forget: the launcher does not wait for VS Code' -Skip:(-not $IsWindows) {
+    # Every other stub in this suite exits in milliseconds, which makes one whole
+    # class of defect invisible: a launcher that WAITS for the process it started
+    # -- `Start-Process -Wait`, or a bare .WaitForExit() with no timeout on the
+    # ProcessStartInfo path issue #66 introduces -- passes all of them and still
+    # leaves the developer's prompt hanging until they close the editor. Nothing
+    # in an exit code, an env dump or an argv dump distinguishes the two; only a
+    # child that outlives the measurement can.
+    #
+    # Why fire-and-forget is the contract and not merely the current behaviour:
+    # the launcher's job ends once VS Code owns the environment it computed. It
+    # has nothing left to do with the editor's exit status (it does not propagate
+    # it -- `code` on Windows returns as soon as it has handed the folder to the
+    # running instance), and staying attached would additionally tie the editor's
+    # lifetime to a console the user is entitled to close. The POSIX counterpart
+    # gets this for free by exec'ing; on Windows it has to be a decision.
+    #
+    # Windows-only: off Windows `code` is a .ps1 stub, which PowerShell runs
+    # INSIDE the launcher process rather than starting as one, so "the launcher
+    # did not wait for it" is not a question that can be asked there.
+
+    BeforeAll {
+        # One measured launch, read by both cases (CPR-SSOT): they are two halves
+        # of one contract, and a blocking launcher costs this Context its whole
+        # budget once instead of once per case.
+        $script:Ctx14 = Measure-LauncherLaunch -Environment (New-Env) -Arguments @('C:\some\project') -BudgetMs 10000
+    }
+
+    It '14a. the launcher returns promptly even when the process it started is still alive' {
+        # The stub records that it ran, then blocks until the runner releases it,
+        # so the two observations below are independent:
+        #   StubStarted        -- a process really was launched (a launcher that
+        #                         starts nothing also returns promptly, and that
+        #                         is a different, worse bug)
+        #   ExitedWithinBudget -- the launcher came back without waiting for it
+        $r = $script:Ctx14
+
+        $r.StubStarted | Should -BeTrue -Because "the long-lived stub never ran, so nothing was measured; launcher output: $($r.Output)"
+        $r.ExitedWithinBudget | Should -BeTrue -Because @"
+the launcher was still running $($r.ElapsedMs)ms after it started a code.cmd that is deliberately still alive:
+it is waiting for VS Code to exit instead of handing over and returning. The invoking shell must get its
+prompt back at once -- the launcher has no use for the editor's exit status and must not tie the editor's
+lifetime to the console it was started from. Launcher output: $($r.Output)
+"@
+    }
+
+    It '14b. the child it did not wait for still received its argv and environment' {
+        # The other half (CPR-E2E): "returned promptly" is trivially satisfiable by
+        # a launcher that hands over nothing at all, so the SAME launch is checked
+        # for the payload as well.
+        $r = $script:Ctx14
+
+        $r.Reached | Should -BeTrue -Because "the stub wrote no environment dump; launcher output: $($r.Output)"
+        Assert-LauncherEnv $r 'ANTHROPIC_BASE_URL' 'https://lite:1' 'responsiveness/env'
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' 'ck' 'responsiveness/env'
+        $expected = @('--user-data-dir', (Join-Path $script:LocalAppData 'vscode-ccgw'), 'C:\some\project')
+        (@($r.Argv) -join "`u{1}") | Should -BeExactly ($expected -join "`u{1}") `
+            -Because "a detached launch must still deliver the full argv; got [$(@($r.Argv) -join '][')]"
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-14-launch-responsiveness.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-14-launch-responsiveness.ps1
@@ -5,25 +5,16 @@
 # Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
 
 Context '14. The launch is fire-and-forget: the launcher does not wait for VS Code' -Skip:(-not $IsWindows) {
-    # Every other stub in this suite exits in milliseconds, which makes one whole
-    # class of defect invisible: a launcher that WAITS for the process it started
-    # -- `Start-Process -Wait`, or a bare .WaitForExit() with no timeout on the
-    # ProcessStartInfo path issue #66 introduces -- passes all of them and still
-    # leaves the developer's prompt hanging until they close the editor. Nothing
-    # in an exit code, an env dump or an argv dump distinguishes the two; only a
-    # child that outlives the measurement can.
-    #
-    # Why fire-and-forget is the contract and not merely the current behaviour:
-    # the launcher's job ends once VS Code owns the environment it computed. It
-    # has nothing left to do with the editor's exit status (it does not propagate
-    # it -- `code` on Windows returns as soon as it has handed the folder to the
-    # running instance), and staying attached would additionally tie the editor's
-    # lifetime to a console the user is entitled to close. The POSIX counterpart
-    # gets this for free by exec'ing; on Windows it has to be a decision.
-    #
-    # Windows-only: off Windows `code` is a .ps1 stub, which PowerShell runs
-    # INSIDE the launcher process rather than starting as one, so "the launcher
-    # did not wait for it" is not a question that can be asked there.
+    # Every other stub exits in milliseconds, hiding one class of defect: a
+    # launcher that WAITS for the process it started (`Start-Process -Wait`,
+    # or .WaitForExit() with no timeout on the #66 ProcessStartInfo path)
+    # leaves the developer's prompt hanging until they close the editor --
+    # only a child outliving the measurement can tell. Fire-and-forget is the
+    # contract: the launcher's job ends once VS Code owns the environment
+    # (`code` returns without propagating exit status), and staying attached
+    # would tie the editor's lifetime to a console the user may close.
+    # Windows-only: off Windows `code` is a .ps1 run INSIDE the launcher
+    # process, so "did it wait" is unaskable there.
 
     BeforeAll {
         # One measured launch, read by both cases (CPR-SSOT): they are two halves

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-15-config-value-injection.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-15-config-value-injection.ps1
@@ -1,0 +1,117 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
+
+Context '15. Adversarial CONFIG values stay data too (issue #66)' -Skip:(-not $IsWindows) {
+    # Context 9 feeds metacharacters through argv. This one feeds them through the
+    # other input the launcher has -- the values it reads from .env and from the
+    # shell -- because those travel a different road to the child and a fix that
+    # secures one road says nothing about the other.
+    #
+    # The road matters: an environment BLOCK is a list of NAME=value pairs handed
+    # to CreateProcess, and nothing in it is ever re-parsed, so a correct
+    # implementation carries `& del *` in a client key without a thought. An
+    # implementation that instead composes the values into the command line --
+    # `cmd /c "set K=%v% && code ..."`, a `-Command` string, an `Invoke-Expression`
+    # -- turns every one of these values into syntax. The two are indistinguishable
+    # on the well-behaved values Contexts 1-4 use, which is precisely why the
+    # adversarial ones belong here.
+    #
+    # Not a hypothetical set: a LiteLLM key is generated, so `&`, `%` and `"` are
+    # all reachable characters; a CA path really can sit under
+    # "C:\Program Files (x86)\..."; and a `%VAR%` in any of them is what a user who
+    # pasted a Windows path into .env ends up with.
+    #
+    # Newlines are deliberately absent -- they are unrepresentable rather than
+    # merely dangerous, and Context 9d covers that contract for argv. `=` is absent
+    # too, but only because the `set`-shaped dump this suite parses cannot
+    # represent it; the launcher never splits a value.
+
+    BeforeAll {
+        # One shape per launch, applied to ALL FOUR value-carrying inputs at once:
+        # they are the same class (CPR-E2C), and a per-input sweep would multiply
+        # the runtime by four to prove the same thing.
+        $script:Ctx15Shapes = [ordered]@{
+            'metachars'     = 'a&b|c^d<e>f'
+            'expansion'     = '%PATH%-100%done'
+            'quotes'        = 'x"y"z'
+            'grouping-bang' = 'a(b)c;d,e!f!'
+            'injection'     = '& type nul > "{0}" &'
+        }
+    }
+
+    It '15a. metacharacters in the base URL, credential, CA path and model reach the child verbatim' {
+        $bad = New-Object System.Collections.Generic.List[string]
+        $i = 0
+        foreach ($name in @($script:Ctx15Shapes.Keys)) {
+            $i++
+            # The injection shape names a marker file that must never exist; the
+            # others format to themselves.
+            $marker = Join-Path $script:Work "config-injection-marker-$i.txt"
+            Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+            $shape = [string]::Format([string]$script:Ctx15Shapes[$name], $marker)
+
+            # Distinct per input, so a launcher that cross-wired two of them (e.g.
+            # exported the key as the base URL) cannot pass by coincidence.
+            $baseUrl = "https://ctx15-lite:1/$shape"
+            $key = "ctx15-key-$shape"
+            $ca = "C:\ctx15\$shape.pem"
+            $model = "ctx15-model-$shape"
+
+            $r = Invoke-Launcher -Environment @{
+                LITELLM_ANTHROPIC_BASE_URL = $baseUrl
+                LITELLM_CLIENT_KEY         = $key
+                CCGW_CA_CERT               = $ca
+                LITELLM_FABLE_MODEL        = $model
+            } -Arguments @('C:\some\project')
+
+            if (Test-Path -LiteralPath $marker) {
+                $bad.Add("${name}: a command embedded in a CONFIG VALUE RAN (marker created)")
+            }
+            if ($r.ExitCode -ne 0) {
+                $bad.Add("${name}: exit $($r.ExitCode); stderr: $($r.StdErr)")
+                continue
+            }
+            if (-not $r.Reached) {
+                $bad.Add("${name}: the stub was never reached; stderr: $($r.StdErr)")
+                continue
+            }
+            foreach ($pair in @(
+                    @{ Var = 'ANTHROPIC_BASE_URL'; Want = $baseUrl }
+                    @{ Var = 'ANTHROPIC_AUTH_TOKEN'; Want = $key }
+                    @{ Var = 'NODE_EXTRA_CA_CERTS'; Want = $ca }
+                    @{ Var = 'ANTHROPIC_DEFAULT_FABLE_MODEL'; Want = $model }
+                    @{ Var = 'ANTHROPIC_MODEL'; Want = $model }
+                )) {
+                $got = if ($r.Env.ContainsKey($pair.Var)) { $r.Env[$pair.Var] } else { '<absent>' }
+                if ($got -cne $pair.Want) {
+                    $bad.Add("${name}: $($pair.Var) reached the child as '$got', expected '$($pair.Want)'")
+                }
+            }
+            # The argv half of the same launch: a value that leaked out of the
+            # environment block and into the command line shows up as extra
+            # arguments even when nothing executed.
+            if (@($r.Argv).Count -ne 3) {
+                $bad.Add("${name}: argv was [$(@($r.Argv) -join '][')] -- a config value reached the command line")
+            }
+        }
+        $bad.Count | Should -Be 0 -Because "config values must be delivered as data, not as syntax: $($bad -join ' // ')"
+    }
+
+    It '15b. an adversarial credential is still never echoed back' {
+        # A value carrying quotes and operators is the one an implementation is
+        # most tempted to print while diagnosing it, and it is still the gateway
+        # credential (OWASP ASVS V8).
+        $key = 'ctx15-secret-& "quoted" %PATH%-key'
+        $r = Invoke-Launcher -Environment @{
+            LITELLM_ANTHROPIC_BASE_URL = 'https://ctx15-lite:1'
+            LITELLM_CLIENT_KEY         = $key
+            CCGW_CA_CERT               = 'C:\ctx15\ca.pem'
+        } -Arguments @('C:\some\project')
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        Assert-LauncherEnv $r 'ANTHROPIC_AUTH_TOKEN' $key 'config-injection/secret'
+        Assert-NoSecretInOutput $r @($key) 'config-injection/secret'
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-15-config-value-injection.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-15-config-value-injection.ps1
@@ -5,29 +5,12 @@
 # Part of the code-ccgw-windows.Tests.ps1 suite, dot-sourced into its Describe.
 
 Context '15. Adversarial CONFIG values stay data too (issue #66)' -Skip:(-not $IsWindows) {
-    # Context 9 feeds metacharacters through argv. This one feeds them through the
-    # other input the launcher has -- the values it reads from .env and from the
-    # shell -- because those travel a different road to the child and a fix that
-    # secures one road says nothing about the other.
-    #
-    # The road matters: an environment BLOCK is a list of NAME=value pairs handed
-    # to CreateProcess, and nothing in it is ever re-parsed, so a correct
-    # implementation carries `& del *` in a client key without a thought. An
-    # implementation that instead composes the values into the command line --
-    # `cmd /c "set K=%v% && code ..."`, a `-Command` string, an `Invoke-Expression`
-    # -- turns every one of these values into syntax. The two are indistinguishable
-    # on the well-behaved values Contexts 1-4 use, which is precisely why the
-    # adversarial ones belong here.
-    #
-    # Not a hypothetical set: a LiteLLM key is generated, so `&`, `%` and `"` are
-    # all reachable characters; a CA path really can sit under
-    # "C:\Program Files (x86)\..."; and a `%VAR%` in any of them is what a user who
-    # pasted a Windows path into .env ends up with.
-    #
-    # Newlines are deliberately absent -- they are unrepresentable rather than
-    # merely dangerous, and Context 9d covers that contract for argv. `=` is absent
-    # too, but only because the `set`-shaped dump this suite parses cannot
-    # represent it; the launcher never splits a value.
+    # Context 9 covers argv metacharacters; this covers .env/shell values --
+    # a different road, since CreateProcess's env BLOCK is never re-parsed,
+    # so only composing values into a command line (cmd /c "set K=%v% && ...",
+    # -Command) would turn them into syntax. Adversarial, not hypothetical: a
+    # generated key can hold `&`/`%`/`"`, a CA path can sit under "Program
+    # Files (x86)". Newlines absent (unrepresentable, per 9d).
 
     BeforeAll {
         # One shape per launch, applied to ALL FOUR value-carrying inputs at once:

--- a/tests/feature-18-serverctl/code-ccgw-windows/helpers-assertions.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/helpers-assertions.ps1
@@ -1,0 +1,125 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from its top-level
+# BeforeAll: the assertions the Contexts share. Definitions only.
+
+function Assert-LauncherEnv {
+    param($Result, [string]$Name, [string]$Expected, [string]$Context)
+    if (-not $Result.Reached) {
+        throw "$Context`: stub 'code' was never reached (no env dump); stderr: $($Result.StdErr)"
+    }
+    if (-not $Result.Env.ContainsKey($Name)) {
+        throw "$Context`: $Name was not exported at all (expected '$Expected')"
+    }
+    if ($Result.Env[$Name] -cne $Expected) {
+        throw "$Context`: $Name='$($Result.Env[$Name])', expected '$Expected'"
+    }
+}
+
+function Assert-LauncherEnvUnset {
+    param($Result, [string]$Name, [string]$Context)
+    # The launcher's own contract treats defined-but-empty as unset, and .NET
+    # drops an env var assigned '' on Windows -- so either shape counts.
+    if ($Result.Env.ContainsKey($Name) -and -not [string]::IsNullOrEmpty($Result.Env[$Name])) {
+        throw "$Context`: $Name was exported as '$($Result.Env[$Name])' but must not be set at all"
+    }
+}
+
+function Assert-LauncherEnvDiffers {
+    param($Result, [string]$A, [string]$B, [string]$Context)
+    if ($Result.Env[$A] -ceq $Result.Env[$B]) {
+        throw "$Context`: $A and $B both resolved to '$($Result.Env[$A])'; the two tiers must stay on separate routing keys"
+    }
+}
+
+# For messages the launcher writes itself through Write-LauncherError, i.e.
+# [Console]::Error -- genuinely stderr on every host, so this stays strict.
+function Assert-Stderr {
+    param($Result, [string]$Pattern, [string]$Context)
+    if ($Result.StdErr -notmatch [regex]::Escape($Pattern)) {
+        throw "$Context`: expected stderr to contain '$Pattern', got: $($Result.StdErr)"
+    }
+}
+
+# For messages the launcher emits through Write-Warning. Which stream the warning
+# stream lands on when redirected is the HOST's decision, not the launcher's --
+# pwsh 7.6 writes it to stdout, other hosts have written it to stderr -- so
+# pinning one stream here asserts a property of the PowerShell build rather than
+# of the launcher (CPR-UNV: no implicit branch on the environment). The contract
+# that matters is that the operator is told.
+function Assert-LauncherWarning {
+    param($Result, [string]$Pattern, [string]$Context)
+    $combined = [string]$Result.StdErr + [string]$Result.StdOut
+    if ($combined -notmatch [regex]::Escape($Pattern)) {
+        throw "$Context`: expected a warning containing '$Pattern', got stderr: $($Result.StdErr) / stdout: $($Result.StdOut)"
+    }
+}
+
+function Assert-NoCaWarning {
+    param($Result, [string]$Context)
+    $combined = [string]$Result.StdErr + [string]$Result.StdOut
+    if ($combined -match 'CCGW_CA_CERT not set') {
+        throw "$Context`: unexpected CA warning: $combined"
+    }
+}
+
+# --- invoking-shell assertions (issue #66) ----------------------------------
+
+# Every name whose value differs between two environment snapshots, rendered for
+# a failure message. Stated as a whole-snapshot diff rather than as a list of
+# forbidden names: a variable nobody thought to enumerate is exactly the one a
+# future assignment would leak (CPR-UNV).
+function Get-EnvSnapshotDiff {
+    param([hashtable]$Before, [hashtable]$After)
+    $diff = New-Object System.Collections.Generic.List[string]
+    foreach ($k in (@($Before.Keys) + @($After.Keys) | Sort-Object -Unique)) {
+        $b = if ($Before.ContainsKey($k)) { $Before[$k] } else { '<absent>' }
+        $a = if ($After.ContainsKey($k)) { $After[$k] } else { '<absent>' }
+        if ($b -cne $a) { $diff.Add("$k : '$b' -> '$a'") }
+    }
+    return $diff
+}
+
+# The zero-pollution contract, applied to one parent-shell run. Used by the happy
+# path (8a) and by every failure path (8g-8j): a launcher that gives up halfway
+# through is exactly where a half-applied environment would be left behind.
+function Assert-ParentEnvUnchanged {
+    param($Result, [string]$Context)
+    if ($Result.BeforeEnv.Count -eq 0) {
+        throw "$Context`: the wrapper wrote no before-snapshot; stderr: $($Result.StdErr)"
+    }
+    if ($Result.AfterEnv.Count -eq 0) {
+        throw "$Context`: the wrapper did not survive the launch; stderr: $($Result.StdErr)"
+    }
+    $diff = Get-EnvSnapshotDiff -Before $Result.BeforeEnv -After $Result.AfterEnv
+    if ($diff.Count -ne 0) {
+        throw "$Context`: the launcher must not write to the shell that invoked it; changed: $($diff -join '; ')"
+    }
+}
+
+# No secret in anything the operator (or CI log) sees. The credential is the one
+# secret the launcher handles; a diagnostic that echoes it would put it into
+# terminal scrollback and CI logs (OWASP ASVS V8). Asserted on the failure paths
+# too, because an error message is precisely where a value gets echoed back "to
+# help".
+function Assert-NoSecretInOutput {
+    param($Result, [string[]]$Secrets, [string]$Context)
+    $combined = [string]$Result.StdOut + [string]$Result.StdErr
+    foreach ($s in $Secrets) {
+        if ([string]::IsNullOrEmpty($s)) { continue }
+        if ($combined -match [regex]::Escape($s)) {
+            throw "$Context`: the credential '$s' appeared in the launcher's output: $combined"
+        }
+    }
+}
+
+# "No child was launched" -- the other half of a refusal. A refusal that has
+# already started VS Code is not a refusal.
+function Assert-NoChildLaunched {
+    param($Result, [string]$Context)
+    if ($Result.Reached) {
+        throw "$Context`: a child process was launched even though the launcher had to refuse"
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/helpers-fixtures.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/helpers-fixtures.ps1
@@ -2,35 +2,23 @@
 # Tests: scripts/code-ccgw.ps1
 # Tags: lifecycle, client-launcher, windows, scope:issue-specific
 #
-# Part of the code-ccgw-windows.Tests.ps1 suite (see that file for the scenario).
-# Dot-sourced from the suite's top-level BeforeAll: fixture trees and the `code`
-# / `mkcert` stubs. Definitions only -- setup.ps1 is what builds anything.
-#
-# Both dumping stubs write the SAME two files in the same format, so every
-# assertion helper is blind to which one ran:
-#   argv dump  -- line 1 `CWD=<working directory>`, then one `ARG="<value>"`
-#                line per argument, in order.
-#   env dump   -- one `NAME=value` line per inherited variable (the shape `set`
-#                produces, so the .cmd stub needs no formatting logic).
+# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from the
+# suite's top-level BeforeAll: fixture trees and the `code` / `mkcert`
+# stubs. Definitions only -- setup.ps1 builds anything. Both dumping stubs
+# write the SAME two files, so assertion helpers are blind to which ran:
+# argv dump -- `CWD=<dir>` then `ARG="<value>"` per argument in order; env
+# dump -- `NAME=value` per variable (the `set` shape, no formatting needed).
 
 # --- code.cmd stub (Windows) ------------------------------------------------
-# Windows uses a code.cmd because that is what a real VS Code install puts on
-# PATH, and because System.Diagnostics.Process cannot start a .ps1 at all -- a
-# .ps1 stub would silently exempt the launcher from the implicit cmd.exe re-parse
-# that Context 9 exists to police.
-#
-# The `ARG="%~1"` quoting is load-bearing, not cosmetic: cmd expands %~1 as text
-# into the line it is already scanning, so an unquoted `echo ARG=%~1` would let a
-# `&` or `|` inside the VALUE split the stub's own echo into two commands -- the
-# stub would then misreport the argv it was asked to observe, and could run
-# whatever followed the operator.
-#
-# chcp 65001 first, by absolute path (the child's PATH is the stub dir alone):
-# `echo` and `set` render through the CONSOLE code page, so without this the
-# round-trip of a non-ASCII argument would hold only on a host whose code page
-# happens to represent it -- CP932 here, CP850 elsewhere. Pinning UTF-8 makes the
-# dump the same bytes on every host (CPR-UNV) and is what lets Context 12 assert
-# a non-ASCII argument literally.
+# Windows uses code.cmd since that's what a real VS Code install puts on
+# PATH, and Process can't start a .ps1 at all -- a .ps1 stub would exempt
+# the launcher from the cmd.exe re-parse Context 9 polices. `ARG="%~1"`
+# quoting is load-bearing: cmd expands %~1 as text into the line it's
+# scanning, so unquoted `echo ARG=%~1` would let `&`/`|` in the VALUE split
+# the stub's own echo, misreporting argv or running what followed the
+# operator. chcp 65001 first, by absolute path (PATH is the stub dir alone):
+# `echo`/`set` render via the CONSOLE code page, so without this a non-ASCII
+# round-trip only holds where the code page happens to match; pinning UTF-8 makes it the same bytes everywhere (CPR-UNV).
 $script:CodeStubCmdBody = @'
 @echo off
 %SystemRoot%\System32\chcp.com 65001 > nul
@@ -66,21 +54,15 @@ $script:CodeStubCmdPositionalBody = @'
 set > "%CCGW_TEST_DUMP%"
 '@
 
-# Long-lived variant of the same stub: it dumps argv and the environment exactly
-# as above, announces itself by creating %CCGW_TEST_STARTED%, and only then stays
-# alive until the test releases it with %CCGW_TEST_STOP%. It exists because every
-# other stub here exits in milliseconds, so a launcher that WAITS for VS Code --
-# `Start-Process -Wait`, or .WaitForExit() with no timeout -- passes all of them
-# while leaving the developer's terminal blocked until they close the editor.
-# Only a child that outlives the measurement window can tell the two apart.
-#
-# ping.exe rather than timeout.exe: timeout.exe refuses to run at all when stdin
-# is redirected ("ERROR: Input redirection is not supported"), which is exactly
-# how a launched child is started here. `ping -n 2` costs one second.
-#
-# The iteration cap is a safety net, not the mechanism: the test releases the
-# stub as soon as it has measured, and the cap only guarantees that a test which
-# dies before doing so cannot leave a process behind forever.
+# Long-lived variant: dumps argv/environment as above, announces itself via
+# %CCGW_TEST_STARTED%, then stays alive until released via %CCGW_TEST_STOP%.
+# Needed because every other stub exits in milliseconds, so a launcher that
+# WAITS (`Start-Process -Wait`, or .WaitForExit() with no timeout) passes
+# them all while blocking the developer's terminal -- only an outliving
+# child can tell. ping.exe not timeout.exe: timeout.exe refuses stdin
+# redirection, which is how the child starts here (`ping -n 2` = 1s). The
+# iteration cap is a safety net, not the mechanism: the test releases the
+# stub once measured; the cap only stops a dying test leaking a process.
 $script:CodeStubCmdLongLivedBody = @'
 @echo off
 %SystemRoot%\System32\chcp.com 65001 > nul
@@ -116,17 +98,14 @@ $script:CodeStubCmdForwardBodyFormat = @'
 "{0}" %*
 '@
 
-# A shebang script on PATH, found via `Get-Command code -CommandType Application`
-# exactly like a real VS Code CLI shim on macOS/Linux: a plain extensionless file
-# with the execute bit set, whose first line hands it to pwsh. Used only off
-# Windows, where cmd.exe (and the .cmd stub above) does not exist.
-#
-# A bare `code.ps1` does NOT satisfy this: PowerShell's own command discovery
-# resolves a .ps1 as an ExternalScript, and the launcher filters
-# `Get-Command code -CommandType Application` -- ExternalScript is excluded, so
-# a .ps1 stub would make the launcher report "code not found" on every
-# non-Windows host, silently exempting these platform-independent contexts
-# from ever actually invoking the stub.
+# A shebang script on PATH, found via `Get-Command code -CommandType
+# Application`, like a real VS Code CLI shim on macOS/Linux: an
+# extensionless file with the execute bit set, first line handing it to
+# pwsh. Used only off Windows, where cmd.exe (and the .cmd stub) don't
+# exist. A bare `code.ps1` does NOT satisfy this: PowerShell resolves a
+# .ps1 as ExternalScript, which the launcher's `-CommandType Application`
+# filter excludes, so a .ps1 stub would make the launcher report "code not
+# found" on every non-Windows host, silently exempting these contexts.
 $script:CodeStubPs1Body = @'
 #!/usr/bin/env pwsh
 $argvOut = New-Object System.Collections.Generic.List[string]

--- a/tests/feature-18-serverctl/code-ccgw-windows/helpers-fixtures.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/helpers-fixtures.ps1
@@ -1,0 +1,278 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite (see that file for the scenario).
+# Dot-sourced from the suite's top-level BeforeAll: fixture trees and the `code`
+# / `mkcert` stubs. Definitions only -- setup.ps1 is what builds anything.
+#
+# Both dumping stubs write the SAME two files in the same format, so every
+# assertion helper is blind to which one ran:
+#   argv dump  -- line 1 `CWD=<working directory>`, then one `ARG="<value>"`
+#                line per argument, in order.
+#   env dump   -- one `NAME=value` line per inherited variable (the shape `set`
+#                produces, so the .cmd stub needs no formatting logic).
+
+# --- code.cmd stub (Windows) ------------------------------------------------
+# Windows uses a code.cmd because that is what a real VS Code install puts on
+# PATH, and because System.Diagnostics.Process cannot start a .ps1 at all -- a
+# .ps1 stub would silently exempt the launcher from the implicit cmd.exe re-parse
+# that Context 9 exists to police.
+#
+# The `ARG="%~1"` quoting is load-bearing, not cosmetic: cmd expands %~1 as text
+# into the line it is already scanning, so an unquoted `echo ARG=%~1` would let a
+# `&` or `|` inside the VALUE split the stub's own echo into two commands -- the
+# stub would then misreport the argv it was asked to observe, and could run
+# whatever followed the operator.
+#
+# chcp 65001 first, by absolute path (the child's PATH is the stub dir alone):
+# `echo` and `set` render through the CONSOLE code page, so without this the
+# round-trip of a non-ASCII argument would hold only on a host whose code page
+# happens to represent it -- CP932 here, CP850 elsewhere. Pinning UTF-8 makes the
+# dump the same bytes on every host (CPR-UNV) and is what lets Context 12 assert
+# a non-ASCII argument literally.
+$script:CodeStubCmdBody = @'
+@echo off
+%SystemRoot%\System32\chcp.com 65001 > nul
+> "%CCGW_TEST_ARGV%" echo CWD=%CD%
+:ccgwloop
+if "%~1"=="" goto ccgwdone
+>>"%CCGW_TEST_ARGV%" echo ARG="%~1"
+shift
+goto ccgwloop
+:ccgwdone
+set > "%CCGW_TEST_DUMP%"
+'@
+
+# Positional variant of the same stub. The loop above cannot report an EMPTY
+# argument at all: `if "%~1"==""` is equally true for "this argument is the empty
+# string" and for "there are no more arguments", so an empty argument reads as
+# end-of-argv and everything after it disappears. Unrolling the loop removes the
+# ambiguity for a known argument count -- position N is dumped whether or not it
+# is empty -- which is what Context 12's empty-argument case needs. Eight slots
+# is well past any argv this suite passes; trailing unused slots dump as empty.
+$script:CodeStubCmdPositionalBody = @'
+@echo off
+%SystemRoot%\System32\chcp.com 65001 > nul
+> "%CCGW_TEST_ARGV%" echo CWD=%CD%
+>>"%CCGW_TEST_ARGV%" echo ARG="%~1"
+>>"%CCGW_TEST_ARGV%" echo ARG="%~2"
+>>"%CCGW_TEST_ARGV%" echo ARG="%~3"
+>>"%CCGW_TEST_ARGV%" echo ARG="%~4"
+>>"%CCGW_TEST_ARGV%" echo ARG="%~5"
+>>"%CCGW_TEST_ARGV%" echo ARG="%~6"
+>>"%CCGW_TEST_ARGV%" echo ARG="%~7"
+>>"%CCGW_TEST_ARGV%" echo ARG="%~8"
+set > "%CCGW_TEST_DUMP%"
+'@
+
+# Long-lived variant of the same stub: it dumps argv and the environment exactly
+# as above, announces itself by creating %CCGW_TEST_STARTED%, and only then stays
+# alive until the test releases it with %CCGW_TEST_STOP%. It exists because every
+# other stub here exits in milliseconds, so a launcher that WAITS for VS Code --
+# `Start-Process -Wait`, or .WaitForExit() with no timeout -- passes all of them
+# while leaving the developer's terminal blocked until they close the editor.
+# Only a child that outlives the measurement window can tell the two apart.
+#
+# ping.exe rather than timeout.exe: timeout.exe refuses to run at all when stdin
+# is redirected ("ERROR: Input redirection is not supported"), which is exactly
+# how a launched child is started here. `ping -n 2` costs one second.
+#
+# The iteration cap is a safety net, not the mechanism: the test releases the
+# stub as soon as it has measured, and the cap only guarantees that a test which
+# dies before doing so cannot leave a process behind forever.
+$script:CodeStubCmdLongLivedBody = @'
+@echo off
+%SystemRoot%\System32\chcp.com 65001 > nul
+> "%CCGW_TEST_ARGV%" echo CWD=%CD%
+:ccgwloop
+if "%~1"=="" goto ccgwdone
+>>"%CCGW_TEST_ARGV%" echo ARG="%~1"
+shift
+goto ccgwloop
+:ccgwdone
+set > "%CCGW_TEST_DUMP%"
+> "%CCGW_TEST_STARTED%" echo started
+set CCGWWAIT=0
+:ccgwwait
+if exist "%CCGW_TEST_STOP%" goto ccgwend
+set /a CCGWWAIT=%CCGWWAIT%+1
+if %CCGWWAIT% GTR 60 goto ccgwend
+%SystemRoot%\System32\ping.exe -n 2 127.0.0.1 > nul
+goto ccgwwait
+:ccgwend
+'@
+
+# A .cmd that forwards its whole argument tail to a real executable, which is the
+# shape of a genuine VS Code install (code.cmd hands %* to Code.exe). It is the
+# only observer in this suite that can report an embedded quote or a trailing
+# backslash faithfully: the `%~1` loop above recovers each argument through cmd's
+# own de-quoting, which neither collapses a doubled "" nor halves a doubled
+# trailing backslash, whereas %* passes the tail on untouched for
+# CommandLineToArgvW in the target .exe to parse by the documented rules.
+# {0} is the absolute path of that executable.
+$script:CodeStubCmdForwardBodyFormat = @'
+@echo off
+"{0}" %*
+'@
+
+# A shebang script on PATH, found via `Get-Command code -CommandType Application`
+# exactly like a real VS Code CLI shim on macOS/Linux: a plain extensionless file
+# with the execute bit set, whose first line hands it to pwsh. Used only off
+# Windows, where cmd.exe (and the .cmd stub above) does not exist.
+#
+# A bare `code.ps1` does NOT satisfy this: PowerShell's own command discovery
+# resolves a .ps1 as an ExternalScript, and the launcher filters
+# `Get-Command code -CommandType Application` -- ExternalScript is excluded, so
+# a .ps1 stub would make the launcher report "code not found" on every
+# non-Windows host, silently exempting these platform-independent contexts
+# from ever actually invoking the stub.
+$script:CodeStubPs1Body = @'
+#!/usr/bin/env pwsh
+$argvOut = New-Object System.Collections.Generic.List[string]
+$argvOut.Add('CWD=' + (Get-Location).ProviderPath)
+foreach ($a in $args) { $argvOut.Add('ARG="' + [string]$a + '"') }
+[System.IO.File]::WriteAllLines($env:CCGW_TEST_ARGV, $argvOut)
+$envOut = New-Object System.Collections.Generic.List[string]
+foreach ($e in Get-ChildItem env:) { $envOut.Add($e.Name + '=' + $e.Value) }
+[System.IO.File]::WriteAllLines($env:CCGW_TEST_DUMP, $envOut)
+'@
+
+# The .exe stub, compiled at fixture time. It exists because "the .exe branch was
+# taken" cannot be shown by absence of an error message: a launcher that launches
+# NOTHING produces no error either. This one reports what it actually received --
+# argv, its inherited environment, and a marker file whose existence is the
+# unambiguous "a process really started" evidence -- in the same dump format as
+# the .cmd stub, and through File.WriteAllLines, which is code-page-independent
+# and therefore also the honest way to assert a non-ASCII argument.
+$script:CodeStubCsSource = @'
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+class CcgwCodeStub {
+  static int Main(string[] argv) {
+    UTF8Encoding enc = new UTF8Encoding(false);
+    List<string> args = new List<string>();
+    args.Add("CWD=" + Directory.GetCurrentDirectory());
+    foreach (string a in argv) args.Add("ARG=\"" + a + "\"");
+    File.WriteAllLines(Environment.GetEnvironmentVariable("CCGW_TEST_ARGV"), args.ToArray(), enc);
+    List<string> env = new List<string>();
+    foreach (DictionaryEntry e in Environment.GetEnvironmentVariables())
+      env.Add(e.Key + "=" + e.Value);
+    File.WriteAllLines(Environment.GetEnvironmentVariable("CCGW_TEST_DUMP"), env.ToArray(), enc);
+    string marker = Environment.GetEnvironmentVariable("CCGW_TEST_EXE_MARKER");
+    if (!string.IsNullOrEmpty(marker)) File.WriteAllText(marker, "launched", enc);
+    return 0;
+  }
+}
+'@
+
+# The launcher reads <script>/../.env. Copying it into a fixture tree pins that
+# file to an empty one, so precedence is asserted from the child's environment
+# block alone.
+function New-FixtureTree {
+    param([string]$Name, [string[]]$DotEnvLines = @('# intentionally empty: precedence is asserted from the env alone'))
+    $root = Join-Path $script:Work $Name
+    New-Item -ItemType Directory -Path (Join-Path $root 'scripts') -Force | Out-Null
+    Copy-Item -LiteralPath $script:SourceLauncher -Destination (Join-Path $root 'scripts' 'code-ccgw.ps1') -Force
+    Set-Content -LiteralPath (Join-Path $root '.env') -Value $DotEnvLines -Encoding utf8
+    return (Join-Path $root 'scripts' 'code-ccgw.ps1')
+}
+
+# Compiles $script:CodeStubCsSource into <Dir>\code.exe. csc.exe from the .NET
+# Framework is used rather than Add-Type -OutputAssembly, which PowerShell 7 does
+# not support; it ships with every Windows install that has .NET Framework 4.
+# Returns $true only when the executable really exists afterwards -- a host
+# without a compiler must produce a SKIP, never a stub that silently proves
+# nothing.
+function New-DumpingCodeExe {
+    param([string]$Dir)
+    if (-not $IsWindows) { return $false }
+    $candidates = @(
+        (Join-Path $env:WINDIR 'Microsoft.NET\Framework64\v4.0.30319\csc.exe')
+        (Join-Path $env:WINDIR 'Microsoft.NET\Framework\v4.0.30319\csc.exe')
+    )
+    $csc = @($candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1)
+    if (-not $csc) {
+        $cmd = @(Get-Command 'csc.exe' -CommandType Application -ErrorAction SilentlyContinue)
+        if ($cmd) { $csc = @($cmd[0].Source) }
+    }
+    if (-not $csc) { return $false }
+    $src = Join-Path $script:Work 'ccgw-code-stub.cs'
+    [System.IO.File]::WriteAllText($src, $script:CodeStubCsSource, (New-Object System.Text.UTF8Encoding($false)))
+    $exe = Join-Path $Dir 'code.exe'
+    & $csc[0] '/nologo' '/target:exe' "/out:$exe" $src 2>&1 | Out-Null
+    return (Test-Path -LiteralPath $exe)
+}
+
+function New-StubDir {
+    param(
+        [string]$Name,
+        [string]$MkcertCaroot,
+        [int]$MkcertExitCode = 0,
+        [switch]$NoCode,
+        [switch]$NoMkcert,
+        [switch]$ExeStub,
+        [switch]$BrokenExeStub,
+        [switch]$PositionalCmdStub,
+        [switch]$LongLivedCmdStub,
+        [string]$ForwardCmdStubTo
+    )
+    $dir = Join-Path $script:Work $Name
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    if ($ForwardCmdStubTo) {
+        Set-Content -LiteralPath (Join-Path $dir 'code.cmd') -Encoding ascii `
+            -Value ([string]::Format($script:CodeStubCmdForwardBodyFormat, $ForwardCmdStubTo))
+    } elseif ($ExeStub) {
+        New-DumpingCodeExe -Dir $dir | Out-Null
+    } elseif ($BrokenExeStub) {
+        # Resolvable as `code` (PATHEXT lists .EXE) but not a startable image, so
+        # CreateProcess fails AFTER every value has been resolved -- the last
+        # place a launcher could still leave the invoking shell dirty.
+        Set-Content -LiteralPath (Join-Path $dir 'code.exe') -Value 'not a portable executable' -Encoding ascii
+    } elseif (-not $NoCode) {
+        if ($IsWindows) {
+            # -Encoding ascii: a UTF-8 BOM ahead of `@echo off` is echoed by cmd
+            # as garbage before the stub ever runs.
+            $body =
+                if ($PositionalCmdStub) { $script:CodeStubCmdPositionalBody }
+                elseif ($LongLivedCmdStub) { $script:CodeStubCmdLongLivedBody }
+                else { $script:CodeStubCmdBody }
+            Set-Content -LiteralPath (Join-Path $dir 'code.cmd') -Value $body -Encoding ascii
+        } else {
+            # Extensionless, matching a real `code` shim's name on PATH: an
+            # extension would let PowerShell's own script discovery resolve it
+            # as ExternalScript, which `Get-Command code -CommandType
+            # Application` does not match (see the shebang-body comment above).
+            $codePath = Join-Path $dir 'code'
+            Set-Content -LiteralPath $codePath -Value $script:CodeStubPs1Body -Encoding utf8
+            & chmod +x $codePath
+        }
+    }
+    if (-not $NoMkcert) {
+        # Prints the CAROOT it was created with; the launcher pipes it through
+        # Select-Object -First 1. A failing stub prints nothing and exits non-zero
+        # -- it deliberately writes no stderr, which would otherwise contaminate
+        # the launcher's own stderr that the warning assertions read.
+        $body = if ($MkcertExitCode -ne 0) {
+            "exit $MkcertExitCode"
+        } else {
+            "Write-Output '" + ($MkcertCaroot -replace "'", "''") + "'"
+        }
+        Set-Content -LiteralPath (Join-Path $dir 'mkcert.ps1') -Value $body -Encoding utf8
+    }
+    return $dir
+}
+
+# The minimum configuration every non-configuration case needs, so that a case
+# about (say) argv is never accidentally satisfied by the base-URL guard refusing
+# to run at all.
+function New-Env {
+    param([hashtable]$Extra = @{})
+    $h = @{}
+    foreach ($k in $script:Configured.Keys) { $h[$k] = $script:Configured[$k] }
+    foreach ($k in $Extra.Keys) { $h[$k] = $Extra[$k] }
+    return $h
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners-latency.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners-latency.ps1
@@ -2,14 +2,12 @@
 # Tests: scripts/code-ccgw.ps1
 # Tags: lifecycle, client-launcher, windows, scope:issue-specific
 #
-# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from its top-level
-# BeforeAll, after helpers-runners.ps1 (whose Set-ChildEnvBlock and dump parsers
-# it uses): the runner that measures how long the launcher takes to come back.
-# Definitions only.
-#
-# It lives in its own file rather than in helpers-runners.ps1 because that file
-# had reached the 300-line split threshold, and this runner is a self-contained
-# third way of running the launcher -- neither of the other two can time it.
+# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from its
+# top-level BeforeAll, after helpers-runners.ps1 (whose Set-ChildEnvBlock
+# and dump parsers it uses): the runner that measures how long the launcher
+# takes to come back. Definitions only. Lives in its own file rather than
+# helpers-runners.ps1 because that file hit the 300-line split threshold,
+# and this is a self-contained third way of running the launcher -- neither of the others can time it.
 
 # --- responsiveness runner (issue #66) --------------------------------------
 # Invoke-Launcher cannot measure how long the launcher takes to return, for a
@@ -79,18 +77,14 @@ function Measure-LauncherLaunch {
             $proc.WaitForExit(10000) | Out-Null
         }
     } else {
-        # The launcher is fire-and-forget: it starts the stub child and returns
-        # well before that long-lived child has necessarily finished writing its
-        # own $started/$dump/$argvFile files. Waiting for the LAUNCHER process to
-        # exit (above) says nothing about whether the CHILD has reached that
-        # point yet, so reading the marker files immediately here races the
-        # child's own writes -- intermittently reporting Reached=$false / an
-        # empty Argv even though the child would have written them a few
-        # milliseconds later. Poll briefly for $started (and, once that shows the
-        # child is alive, for $dump/$argvFile) before trusting their presence.
-        # This only firms up the artifact-existence observation; ElapsedMs and
-        # ExitedWithinBudget above already captured the launcher's own
-        # responsiveness and are untouched by this wait.
+        # The launcher is fire-and-forget: it returns well before the
+        # long-lived child necessarily finishes writing $started/$dump/
+        # $argvFile. Waiting for the LAUNCHER to exit says nothing about the
+        # CHILD reaching that point, so reading the markers immediately
+        # races the child's writes -- intermittently reporting Reached=
+        # $false / empty Argv even though they'd land a few ms later. Poll
+        # briefly for $started, then $dump/$argvFile, before trusting them;
+        # this only firms up artifact existence -- ElapsedMs/ExitedWithinBudget above are untouched.
         $pollBudget = [System.Diagnostics.Stopwatch]::StartNew()
         while (-not (Test-Path -LiteralPath $started) -and $pollBudget.ElapsedMilliseconds -lt 3000) {
             Start-Sleep -Milliseconds 50

--- a/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners-latency.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners-latency.ps1
@@ -1,0 +1,115 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from its top-level
+# BeforeAll, after helpers-runners.ps1 (whose Set-ChildEnvBlock and dump parsers
+# it uses): the runner that measures how long the launcher takes to come back.
+# Definitions only.
+#
+# It lives in its own file rather than in helpers-runners.ps1 because that file
+# had reached the 300-line split threshold, and this runner is a self-contained
+# third way of running the launcher -- neither of the other two can time it.
+
+# --- responsiveness runner (issue #66) --------------------------------------
+# Invoke-Launcher cannot measure how long the launcher takes to return, for a
+# reason that has nothing to do with the launcher: it reads the launcher's stdout
+# to the end, and a GRANDCHILD that inherited that pipe holds it open for as long
+# as it lives. Against a deliberately long-lived `code` stub the read alone would
+# block, whatever the launcher did. This runner therefore redirects the launcher's
+# streams to a FILE from inside a one-line wrapper -- a file handle an inherited
+# grandchild cannot stall on -- and times the launcher process itself.
+$script:LatencyWrapperBody = @'
+param(
+    [string]$LauncherPath,
+    [string]$OutFile,
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$LauncherArgs = @()
+)
+if ($LauncherArgs.Count -gt 0) { & $LauncherPath @LauncherArgs *> $OutFile } else { & $LauncherPath *> $OutFile }
+if ($null -eq $LASTEXITCODE) { exit 0 }
+exit $LASTEXITCODE
+'@
+
+# Starts the launcher against the long-lived stub and reports how long the
+# launcher took to come back. The stub is released as soon as the measurement is
+# taken, so a launcher that DOES block still ends the case in seconds instead of
+# waiting out the stub's own safety cap.
+function Measure-LauncherLaunch {
+    param(
+        [hashtable]$Environment = @{},
+        [string[]]$Arguments = @(),
+        [string]$StubDir = $script:StubLongLived,
+        [string]$LauncherPath = $script:Launcher,
+        [int]$BudgetMs = 10000
+    )
+
+    $dump = Join-Path $script:Work 'latency.env.dump'
+    $argvFile = Join-Path $script:Work 'latency.argv.dump'
+    $outFile = Join-Path $script:Work 'latency.out.txt'
+    $started = Join-Path $script:Work 'latency.started.txt'
+    $stop = Join-Path $script:Work 'latency.stop.txt'
+    Remove-Item -LiteralPath $dump, $argvFile, $outFile, $started, $stop -Force -ErrorAction SilentlyContinue
+
+    $childEnv = @{}
+    foreach ($k in $Environment.Keys) { $childEnv[$k] = $Environment[$k] }
+    $childEnv['CCGW_TEST_STARTED'] = $started
+    $childEnv['CCGW_TEST_STOP'] = $stop
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $script:PwshPath
+    foreach ($a in @('-NoProfile', '-NonInteractive', '-File', $script:LatencyWrapper, $LauncherPath, $outFile) + $Arguments) {
+        $psi.ArgumentList.Add([string]$a)
+    }
+    # Deliberately NOT redirected here; the wrapper above owns the redirection.
+    $psi.UseShellExecute = $false
+    $psi.WorkingDirectory = $script:Work
+    Set-ChildEnvBlock -Psi $psi -Environment $childEnv -StubDir $StubDir -DumpPath $dump -ArgvPath $argvFile
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $exitedInBudget = $proc.WaitForExit($BudgetMs)
+    $sw.Stop()
+
+    # Release the stub whatever the verdict, then let the launcher finish so the
+    # next case starts from a quiet machine.
+    [System.IO.File]::WriteAllText($stop, 'stop')
+    if (-not $exitedInBudget) {
+        if (-not $proc.WaitForExit(90000)) {
+            try { $proc.Kill($true) } catch { }
+            $proc.WaitForExit(10000) | Out-Null
+        }
+    } else {
+        # The launcher is fire-and-forget: it starts the stub child and returns
+        # well before that long-lived child has necessarily finished writing its
+        # own $started/$dump/$argvFile files. Waiting for the LAUNCHER process to
+        # exit (above) says nothing about whether the CHILD has reached that
+        # point yet, so reading the marker files immediately here races the
+        # child's own writes -- intermittently reporting Reached=$false / an
+        # empty Argv even though the child would have written them a few
+        # milliseconds later. Poll briefly for $started (and, once that shows the
+        # child is alive, for $dump/$argvFile) before trusting their presence.
+        # This only firms up the artifact-existence observation; ElapsedMs and
+        # ExitedWithinBudget above already captured the launcher's own
+        # responsiveness and are untouched by this wait.
+        $pollBudget = [System.Diagnostics.Stopwatch]::StartNew()
+        while (-not (Test-Path -LiteralPath $started) -and $pollBudget.ElapsedMilliseconds -lt 3000) {
+            Start-Sleep -Milliseconds 50
+        }
+        if (Test-Path -LiteralPath $started) {
+            while ((-not (Test-Path -LiteralPath $dump) -or -not (Test-Path -LiteralPath $argvFile)) -and $pollBudget.ElapsedMilliseconds -lt 3000) {
+                Start-Sleep -Milliseconds 50
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        ExitedWithinBudget = $exitedInBudget
+        ElapsedMs          = [int]$sw.ElapsedMilliseconds
+        BudgetMs           = $BudgetMs
+        StubStarted        = (Test-Path -LiteralPath $started)
+        Reached            = (Test-Path -LiteralPath $dump)
+        Argv               = (ConvertFrom-ArgvDump -Path $argvFile).Argv
+        Env                = ConvertFrom-SetDump -Path $dump
+        Output             = if (Test-Path -LiteralPath $outFile) { [System.IO.File]::ReadAllText($outFile) } else { '' }
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners.ps1
@@ -1,0 +1,228 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from its top-level
+# BeforeAll: two of the three ways this suite runs the launcher, plus the
+# environment-block builder and dump parsers all three share (the third,
+# Measure-LauncherLaunch, is in helpers-runners-latency.ps1 and builds on these).
+# Definitions only.
+#
+# The child's environment block is cleared and rebuilt, so an ambient
+# LITELLM_*/CCGW_*/DS4_* value in the developer's shell can never satisfy an
+# assertion by accident, and a genuinely installed mkcert cannot turn the
+# "no mkcert" case into a false pass.
+
+# Builds the child's environment block. Shared by every runner below so the
+# "cleared and rebuilt" guarantee is stated once (CPR-SSOT).
+function Set-ChildEnvBlock {
+    param(
+        $Psi,
+        [hashtable]$Environment = @{},
+        [string]$StubDir = $script:StubDir,
+        [string]$DumpPath,
+        [string]$ArgvPath,
+        [string]$ExeMarkerPath,
+        [switch]$NoLocalAppData
+    )
+    $Psi.Environment.Clear()
+    $Psi.Environment['PATH'] = $StubDir
+    $Psi.Environment['CCGW_TEST_DUMP'] = $DumpPath
+    $Psi.Environment['CCGW_TEST_ARGV'] = $ArgvPath
+    if ($ExeMarkerPath) { $Psi.Environment['CCGW_TEST_EXE_MARKER'] = $ExeMarkerPath }
+    if (-not $NoLocalAppData) { $Psi.Environment['LOCALAPPDATA'] = $script:LocalAppData }
+    $Psi.Environment['TEMP'] = $script:Work
+    $Psi.Environment['TMP'] = $script:Work
+    $Psi.Environment['TMPDIR'] = $script:Work
+    $Psi.Environment['HOME'] = $script:Work
+    $Psi.Environment['USERPROFILE'] = $script:Work
+    # .ps1 must stay a discoverable command extension for the stubs above, and
+    # .CMD must precede it so a Windows run resolves `code` the way a real VS Code
+    # install does.
+    $Psi.Environment['PATHEXT'] = '.COM;.EXE;.BAT;.CMD;.PS1'
+    foreach ($passthrough in @('SystemRoot', 'ComSpec', 'windir')) {
+        $v = [Environment]::GetEnvironmentVariable($passthrough)
+        if ($v) { $Psi.Environment[$passthrough] = $v }
+    }
+    foreach ($k in $Environment.Keys) {
+        $Psi.Environment[[string]$k] = [string]$Environment[$k]
+    }
+}
+
+# Reads a dump file as UTF-8 explicitly. Every writer in this suite emits UTF-8 --
+# File.WriteAllLines from the .ps1 and .exe stubs, `set`/`echo` under the code
+# page the .cmd stub pins to 65001 -- so decoding it as anything else would make
+# a non-ASCII assertion a property of the developer's locale (CPR-UNV).
+function Read-DumpLines {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return @() }
+    return @([System.IO.File]::ReadAllLines($Path, [System.Text.Encoding]::UTF8))
+}
+
+# Parses the `NAME=value` env dump every stub writes. A line whose '=' sits at
+# index 0 is `set`'s rendering of a cmd-internal variable (=C:, =ExitCode) and is
+# not an inheritable variable at all.
+function ConvertFrom-SetDump {
+    param([string]$Path)
+    $map = @{}
+    foreach ($line in (Read-DumpLines -Path $Path)) {
+        $i = $line.IndexOf('=')
+        if ($i -lt 1) { continue }
+        $map[$line.Substring(0, $i)] = $line.Substring($i + 1)
+    }
+    return $map
+}
+
+function ConvertFrom-ArgvDump {
+    param([string]$Path)
+    $argv = @()
+    $cwd = $null
+    foreach ($line in (Read-DumpLines -Path $Path)) {
+        if ($line -match '^ARG="(.*)"$') { $argv += $Matches[1] }
+        elseif ($line -match '^CWD=(.*)$') { $cwd = $Matches[1] }
+    }
+    return [pscustomobject]@{ Argv = $argv; Cwd = $cwd }
+}
+
+function Invoke-Launcher {
+    param(
+        [hashtable]$Environment = @{},
+        [string[]]$Arguments = @(),
+        [string]$StubDir = $script:StubDir,
+        [string]$LauncherPath = $script:Launcher,
+        [string]$WorkingDirectory = $script:Work,
+        [switch]$NoLocalAppData
+    )
+
+    $dump = Join-Path $script:Work 'env.dump'
+    $argvFile = Join-Path $script:Work 'argv.dump'
+    $marker = Join-Path $script:Work 'exe-launch-marker.txt'
+    Remove-Item -LiteralPath $dump, $argvFile, $marker -Force -ErrorAction SilentlyContinue
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $script:PwshPath
+    foreach ($a in @('-NoProfile', '-NonInteractive', '-File', $LauncherPath) + $Arguments) {
+        $psi.ArgumentList.Add([string]$a)
+    }
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.WorkingDirectory = $WorkingDirectory
+    Set-ChildEnvBlock -Psi $psi -Environment $Environment -StubDir $StubDir `
+        -DumpPath $dump -ArgvPath $argvFile -ExeMarkerPath $marker -NoLocalAppData:$NoLocalAppData
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    if (-not $proc.WaitForExit(60000)) {
+        try { $proc.Kill($true) } catch { }
+        throw "launcher did not exit within 60s"
+    }
+
+    $parsed = ConvertFrom-ArgvDump -Path $argvFile
+    return [pscustomobject]@{
+        ExitCode  = $proc.ExitCode
+        StdOut    = $stdout
+        StdErr    = $stderr
+        Env       = ConvertFrom-SetDump -Path $dump
+        Argv      = $parsed.Argv
+        Cwd       = $parsed.Cwd
+        Reached   = (Test-Path -LiteralPath $dump)
+        ExeMarker = (Test-Path -LiteralPath $marker)
+    }
+}
+
+# --- invoking-shell runner (issue #66) --------------------------------------
+# Invoke-Launcher above can never see the bug this suite exists to catch: it
+# inspects the CHILD's environment, and the leak is in the PARENT's. This runner
+# therefore inserts one wrapper script that plays the developer's interactive
+# shell -- it snapshots its own process environment, calls the launcher with `&`
+# (a child SCOPE, not a child PROCESS, so every `$env:` assignment the launcher
+# makes stays in the wrapper exactly as it stays in the invoking pwsh), and
+# snapshots again. The two snapshots are the evidence; the child dump is still
+# collected so the same run can also show the values did reach VS Code.
+#
+# `exit` inside a `&`-called script ends that script, not the wrapper, so the
+# after-snapshot is written on the failure paths too -- which is what lets the
+# error cases (8g-8j) be asserted here rather than only through a disposable
+# child process. The launcher's own exit code survives in $LASTEXITCODE and is
+# recorded separately: the wrapper's process exit code is the WRAPPER's.
+$script:ParentShellWrapperBody = @'
+param(
+    [string]$LauncherPath,
+    [string]$BeforeFile,
+    [string]$AfterFile,
+    [string]$ExitFile,
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$LauncherArgs = @()
+)
+function Save-CcgwEnvSnapshot([string]$Path) {
+    $lines = New-Object System.Collections.Generic.List[string]
+    foreach ($e in Get-ChildItem env:) { $lines.Add($e.Name + '=' + $e.Value) }
+    [System.IO.File]::WriteAllLines($Path, $lines)
+}
+Save-CcgwEnvSnapshot $BeforeFile
+$launcherExit = 'NONE'
+try {
+    if ($LauncherArgs.Count -gt 0) { & $LauncherPath @LauncherArgs } else { & $LauncherPath }
+    $launcherExit = [string]$LASTEXITCODE
+} catch {
+    [Console]::Error.WriteLine('[wrapper] ' + $_.Exception.Message)
+    $launcherExit = 'THREW'
+}
+Save-CcgwEnvSnapshot $AfterFile
+[System.IO.File]::WriteAllText($ExitFile, $launcherExit)
+'@
+
+function Invoke-LauncherInParentShell {
+    param(
+        [hashtable]$Environment = @{},
+        [string[]]$Arguments = @(),
+        [string]$StubDir = $script:StubDir,
+        [string]$LauncherPath = $script:Launcher
+    )
+
+    $dump = Join-Path $script:Work 'parent.env.dump'
+    $argvFile = Join-Path $script:Work 'parent.argv.dump'
+    $beforeFile = Join-Path $script:Work 'parent.before.dump'
+    $afterFile = Join-Path $script:Work 'parent.after.dump'
+    $exitFile = Join-Path $script:Work 'parent.exit.dump'
+    $marker = Join-Path $script:Work 'parent.exe-launch-marker.txt'
+    Remove-Item -LiteralPath $dump, $argvFile, $beforeFile, $afterFile, $exitFile, $marker `
+        -Force -ErrorAction SilentlyContinue
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $script:PwshPath
+    $wrapperArgs = @('-NoProfile', '-NonInteractive', '-File', $script:ParentShellWrapper,
+        $LauncherPath, $beforeFile, $afterFile, $exitFile) + $Arguments
+    foreach ($a in $wrapperArgs) { $psi.ArgumentList.Add([string]$a) }
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.WorkingDirectory = $script:Work
+    Set-ChildEnvBlock -Psi $psi -Environment $Environment -StubDir $StubDir `
+        -DumpPath $dump -ArgvPath $argvFile -ExeMarkerPath $marker
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    if (-not $proc.WaitForExit(60000)) {
+        try { $proc.Kill($true) } catch { }
+        throw "parent-shell wrapper did not exit within 60s"
+    }
+
+    $launcherExit = if (Test-Path -LiteralPath $exitFile) {
+        [System.IO.File]::ReadAllText($exitFile).Trim()
+    } else { 'NONE' }
+
+    return [pscustomobject]@{
+        ExitCode         = $proc.ExitCode
+        LauncherExitCode = $launcherExit
+        StdOut           = $stdout
+        StdErr           = $stderr
+        Env              = ConvertFrom-SetDump -Path $dump
+        Argv             = (ConvertFrom-ArgvDump -Path $argvFile).Argv
+        BeforeEnv        = ConvertFrom-SetDump -Path $beforeFile
+        AfterEnv         = ConvertFrom-SetDump -Path $afterFile
+        Reached          = (Test-Path -LiteralPath $dump)
+    }
+}

--- a/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/helpers-runners.ps1
@@ -2,16 +2,12 @@
 # Tests: scripts/code-ccgw.ps1
 # Tags: lifecycle, client-launcher, windows, scope:issue-specific
 #
-# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from its top-level
-# BeforeAll: two of the three ways this suite runs the launcher, plus the
-# environment-block builder and dump parsers all three share (the third,
-# Measure-LauncherLaunch, is in helpers-runners-latency.ps1 and builds on these).
-# Definitions only.
-#
-# The child's environment block is cleared and rebuilt, so an ambient
-# LITELLM_*/CCGW_*/DS4_* value in the developer's shell can never satisfy an
-# assertion by accident, and a genuinely installed mkcert cannot turn the
-# "no mkcert" case into a false pass.
+# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced from its
+# top-level BeforeAll: two of the three ways this suite runs the launcher,
+# plus the shared environment-block builder and dump parsers (the third,
+# Measure-LauncherLaunch, is in helpers-runners-latency.ps1). The child's
+# environment block is cleared and rebuilt so an ambient LITELLM_*/CCGW_*
+# value in the dev's shell can't satisfy an assertion by accident, and a real mkcert can't fake "no mkcert" passing.
 
 # Builds the child's environment block. Shared by every runner below so the
 # "cleared and rebuilt" guarantee is stated once (CPR-SSOT).
@@ -133,20 +129,15 @@ function Invoke-Launcher {
 }
 
 # --- invoking-shell runner (issue #66) --------------------------------------
-# Invoke-Launcher above can never see the bug this suite exists to catch: it
-# inspects the CHILD's environment, and the leak is in the PARENT's. This runner
-# therefore inserts one wrapper script that plays the developer's interactive
-# shell -- it snapshots its own process environment, calls the launcher with `&`
-# (a child SCOPE, not a child PROCESS, so every `$env:` assignment the launcher
-# makes stays in the wrapper exactly as it stays in the invoking pwsh), and
-# snapshots again. The two snapshots are the evidence; the child dump is still
-# collected so the same run can also show the values did reach VS Code.
-#
-# `exit` inside a `&`-called script ends that script, not the wrapper, so the
-# after-snapshot is written on the failure paths too -- which is what lets the
-# error cases (8g-8j) be asserted here rather than only through a disposable
-# child process. The launcher's own exit code survives in $LASTEXITCODE and is
-# recorded separately: the wrapper's process exit code is the WRAPPER's.
+# Invoke-Launcher above can never see this suite's target bug: it inspects
+# the CHILD's environment, and the leak is in the PARENT's. This runner
+# inserts a wrapper script playing the interactive shell -- it snapshots its
+# own process environment, calls the launcher with `&` (a child SCOPE not a
+# PROCESS, so every `$env:` assignment stays exactly as in the invoking
+# pwsh), and snapshots again; the child dump still shows values reached VS
+# Code too. `exit` inside a `&`-called script ends that script, not the
+# wrapper, so the after-snapshot is written on failure paths too, letting
+# 8g-8j be asserted here ($LASTEXITCODE records the launcher's own exit code separately).
 $script:ParentShellWrapperBody = @'
 param(
     [string]$LauncherPath,

--- a/tests/feature-18-serverctl/code-ccgw-windows/setup.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/setup.ps1
@@ -1,0 +1,166 @@
+#!/usr/bin/env pwsh
+# Tests: scripts/code-ccgw.ps1
+# Tags: lifecycle, client-launcher, windows, scope:issue-specific
+# lang-check: ignore (non-ASCII path fixtures are the test subject)
+#
+# Part of the code-ccgw-windows.Tests.ps1 suite. Dot-sourced LAST from its
+# top-level BeforeAll, after the three helpers-*.ps1 files: this is the one part
+# that actually builds things, so every function it calls is already defined.
+# It runs as top-level code (not as a function) on purpose -- the $script:
+# variables it sets are what every Context reads.
+
+# The repo root is found by walking up until the launcher is there, rather than
+# by counting '..' segments: this file's depth below the suite is a layout
+# detail, and the split that introduced the sub-folder is exactly the kind of
+# move that silently re-points a hard-coded relative path.
+$script:RepoRoot = $PSScriptRoot
+while ($script:RepoRoot -and -not (Test-Path -LiteralPath (Join-Path (Join-Path $script:RepoRoot 'scripts') 'code-ccgw.ps1'))) {
+    $parent = Split-Path -Parent $script:RepoRoot
+    if ($parent -eq $script:RepoRoot) { break }
+    $script:RepoRoot = $parent
+}
+$script:SourceLauncher = Join-Path (Join-Path $script:RepoRoot 'scripts') 'code-ccgw.ps1'
+if (-not (Test-Path -LiteralPath $script:SourceLauncher)) {
+    throw "scripts/code-ccgw.ps1 not found above $PSScriptRoot (implementation pending)"
+}
+
+$script:Work = Join-Path ([IO.Path]::GetTempPath()) ("ccgw-win-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $script:Work -Force | Out-Null
+
+# The host that runs the launcher under test. Parameterized because the
+# launcher's stated floor is `#Requires -Version 5.1` while only pwsh ever
+# exercised it -- see the suite header. An explicitly requested host that is not
+# installed is a configuration error, not a case to skip: the caller asked for a
+# specific verification and silently not doing it is worse than red.
+$script:LauncherHostOverride = [Environment]::GetEnvironmentVariable('CCGW_TEST_LAUNCHER_HOST')
+$script:PwshPath =
+    if (-not [string]::IsNullOrEmpty($script:LauncherHostOverride)) {
+        $hostCmd = Get-Command $script:LauncherHostOverride -CommandType Application -ErrorAction SilentlyContinue
+        if (-not $hostCmd) { throw "CCGW_TEST_LAUNCHER_HOST='$($script:LauncherHostOverride)' not found on PATH" }
+        @($hostCmd)[0].Source
+    } elseif ($IsWindows) { Join-Path $PSHOME 'pwsh.exe' }
+    else { Join-Path $PSHOME 'pwsh' }
+
+# --- Retired variable names -------------------------------------------------
+# The cases that prove a retired variable no longer configures anything need its
+# exact spelling, but those spellings are banned repo-wide by
+# tests/ccgw-naming/test_no_legacy_names.py, whose scan is a raw substring match
+# over every tracked file -- this one included. The names are therefore assembled
+# at runtime instead of appearing as literals. The cases themselves must stay: a
+# stale .env still carrying them is precisely the situation where a surviving
+# fallback would silently route around the new single path.
+$script:RBaseDs4 = 'DS4_ANTHROPIC' + '_BASE_URL'
+$script:RBaseCcgw = 'CCGW_ANTHROPIC' + '_BASE_URL'
+$script:RKeyDs4 = 'DS4_API' + '_KEY'
+$script:RKeyCcgw = 'CCGW_API' + '_KEY'
+$script:RCaDs4 = 'DS4_CA' + '_CERT'
+$script:RDefaultModel = 'CCGW_DEFAULT' + '_MODEL'
+
+# --- fixture trees ----------------------------------------------------------
+$script:Launcher = New-FixtureTree -Name 'fixture-default'
+
+# Configuration that exists ONLY in the fixture's .env, so a case can prove the
+# launcher found that file from its own location rather than from the caller's
+# working directory (Context 5's cwd case). Defined here, not in a Context,
+# because Pester keeps only the last BeforeAll of a block and nothing may depend
+# on which Context happens to run first.
+$script:DotEnvLauncherForCwd = New-FixtureTree -Name 'fixture-cwd' -DotEnvLines @(
+    'LITELLM_ANTHROPIC_BASE_URL=https://from-dotenv-cwd:9'
+    'LITELLM_CLIENT_KEY=cwd-token'
+)
+
+# A launcher whose whole tree sits under a non-ASCII directory name (Context 12).
+# Every path the launcher composes -- $PSScriptRoot, the .env beside it -- is then
+# non-ASCII, which is what a real install under OneDrive\ドキュメント looks like.
+$script:UnicodeDirName = "fixture-$([char]0x30D7)$([char]0x30ED)$([char]0x30B8)$([char]0x30A7)$([char]0x30AF)$([char]0x30C8)"
+$script:UnicodeLauncher = New-FixtureTree -Name $script:UnicodeDirName -DotEnvLines @(
+    'LITELLM_ANTHROPIC_BASE_URL=https://unicode-lite:1'
+    'LITELLM_CLIENT_KEY=unicode-token'
+)
+
+# --- stub dirs --------------------------------------------------------------
+# Default stub dir: `code` present, no mkcert at all.
+$script:StubDir = New-StubDir -Name 'stub' -NoMkcert
+
+# mkcert whose CAROOT really holds a rootCA.pem.
+$script:CarootOk = Join-Path $script:Work 'caroot-ok'
+New-Item -ItemType Directory -Path $script:CarootOk -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $script:CarootOk 'rootCA.pem') -Value '' -Encoding utf8
+$script:StubMkcertOk = New-StubDir -Name 'stub-mkcert-ok' -MkcertCaroot $script:CarootOk
+
+# mkcert whose CAROOT is empty (no rootCA.pem).
+$script:CarootEmpty = Join-Path $script:Work 'caroot-empty'
+New-Item -ItemType Directory -Path $script:CarootEmpty -Force | Out-Null
+$script:StubMkcertBad = New-StubDir -Name 'stub-mkcert-bad' -MkcertCaroot $script:CarootEmpty
+
+# mkcert that exits non-zero without printing a CAROOT.
+$script:StubMkcertFails = New-StubDir -Name 'stub-mkcert-fails' -MkcertExitCode 3
+
+# No `code` on PATH at all.
+$script:StubNoCode = New-StubDir -Name 'stub-nocode' -NoCode -NoMkcert
+
+# `code` resolving to a real, dumping .exe (Context 10).
+$script:StubExe = New-StubDir -Name 'stub-exe' -NoMkcert -ExeStub
+$script:HaveExeStub = Test-Path -LiteralPath (Join-Path $script:StubExe 'code.exe')
+
+# `code` that resolves but cannot be started (Context 8's process-start failure).
+$script:StubBrokenExe = New-StubDir -Name 'stub-broken-exe' -NoMkcert -BrokenExeStub
+
+# `code.cmd` that dumps argv by position, so an empty argument is visible
+# (Context 12).
+$script:StubPositional = New-StubDir -Name 'stub-positional' -NoMkcert -PositionalCmdStub
+
+# `code.cmd` that stays alive until released, so "the launcher returned" can be
+# distinguished from "the launcher waited for VS Code" (Context 14).
+$script:StubLongLived = New-StubDir -Name 'stub-longlived' -NoMkcert -LongLivedCmdStub
+
+# A stub directory whose own PATH entry carries a space, parentheses and `&` --
+# the shape of "C:\Program Files (x86)\Foo & Bar\code.cmd" (Context 9e). The
+# resolved path of `code` itself is part of the command line the launcher builds,
+# so it needs the same escaping as any argument does; every other stub dir in this
+# suite is shell-safe and would never show a missing quote.
+$script:StubMetacharDir = New-StubDir -Name 'stub (x86) & co' -NoMkcert
+
+# code.cmd -> code.exe forwarding pair (Context 9f): the .cmd hands %* to a real
+# executable, so an embedded quote or a trailing backslash can be compared
+# literally instead of through cmd's own de-quoting. The observer lives outside
+# the stub dir so only the .cmd is discoverable as `code`.
+$script:ObserverDir = Join-Path $script:Work 'observer'
+New-Item -ItemType Directory -Path $script:ObserverDir -Force | Out-Null
+$script:HaveObserverExe = [bool](New-DumpingCodeExe -Dir $script:ObserverDir)
+$script:StubCmdForward = if ($script:HaveObserverExe) {
+    New-StubDir -Name 'stub-cmd-forward' -NoMkcert -ForwardCmdStubTo (Join-Path $script:ObserverDir 'code.exe')
+} else { $null }
+
+$script:LocalAppData = Join-Path $script:Work 'localappdata'
+New-Item -ItemType Directory -Path $script:LocalAppData -Force | Out-Null
+
+$script:Configured = @{
+    LITELLM_ANTHROPIC_BASE_URL = 'https://lite:1'
+    LITELLM_CLIENT_KEY         = 'ck'
+}
+
+# The wrapper that plays the developer's interactive shell; see
+# helpers-runners.ps1 for why it exists and what it proves.
+$script:ParentShellWrapper = Join-Path $script:Work 'parent-shell-wrapper.ps1'
+Set-Content -LiteralPath $script:ParentShellWrapper -Encoding utf8 -Value $script:ParentShellWrapperBody
+
+# The wrapper that keeps the launcher's streams off a pipe so its runtime can be
+# measured; see Measure-LauncherLaunch in helpers-runners.ps1.
+$script:LatencyWrapper = Join-Path $script:Work 'latency-wrapper.ps1'
+Set-Content -LiteralPath $script:LatencyWrapper -Encoding utf8 -Value $script:LatencyWrapperBody
+
+# The four /model tiers Claude Code switches between.
+$script:TierVars = @(
+    'ANTHROPIC_DEFAULT_FABLE_MODEL'
+    'ANTHROPIC_DEFAULT_OPUS_MODEL'
+    'ANTHROPIC_DEFAULT_SONNET_MODEL'
+    'ANTHROPIC_DEFAULT_HAIKU_MODEL'
+)
+# The vars that name the model in play at startup. CLAUDE_CODE_SUBAGENT_MODEL is
+# deliberately NOT here any more: it is now opt-in (section 4d).
+$script:ActiveVars = @(
+    'ANTHROPIC_MODEL'
+    'ANTHROPIC_CUSTOM_MODEL_OPTION'
+)
+$script:ModelVars = $script:TierVars + $script:ActiveVars + @('CLAUDE_CODE_SUBAGENT_MODEL')

--- a/tests/feature-18-serverctl/test-code-ccgw-windows.sh
+++ b/tests/feature-18-serverctl/test-code-ccgw-windows.sh
@@ -3,19 +3,18 @@
 # Tags: lifecycle, client-launcher, windows, scope:issue-specific
 #
 # Scenario: bash driver for the Pester suite that covers the Windows client
-# launcher (code-ccgw-windows.Tests.ps1) — the single-source base URL and its
-# hard failure when absent, the LITELLM_CLIENT_KEY credential with its one-cycle
-# deprecated alias, the retained CCGW_CA_CERT + mkcert derivation, the
-# unconditional LiteLLM routing-key tier map, and the opt-in subagent contract.
+# launcher (code-ccgw-windows.Tests.ps1), including the issue #66 env-isolation
+# and cmd.exe-metacharacter contracts. Runs the suite on pwsh 7 always, and also
+# on Windows PowerShell 5.1 when RUN_TL3 asks for it (CCGW_TEST_LAUNCHER_HOST) --
+# see the .Tests.ps1 header for what each contract covers and why.
 #
-# The assertions live in the .Tests.ps1; this file exists so the suite is
-# reachable from the same `bash tests/.../test-*.sh` convention as its siblings.
-# Skips (exit 0) when pwsh is unavailable — the launcher is Windows-only, and a
-# Mac/Linux developer must not see a red run for a shell they do not have.
+# This file only makes the suite reachable from the `bash tests/.../test-*.sh`
+# convention; skips (exit 0) when pwsh is unavailable (Windows-only launcher).
 #
-# TL3 gap: everything a real Windows host provides — a real VS Code, a real
-#   mkcert CA in the Windows trust store, and the LOCALAPPDATA profile path
-#   actually being writable.
+# TL3 gap: a real Windows host — real VS Code, a real mkcert CA in the Windows
+#   trust store, a writable LOCALAPPDATA profile path.
+# TL3 gap: Windows PowerShell 5.1 as the launcher host (RUN_TL3=on), the only
+#   way to catch .NET Framework-only breakage the default pwsh-7 run cannot.
 set -u
 
 # REPO is derived from $0's logical location (no symlink target resolution - see test-repo-derivation.sh); export REPO=<path> to point at another checkout.
@@ -38,10 +37,57 @@ if ! pwsh -NoProfile -Command 'if (-not (Get-Module -ListAvailable -Name Pester 
     exit 0
 fi
 
+# Under Git Bash $SUITE is a POSIX path (/c/git/...), which pwsh resolves against
+# the current drive as C:\c\git\... — Pester then finds no test file, and because
+# `exit $r.FailedCount` never runs after that throw the driver used to report PASS
+# for a suite it had not executed. Hand pwsh a real Windows path, and make "the run
+# did not happen" an explicit failure rather than a silent zero.
+SUITE_PS="$SUITE"
+command -v cygpath >/dev/null 2>&1 && SUITE_PS="$(cygpath -m -- "$SUITE")"
+
 # -PassThru + explicit exit: Invoke-Pester on its own returns 0 even when cases
 # fail, so the failure count has to be turned into the process exit status here.
-pwsh -NoProfile -Command "\$r = Invoke-Pester '$SUITE' -Output Detailed -PassThru; exit \$r.FailedCount"
+run_suite() {
+    pwsh -NoProfile -Command "\$ErrorActionPreference = 'Stop'; \$r = \$null; try { \$r = Invoke-Pester '$SUITE_PS' -Output Detailed -PassThru } catch { [Console]::Error.WriteLine('Invoke-Pester failed: ' + \$_); exit 99 }; if (\$null -eq \$r -or \$r.TotalCount -eq 0) { [Console]::Error.WriteLine('Invoke-Pester ran no cases'); exit 98 }; exit \$r.FailedCount"
+}
+
+# The first run is the pwsh-7-host run, and it has to be that whatever the
+# caller's environment already contains: CCGW_TEST_LAUNCHER_HOST inherited from
+# the shell would silently retarget it. That is not a cosmetic risk here — the
+# TL3 block below re-runs the SAME suite with the variable set, so an inherited
+# value collapses the two runs into one host, and the pwsh-7 half of the contract
+# would go unasserted while the driver still printed PASS. Subshell, so the unset
+# scopes to this run only (bash leaks a var prefix on a *function* call into the
+# rest of the shell, which is why neither run uses that form).
+( unset CCGW_TEST_LAUNCHER_HOST; run_suite )
 RC=$?
+
+# Second host: Windows PowerShell 5.1 as the launcher's host. The launcher
+# supports it (#Requires -Version 5.1) but only pwsh 7 ever ran it, and the #66
+# work lands on APIs whose 5.1 behavior differs — so the same suite is re-run with
+# only the host of the process under test swapped. Opt-in because it doubles an
+# already slow suite and only a Windows host can satisfy it: a missing
+# powershell.exe or an unset RUN_TL3 reports a skip and leaves RC alone, so the
+# default run still decides the overall result.
+if [ "${RUN_TL3:-}" != "on" ]; then
+    echo "SKIP: RUN_TL3 is not 'on' - the Windows PowerShell 5.1 launcher-host run was not executed."
+    echo "      Run it with: RUN_TL3=on bash $0"
+elif ! command -v powershell.exe >/dev/null 2>&1; then
+    echo "SKIP: powershell.exe not on PATH - the Windows PowerShell 5.1 launcher-host run was not executed."
+    echo "      It exists only on Windows; the run above already covered the assertions under pwsh 7."
+else
+    echo "--- launcher on Windows PowerShell 5.1 (RUN_TL3=on) ---"
+    # An explicitly requested host that is missing makes the suite throw rather
+    # than skip, which is why the availability gate has to be here, not in Pester.
+    # Subshell: a var prefix on a *function* call leaks into the rest of the shell
+    # in bash, and this override must not outlive the run it configures.
+    ( export CCGW_TEST_LAUNCHER_HOST=powershell.exe; run_suite )
+    RC51=$?
+    if [ "$RC51" -ne 0 ]; then
+        echo "FAIL: the suite failed with the launcher on Windows PowerShell 5.1 ($RC51 case(s))." >&2
+        [ "$RC" -eq 0 ] && RC="$RC51"
+    fi
+fi
 
 [ "$RC" -eq 0 ] && echo "PASS: test-code-ccgw-windows"
 exit "$RC"


### PR DESCRIPTION
code-ccgw.ps1 used $env: to set routing/connection values, mutating the invoking
PowerShell process itself; Windows has no exec, so those values outlived the
launch and leaked into unrelated sessions run later in the same shell. The
launcher now overlays a $ChildEnv block onto the spawned VS Code process's
ProcessStartInfo.Environment only, and strips the full credential/config class
(CLAUDE_CODE_OAUTH_TOKEN, Bedrock/Vertex + AWS/GCP credentials,
NODE_TLS_REJECT_UNAUTHORIZED) from the child rather than just ANTHROPIC_API_KEY.
code-ccgw.sh receives the same treatment for parity. Conditionally-set derived
variables (model tiers, ANTHROPIC_MODEL, CLAUDE_CODE_SUBAGENT_MODEL) now clear
explicitly in the child when their .env source is absent.

Closes #66
