### PR TITLE
fix(dotenv): make DOTENV_FORCE_KEYS optional so `set -eu` callers don't crash

### DIFF
--- a/llama-swap/config.yaml
+++ b/llama-swap/config.yaml
@@ -78,7 +78,7 @@ models:
     # above (hybrid Gated DeltaNet/Gated Attention, 80B/3B, 84.7GB in 8bit),
     # but the Thinking variant instead of Coder -- an A/B alternative for the
     # opus tier when Coder-Next's lack of a thinking mode is the bottleneck.
-    # Switch between the two with `scripts/set-model opus <key>` -- both are
+    # Switch between the two with `scripts/set-model.sh opus <key>` -- both are
     # mlx_lm.server/openai-shape, so it's a same-shape swap needing no manual
     # litellm-server/config.yaml edit.
     cmd: >-

--- a/scripts/lib/load-dotenv.sh
+++ b/scripts/lib/load-dotenv.sh
@@ -51,7 +51,7 @@ _dotenv_filter_os_blocks() {
 # stale shell value -- e.g. the ccgw model-routing keys. Loaders that never set
 # it keep the default "shell value wins" behavior unchanged.
 _dotenv_force_key() {
-    case " $DOTENV_FORCE_KEYS " in
+    case " ${DOTENV_FORCE_KEYS:-} " in
         *" $1 "*) return 0 ;;
         *) return 1 ;;
     esac

--- a/scripts/set-model.sh
+++ b/scripts/set-model.sh
@@ -1,24 +1,20 @@
 #!/bin/sh
 # set-model — change which physical backend a Claude Code tier routes to.
 #
-# Two things have to move together, or Claude Code's own /model display goes
-# stale: LITELLM_<TIER>_MODEL in .env (what Claude Code sends as the request's
-# `model` field, via ANTHROPIC_DEFAULT_<TIER>_MODEL -- see scripts/code-ccgw.sh)
-# and litellm_params.model in litellm-server/config.yaml (the actual backend
-# that tier's model_list block calls). This script writes both, keyed off the
-# same bare model-key, then restarts litellm-server so it re-resolves
-# os.environ/LITELLM_<TIER>_MODEL from the new .env value.
+# .env's LITELLM_<TIER>_MODEL and litellm-server/config.yaml's
+# litellm_params.model must move together or /model goes stale, so this script
+# writes both off one bare model-key and restarts litellm-server.
 #
-# fable/opus route to Mac llama-swap (llama-swap/config.yaml `models:` keys,
-# enumerable from this repo). haiku/sonnet route to the Windows llama-swap
-# instance, whose config.yaml is not in this repo (docs/infrastructure.md) --
-# their choices, and the provider shape of a given key, can't be verified
-# here, only the currently-configured backend can be shown.
+# Only fable/opus keys are enumerable here (llama-swap/config.yaml); haiku and
+# sonnet live on the Windows instance -- see docs/infrastructure.md.
 set -eu
 
 CCGW_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 # shellcheck source=scripts/lib/root.sh
 . "$CCGW_SCRIPT_DIR/lib/root.sh"
+# This script reads and writes the model-routing keys, so .env must win over a
+# stale shell value. Same list as scripts/code-ccgw.sh.
+DOTENV_FORCE_KEYS="LITELLM_HAIKU_MODEL LITELLM_SONNET_MODEL LITELLM_FABLE_MODEL LITELLM_OPUS_MODEL CCGW_SUBAGENT_MODEL"
 # shellcheck source=scripts/lib/load-dotenv.sh
 . "$CCGW_SCRIPT_DIR/lib/load-dotenv.sh"
 # shellcheck source=scripts/lib/paths.sh
@@ -42,9 +38,9 @@ _display_path() {
 
 _usage() {
     cat <<EOF
-Usage: set-model <tier> <model-key>
-       set-model --list [tier]
-       set-model -h|--help
+Usage: set-model.sh <tier> <model-key>
+       set-model.sh --list [tier]
+       set-model.sh -h|--help
 
 Tiers: haiku, sonnet, fable, opus
 

--- a/tests/feature-18-serverctl/test-atomic-write.sh
+++ b/tests/feature-18-serverctl/test-atomic-write.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tests: scripts/lib/atomic-write.sh, scripts/set-model
+# Tests: scripts/lib/atomic-write.sh, scripts/set-model.sh
 # Tags: scope:issue-specific, layer:TL1
 # Scenario (issue #62): set-model's old atomic write did
 # mktemp "$TARGET.XXXXXX" + mv tmp "$TARGET", replacing a symlinked TARGET's
@@ -134,8 +134,8 @@ _ccgw_commit_write "$tmp" "$WORK/c10/does-not-exist.txt" || fail "case 10: commi
 [ "$(cat "$WORK/c10/does-not-exist.txt")" = fresh ] || fail "case 10: new file content missing after commit"
 no_leftover_tmp "$WORK/c10" "case 10"
 
-# --- Case 11: static regression guard on scripts/set-model ------------------
-SET_MODEL="$REPO/scripts/set-model"
+# --- Case 11: static regression guard on scripts/set-model.sh ---------------
+SET_MODEL="$REPO/scripts/set-model.sh"
 [ -f "$SET_MODEL" ] || fail "case 11: $SET_MODEL not found"
 grep -q 'lib/atomic-write\.sh' "$SET_MODEL" || fail "case 11: set-model no longer sources lib/atomic-write.sh"
 if grep -E 'mktemp[[:space:]]+"\$(DOTENV_FILE|LITELLM_CONFIG)\.XXXXXX"' "$SET_MODEL" >/dev/null; then

--- a/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
+++ b/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
@@ -1,33 +1,13 @@
 #!/usr/bin/env bash
-# Tests: scripts/set-model.sh, scripts/lib/load-dotenv.sh
-# Tags: scope:issue-specific, layer:TL2, set-model, dotenv, load-dotenv, regression
-# Scenario (issue #68): load-dotenv.sh's _dotenv_force_key() dereferences
-# $DOTENV_FORCE_KEYS unconditionally, so every scripts/ entrypoint sourcing the
-# loader under `set -eu` aborted with "DOTENV_FORCE_KEYS: unbound variable" on
-# the first KEY=VALUE line of .env -- DOTENV_FORCE_KEYS being a NON-exported
-# opt-in most callers never set. Reported symptom: `./scripts/set-model --list`,
-# a read-only command, crashing before it printed anything.
+# Tests: scripts/lib/load-dotenv.sh, scripts/set-model.sh
+# Tags: scope:issue-specific, layer:TL2, dotenv, load-dotenv, set-model, regression
+# Scenario (issue #68): _dotenv_force_key() dereferenced $DOTENV_FORCE_KEYS
+# unconditionally, so `set -eu` callers crashed on an unset opt-in list.
 set -u
-
-# --list is the cheapest entry point that reaches the crash site: loader plus
-# two config.yaml reads for display -- no backend, no daemon, no writes. The
-# daemon launchers (litellm.sh, llama-swap.sh, ds4-server.sh, ccgw-proxy.sh)
-# share the crash but are deliberately not executed here. Run as `sh "$SCRIPT"`
-# to match the #!/bin/sh shebang, so the fatal `set -eu` is the real one.
-
-# TL3 gap: whether litellm-server actually restarts and re-resolves the new
-#   os.environ/LITELLM_<TIER>_MODEL after a real `set-model <tier> <key>` write.
-#   Only a real host answers that; --list is read-only by design and this file
-#   stays side-effect-free. Covered by docs/ops.md at user_verification.
 
 # REPO is derived from $0's logical location (no symlink target resolution - see test-repo-derivation.sh); export REPO=<path> to point at another checkout.
 REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
 SCRIPT="$REPO/scripts/set-model.sh"
-LOADER="$REPO/scripts/lib/load-dotenv.sh"
-
-# Skips until the scripts/set-model -> scripts/set-model.sh rename lands.
-[ -f "$SCRIPT" ] || { echo "SKIP: $SCRIPT not found (implementation pending)"; exit 77; }
-[ -f "$LOADER" ] || { echo "SKIP: $LOADER not found (implementation pending)"; exit 77; }
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
@@ -36,129 +16,41 @@ trap 'rm -rf "$WORK"' EXIT
 export HOME="$WORK/home"
 mkdir -p "$HOME"
 
-# Pin DOTENV_FILE into this test's tmpdir so the real repo .env is never read
-# (its secrets must not enter this process, and its key set must not decide the
-# verdict). At least one KEY=VALUE line is required: the crash site lives in the
-# loader's per-line loop, so an empty fixture makes every case vacuous -- case 0
-# asserts that line is genuinely consumed.
+# Pinned so the real .env is never read; needs one KEY=VALUE line because the
+# crash site is inside the loader's per-line loop.
 export DOTENV_FILE="$WORK/dotenv"
-cat > "$DOTENV_FILE" <<'EOF'
-CCGW_DOTENV_PROBE=probe-value
-LITELLM_HAIKU_MODEL=fixture-haiku
-LITELLM_SONNET_MODEL=fixture-sonnet
-LITELLM_FABLE_MODEL=fixture-fable
-LITELLM_OPUS_MODEL=fixture-opus
-EOF
+printf 'LITELLM_OPUS_MODEL=fixture-opus\n' > "$DOTENV_FILE"
 
-# Fixture ops root: paths.sh derives LLAMA_SWAP_ROOT/LITELLM_ROOT from
-# CCGW_OPS_ROOT, so seeding one tmpdir pins both configs --list reads.
-FIXTURE_ROOT="$WORK/ops"
-mkdir -p "$FIXTURE_ROOT/llama-swap" "$FIXTURE_ROOT/litellm-server"
-cat > "$FIXTURE_ROOT/litellm-server/config.yaml" <<'EOF'
-model_list:
-  - model_name: os.environ/LITELLM_HAIKU_MODEL
-    litellm_params:
-      model: openai/fixture-haiku-backend
-  - model_name: os.environ/LITELLM_SONNET_MODEL
-    litellm_params:
-      model: openai/fixture-sonnet-backend
-  - model_name: os.environ/LITELLM_FABLE_MODEL
-    litellm_params:
-      model: anthropic/fixture-fable-backend
-  - model_name: os.environ/LITELLM_OPUS_MODEL
-    litellm_params:
-      model: openai/fixture-opus-backend
-EOF
-cat > "$FIXTURE_ROOT/llama-swap/config.yaml" <<'EOF'
-healthCheckTimeout: 600
-models:
-  fixture-model-a:
-    cmd: mlx_lm.server --host 127.0.0.1
-    proxy: http://127.0.0.1:8080
-  fixture-model-b:
-    cmd: ds4-server --host 127.0.0.1
-    proxy: http://127.0.0.1:8081
-EOF
-
-assert_no_unbound() { # assert_no_unbound <label> <status> <stderr-file>
-    if grep -q 'unbound variable' "$3"; then
-        fail "$1: crashed on an unbound variable (issue #68 regression):
-$(cat "$3")"
-    fi
-    [ "$2" -eq 0 ] || fail "$1: exited $2 (expected 0). stderr:
-$(cat "$3")"
+run_loader() { # run_loader <env-args...>
+    env "$@" HOME="$HOME" DOTENV_FILE="$DOTENV_FILE" CCGW_SCRIPT_DIR="$REPO/scripts" \
+        sh -c 'set -eu
+               . "$CCGW_SCRIPT_DIR/lib/root.sh"
+               . "$CCGW_SCRIPT_DIR/lib/load-dotenv.sh"
+               printenv LITELLM_OPUS_MODEL' 2>"$WORK/err"
 }
 
-# --- Case 0: the fixture .env line really reaches the loader's loop ---------
-# False-green guard for every case below: proves the per-line loop (where
-# _dotenv_force_key is called) executes with DOTENV_FORCE_KEYS unset under
-# `set -eu`, rather than being skipped over an empty fixture.
-PROBE="$(env -u DOTENV_FORCE_KEYS HOME="$HOME" DOTENV_FILE="$DOTENV_FILE" \
-    CCGW_SCRIPT_DIR="$REPO/scripts" \
-    sh -c 'set -eu
-           . "$CCGW_SCRIPT_DIR/lib/root.sh"
-           . "$CCGW_SCRIPT_DIR/lib/load-dotenv.sh"
-           printenv CCGW_DOTENV_PROBE' 2>"$WORK/probe.err")" || PROBE=""
-assert_no_unbound "case 0 (loader sourced, DOTENV_FORCE_KEYS unset)" 0 "$WORK/probe.err"
-[ "$PROBE" = "probe-value" ] || fail "case 0: loader did not export CCGW_DOTENV_PROBE from the fixture .env (got '$PROBE') -- the crash site is never reached, so every case below would be vacuous"
+# --- Case 1: DOTENV_FORCE_KEYS unset (the reported crash) -------------------
+OUT="$(run_loader -u DOTENV_FORCE_KEYS)" || OUT=""
+grep -q 'unbound variable' "$WORK/err" && fail "case 1: unbound variable regression:
+$(cat "$WORK/err")"
+[ "$OUT" = "fixture-opus" ] || fail "case 1: .env value not exported (got '$OUT')"
 
-# --- Case 1: `set-model.sh --list` with DOTENV_FORCE_KEYS unset -------------
-# The exact originally-reported crash, post-rename. `env -u` pins the branch
-# explicitly so an ambient DOTENV_FORCE_KEYS cannot mask the regression.
-OUT="$(env -u DOTENV_FORCE_KEYS CCGW_OPS_ROOT="$FIXTURE_ROOT" \
-    sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
-assert_no_unbound "case 1 (--list, DOTENV_FORCE_KEYS unset)" "$STATUS" "$WORK/err"
-for TIER in haiku sonnet fable opus; do
-    echo "$OUT" | grep -q "^$TIER " || fail "case 1: --list printed no '$TIER' line:
-$OUT"
-done
-# Assert the fixture's own values, so the case fails if --list silently stops
-# reading the configs instead of merely not crashing.
-echo "$OUT" | grep -q 'fixture-opus-backend' || fail "case 1: --list did not report the fixture opus backend:
-$OUT"
-echo "$OUT" | grep -q 'fixture-model-a' || fail "case 1: --list did not enumerate the fixture llama-swap model keys:
-$OUT"
+# --- Case 2: DOTENV_FORCE_KEYS set (feature still works) --------------------
+# A stale shell value must lose to .env for a forced key, so case 1 cannot be
+# satisfied by deleting the force-key feature.
+OUT="$(run_loader LITELLM_OPUS_MODEL=stale DOTENV_FORCE_KEYS=LITELLM_OPUS_MODEL)" || OUT=""
+[ "$OUT" = "fixture-opus" ] || fail "case 2: forced key did not beat the stale shell value (got '$OUT')"
 
-# --- Case 2: same command with DOTENV_FORCE_KEYS SET ------------------------
-# Symmetric branch (CPR-ORTH): the opt-in _dotenv_force_key exists for must keep
-# working, so case 1 cannot be satisfied by deleting the feature.
-OUT="$(env CCGW_OPS_ROOT="$FIXTURE_ROOT" DOTENV_FORCE_KEYS='LITELLM_OPUS_MODEL LITELLM_FABLE_MODEL' \
-    sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
-assert_no_unbound "case 2 (--list, DOTENV_FORCE_KEYS set)" "$STATUS" "$WORK/err"
-echo "$OUT" | grep -q 'fixture-opus-backend' || fail "case 2: --list did not report the fixture opus backend:
-$OUT"
+# --- Case 3: set but empty --------------------------------------------------
+# What a caller building the list conditionally leaves behind: no forced keys,
+# so the stale shell value wins.
+OUT="$(run_loader LITELLM_OPUS_MODEL=stale DOTENV_FORCE_KEYS=)" || OUT=""
+grep -q 'unbound variable' "$WORK/err" && fail "case 3: unbound variable on empty list"
+[ "$OUT" = "stale" ] || fail "case 3: empty list forced anyway (got '$OUT')"
 
-# --- Case 3: DOTENV_FORCE_KEYS set but empty --------------------------------
-# Edge case between the two branches above -- what a caller that builds the list
-# conditionally leaves behind. Must read as "no forced keys": no crash, and no
-# forcing of everything.
-OUT="$(env CCGW_OPS_ROOT="$FIXTURE_ROOT" DOTENV_FORCE_KEYS='' \
-    sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
-assert_no_unbound "case 3 (--list, DOTENV_FORCE_KEYS empty)" "$STATUS" "$WORK/err"
-echo "$OUT" | grep -q 'fixture-opus-backend' || fail "case 3: --list did not report the fixture opus backend:
-$OUT"
-
-# --- Case 4: single-tier `--list <tier>` ------------------------------------
-# The other --list arm; also a negative control on case 1's per-tier assertion,
-# which would pass against an implementation that always prints all four.
-OUT="$(env -u DOTENV_FORCE_KEYS CCGW_OPS_ROOT="$FIXTURE_ROOT" \
-    sh "$SCRIPT" --list opus 2>"$WORK/err")" && STATUS=0 || STATUS=$?
-assert_no_unbound "case 4 (--list opus)" "$STATUS" "$WORK/err"
-echo "$OUT" | grep -q '^opus ' || fail "case 4: --list opus printed no 'opus' line:
-$OUT"
-echo "$OUT" | grep -q '^haiku ' && fail "case 4: --list opus also printed a 'haiku' line (the single-tier form must show one tier):
-$OUT"
-
-# --- Case 5: the real repo configs, as the issue reporter ran it ------------
-# Read-only: CCGW_OPS_ROOT is left to paths.sh's own derivation so --list parses
-# the shipped configs, while DOTENV_FILE stays pinned to the fixture (the real
-# .env, and its secrets, are never read). Catches a crash only the real config
-# content would trigger.
-OUT="$(env -u DOTENV_FORCE_KEYS sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
-assert_no_unbound "case 5 (--list against the shipped configs)" "$STATUS" "$WORK/err"
-for TIER in haiku sonnet fable opus; do
-    echo "$OUT" | grep -q "^$TIER " || fail "case 5: --list printed no '$TIER' line:
-$OUT"
-done
+# --- Case 4: set-model.sh carries its own force-list ------------------------
+[ -f "$SCRIPT" ] || fail "case 4: $SCRIPT not found"
+grep -q '^DOTENV_FORCE_KEYS=.*LITELLM_OPUS_MODEL' "$SCRIPT" \
+    || fail "case 4: set-model.sh no longer sets a non-empty DOTENV_FORCE_KEYS"
 
 echo "PASS: test-set-model-dotenv-force-keys"

--- a/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
+++ b/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Tests: scripts/set-model.sh, scripts/lib/load-dotenv.sh
+# Tags: scope:issue-specific, layer:TL2, set-model, dotenv, load-dotenv, regression
+# Scenario (issue #68): load-dotenv.sh's _dotenv_force_key() dereferences
+# $DOTENV_FORCE_KEYS unconditionally, so every scripts/ entrypoint sourcing the
+# loader under `set -eu` aborted with "DOTENV_FORCE_KEYS: unbound variable" on
+# the first KEY=VALUE line of .env -- DOTENV_FORCE_KEYS being a NON-exported
+# opt-in most callers never set. Reported symptom: `./scripts/set-model --list`,
+# a read-only command, crashing before it printed anything.
+set -u
+
+# --list is the cheapest entry point that reaches the crash site: loader plus
+# two config.yaml reads for display -- no backend, no daemon, no writes. The
+# daemon launchers (litellm.sh, llama-swap.sh, ds4-server.sh, ccgw-proxy.sh)
+# share the crash but are deliberately not executed here. Run as `sh "$SCRIPT"`
+# to match the #!/bin/sh shebang, so the fatal `set -eu` is the real one.
+
+# TL3 gap: whether litellm-server actually restarts and re-resolves the new
+#   os.environ/LITELLM_<TIER>_MODEL after a real `set-model <tier> <key>` write.
+#   Only a real host answers that; --list is read-only by design and this file
+#   stays side-effect-free. Covered by docs/ops.md at user_verification.
+
+# REPO is derived from $0's logical location (no symlink target resolution - see test-repo-derivation.sh); export REPO=<path> to point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+SCRIPT="$REPO/scripts/set-model.sh"
+LOADER="$REPO/scripts/lib/load-dotenv.sh"
+
+# Skips until the scripts/set-model -> scripts/set-model.sh rename lands.
+[ -f "$SCRIPT" ] || { echo "SKIP: $SCRIPT not found (implementation pending)"; exit 77; }
+[ -f "$LOADER" ] || { echo "SKIP: $LOADER not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export HOME="$WORK/home"
+mkdir -p "$HOME"
+
+# Pin DOTENV_FILE into this test's tmpdir so the real repo .env is never read
+# (its secrets must not enter this process, and its key set must not decide the
+# verdict). At least one KEY=VALUE line is required: the crash site lives in the
+# loader's per-line loop, so an empty fixture makes every case vacuous -- case 0
+# asserts that line is genuinely consumed.
+export DOTENV_FILE="$WORK/dotenv"
+cat > "$DOTENV_FILE" <<'EOF'
+CCGW_DOTENV_PROBE=probe-value
+LITELLM_HAIKU_MODEL=fixture-haiku
+LITELLM_SONNET_MODEL=fixture-sonnet
+LITELLM_FABLE_MODEL=fixture-fable
+LITELLM_OPUS_MODEL=fixture-opus
+EOF
+
+# Fixture ops root: paths.sh derives LLAMA_SWAP_ROOT/LITELLM_ROOT from
+# CCGW_OPS_ROOT, so seeding one tmpdir pins both configs --list reads.
+FIXTURE_ROOT="$WORK/ops"
+mkdir -p "$FIXTURE_ROOT/llama-swap" "$FIXTURE_ROOT/litellm-server"
+cat > "$FIXTURE_ROOT/litellm-server/config.yaml" <<'EOF'
+model_list:
+  - model_name: os.environ/LITELLM_HAIKU_MODEL
+    litellm_params:
+      model: openai/fixture-haiku-backend
+  - model_name: os.environ/LITELLM_SONNET_MODEL
+    litellm_params:
+      model: openai/fixture-sonnet-backend
+  - model_name: os.environ/LITELLM_FABLE_MODEL
+    litellm_params:
+      model: anthropic/fixture-fable-backend
+  - model_name: os.environ/LITELLM_OPUS_MODEL
+    litellm_params:
+      model: openai/fixture-opus-backend
+EOF
+cat > "$FIXTURE_ROOT/llama-swap/config.yaml" <<'EOF'
+healthCheckTimeout: 600
+models:
+  fixture-model-a:
+    cmd: mlx_lm.server --host 127.0.0.1
+    proxy: http://127.0.0.1:8080
+  fixture-model-b:
+    cmd: ds4-server --host 127.0.0.1
+    proxy: http://127.0.0.1:8081
+EOF
+
+assert_no_unbound() { # assert_no_unbound <label> <status> <stderr-file>
+    if grep -q 'unbound variable' "$3"; then
+        fail "$1: crashed on an unbound variable (issue #68 regression):
+$(cat "$3")"
+    fi
+    [ "$2" -eq 0 ] || fail "$1: exited $2 (expected 0). stderr:
+$(cat "$3")"
+}
+
+# --- Case 0: the fixture .env line really reaches the loader's loop ---------
+# False-green guard for every case below: proves the per-line loop (where
+# _dotenv_force_key is called) executes with DOTENV_FORCE_KEYS unset under
+# `set -eu`, rather than being skipped over an empty fixture.
+PROBE="$(env -u DOTENV_FORCE_KEYS HOME="$HOME" DOTENV_FILE="$DOTENV_FILE" \
+    CCGW_SCRIPT_DIR="$REPO/scripts" \
+    sh -c 'set -eu
+           . "$CCGW_SCRIPT_DIR/lib/root.sh"
+           . "$CCGW_SCRIPT_DIR/lib/load-dotenv.sh"
+           printenv CCGW_DOTENV_PROBE' 2>"$WORK/probe.err")" || PROBE=""
+assert_no_unbound "case 0 (loader sourced, DOTENV_FORCE_KEYS unset)" 0 "$WORK/probe.err"
+[ "$PROBE" = "probe-value" ] || fail "case 0: loader did not export CCGW_DOTENV_PROBE from the fixture .env (got '$PROBE') -- the crash site is never reached, so every case below would be vacuous"
+
+# --- Case 1: `set-model.sh --list` with DOTENV_FORCE_KEYS unset -------------
+# The exact originally-reported crash, post-rename. `env -u` pins the branch
+# explicitly so an ambient DOTENV_FORCE_KEYS cannot mask the regression.
+OUT="$(env -u DOTENV_FORCE_KEYS CCGW_OPS_ROOT="$FIXTURE_ROOT" \
+    sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
+assert_no_unbound "case 1 (--list, DOTENV_FORCE_KEYS unset)" "$STATUS" "$WORK/err"
+for TIER in haiku sonnet fable opus; do
+    echo "$OUT" | grep -q "^$TIER " || fail "case 1: --list printed no '$TIER' line:
+$OUT"
+done
+# Assert the fixture's own values, so the case fails if --list silently stops
+# reading the configs instead of merely not crashing.
+echo "$OUT" | grep -q 'fixture-opus-backend' || fail "case 1: --list did not report the fixture opus backend:
+$OUT"
+echo "$OUT" | grep -q 'fixture-model-a' || fail "case 1: --list did not enumerate the fixture llama-swap model keys:
+$OUT"
+
+# --- Case 2: same command with DOTENV_FORCE_KEYS SET ------------------------
+# Symmetric branch (CPR-ORTH): the opt-in _dotenv_force_key exists for must keep
+# working, so case 1 cannot be satisfied by deleting the feature.
+OUT="$(env CCGW_OPS_ROOT="$FIXTURE_ROOT" DOTENV_FORCE_KEYS='LITELLM_OPUS_MODEL LITELLM_FABLE_MODEL' \
+    sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
+assert_no_unbound "case 2 (--list, DOTENV_FORCE_KEYS set)" "$STATUS" "$WORK/err"
+echo "$OUT" | grep -q 'fixture-opus-backend' || fail "case 2: --list did not report the fixture opus backend:
+$OUT"
+
+# --- Case 3: DOTENV_FORCE_KEYS set but empty --------------------------------
+# Edge case between the two branches above -- what a caller that builds the list
+# conditionally leaves behind. Must read as "no forced keys": no crash, and no
+# forcing of everything.
+OUT="$(env CCGW_OPS_ROOT="$FIXTURE_ROOT" DOTENV_FORCE_KEYS='' \
+    sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
+assert_no_unbound "case 3 (--list, DOTENV_FORCE_KEYS empty)" "$STATUS" "$WORK/err"
+echo "$OUT" | grep -q 'fixture-opus-backend' || fail "case 3: --list did not report the fixture opus backend:
+$OUT"
+
+# --- Case 4: single-tier `--list <tier>` ------------------------------------
+# The other --list arm; also a negative control on case 1's per-tier assertion,
+# which would pass against an implementation that always prints all four.
+OUT="$(env -u DOTENV_FORCE_KEYS CCGW_OPS_ROOT="$FIXTURE_ROOT" \
+    sh "$SCRIPT" --list opus 2>"$WORK/err")" && STATUS=0 || STATUS=$?
+assert_no_unbound "case 4 (--list opus)" "$STATUS" "$WORK/err"
+echo "$OUT" | grep -q '^opus ' || fail "case 4: --list opus printed no 'opus' line:
+$OUT"
+echo "$OUT" | grep -q '^haiku ' && fail "case 4: --list opus also printed a 'haiku' line (the single-tier form must show one tier):
+$OUT"
+
+# --- Case 5: the real repo configs, as the issue reporter ran it ------------
+# Read-only: CCGW_OPS_ROOT is left to paths.sh's own derivation so --list parses
+# the shipped configs, while DOTENV_FILE stays pinned to the fixture (the real
+# .env, and its secrets, are never read). Catches a crash only the real config
+# content would trigger.
+OUT="$(env -u DOTENV_FORCE_KEYS sh "$SCRIPT" --list 2>"$WORK/err")" && STATUS=0 || STATUS=$?
+assert_no_unbound "case 5 (--list against the shipped configs)" "$STATUS" "$WORK/err"
+for TIER in haiku sonnet fable opus; do
+    echo "$OUT" | grep -q "^$TIER " || fail "case 5: --list printed no '$TIER' line:
+$OUT"
+done
+
+echo "PASS: test-set-model-dotenv-force-keys"

--- a/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
+++ b/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
@@ -2,7 +2,7 @@
 # Tests: scripts/lib/load-dotenv.sh, scripts/set-model.sh
 # Tags: scope:issue-specific, layer:TL2, dotenv, load-dotenv, set-model, regression
 # Scenario (issue #68): _dotenv_force_key() dereferenced $DOTENV_FORCE_KEYS
-# unconditionally, so `set -eu` callers crashed on an unset opt-in list.
+# unconditionally, crashing `set -eu` callers that left the opt-in list unset.
 set -u
 
 # REPO is derived from $0's logical location (no symlink target resolution - see test-repo-derivation.sh); export REPO=<path> to point at another checkout.
@@ -16,8 +16,7 @@ trap 'rm -rf "$WORK"' EXIT
 export HOME="$WORK/home"
 mkdir -p "$HOME"
 
-# Pinned so the real .env is never read; needs one KEY=VALUE line because the
-# crash site is inside the loader's per-line loop.
+# One KEY=VALUE line is required: the crash site is the loader's per-line loop.
 export DOTENV_FILE="$WORK/dotenv"
 printf 'LITELLM_OPUS_MODEL=fixture-opus\n' > "$DOTENV_FILE"
 
@@ -35,15 +34,11 @@ grep -q 'unbound variable' "$WORK/err" && fail "case 1: unbound variable regress
 $(cat "$WORK/err")"
 [ "$OUT" = "fixture-opus" ] || fail "case 1: .env value not exported (got '$OUT')"
 
-# --- Case 2: DOTENV_FORCE_KEYS set (feature still works) --------------------
-# A stale shell value must lose to .env for a forced key, so case 1 cannot be
-# satisfied by deleting the force-key feature.
+# --- Case 2: set -- keeps case 1 from being satisfied by deleting the feature
 OUT="$(run_loader LITELLM_OPUS_MODEL=stale DOTENV_FORCE_KEYS=LITELLM_OPUS_MODEL)" || OUT=""
 [ "$OUT" = "fixture-opus" ] || fail "case 2: forced key did not beat the stale shell value (got '$OUT')"
 
-# --- Case 3: set but empty --------------------------------------------------
-# What a caller building the list conditionally leaves behind: no forced keys,
-# so the stale shell value wins.
+# --- Case 3: set but empty -- what a conditionally-built list leaves behind --
 OUT="$(run_loader LITELLM_OPUS_MODEL=stale DOTENV_FORCE_KEYS=)" || OUT=""
 grep -q 'unbound variable' "$WORK/err" && fail "case 3: unbound variable on empty list"
 [ "$OUT" = "stale" ] || fail "case 3: empty list forced anyway (got '$OUT')"


### PR DESCRIPTION
## Summary

`_dotenv_force_key()` in `scripts/lib/load-dotenv.sh` dereferenced
`$DOTENV_FORCE_KEYS` unconditionally, so any caller sourcing the loader under
`set -eu` aborted with `DOTENV_FORCE_KEYS: unbound variable` on the first
`KEY=VALUE` line of `.env`. This makes the list optional, as its own contract
already documented it to be.

## Background

The function's comment states the caller **may** set the list and that
"loaders that never set it keep the default behavior unchanged" -- unset is the
documented normal case, so the unconditional dereference contradicted the
file's own contract.

Reported symptom: `./scripts/set-model --list`, a read-only command, crashing
before printing anything.

## Changes

Loader, one line:

```diff
-    case " $DOTENV_FORCE_KEYS " in
+    case " ${DOTENV_FORCE_KEYS:-} " in
```

Fixing the class root repairs all six current callers and every future one
(CPR-E2C / CPR-UNV). Setting `DOTENV_FORCE_KEYS=` in each caller instead would
suppress the symptom per member and leave caller seven broken.

Alongside it:

- `scripts/set-model` -> `scripts/set-model.sh`, for consistency with every
  other script in `scripts/`. Path references updated.
- `set-model.sh` gains the same non-empty force-list as `scripts/code-ccgw.sh`,
  because it reads and writes the model-routing keys and must not be overridden
  by a stale shell value. Semantics, not crash mitigation.
- Its file header comment was compressed to satisfy the comment-block size rule.

## Tests

`tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh` (TL2) asserts
the loader contract directly:

1. `DOTENV_FORCE_KEYS` unset -- the reported crash; the `.env` value is exported.
2. Set -- a forced key still beats a stale shell value, so case 1 cannot be
   satisfied by deleting the force-key feature.
3. Set but empty -- no forced keys; the stale shell value wins.
4. Static guard that `set-model.sh` still carries a non-empty force-list.

An earlier draft drove these through `set-model.sh --list` against two fixture
`config.yaml` trees; that was fixture and commentary rather than coverage,
since the crash site is in the loader. Cut in 080a78d.

All six affected tests under `tests/feature-18-serverctl/` were run and are
green: this one plus the atomic-write, os-blocks, and the three existing
backend-target/guard tests.

Closes #68

<!-- issue-close-pr-of: 68 -->