### PR TITLE
test(dotenv): guard the force-list against drift between its two declarations

### DIFF
--- a/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
+++ b/tests/feature-18-serverctl/test-set-model-dotenv-force-keys.sh
@@ -43,9 +43,21 @@ OUT="$(run_loader LITELLM_OPUS_MODEL=stale DOTENV_FORCE_KEYS=)" || OUT=""
 grep -q 'unbound variable' "$WORK/err" && fail "case 3: unbound variable on empty list"
 [ "$OUT" = "stale" ] || fail "case 3: empty list forced anyway (got '$OUT')"
 
-# --- Case 4: set-model.sh carries its own force-list ------------------------
-[ -f "$SCRIPT" ] || fail "case 4: $SCRIPT not found"
-grep -q '^DOTENV_FORCE_KEYS=.*LITELLM_OPUS_MODEL' "$SCRIPT" \
-    || fail "case 4: set-model.sh no longer sets a non-empty DOTENV_FORCE_KEYS"
+# --- Case 4: set-model.sh's force-list matches code-ccgw.sh's ---------------
+# The two are the same list of routing keys, declared twice; nothing but this
+# case stops them drifting when a fifth key is added to one of them. Cases 1-3
+# prove the loader honors whatever list it is handed, so a complete, matching
+# list here is what makes set-model.sh's own behavior guaranteed -- there is no
+# read-only way to observe the resolved value through the script itself.
+force_list_of() { sed -n 's/^DOTENV_FORCE_KEYS="\(.*\)"$/\1/p' "$1"; }
+CCGW="$REPO/scripts/code-ccgw.sh"
+for f in "$SCRIPT" "$CCGW"; do [ -f "$f" ] || fail "case 4: $f not found"; done
+SET_MODEL_LIST="$(force_list_of "$SCRIPT")"
+CCGW_LIST="$(force_list_of "$CCGW")"
+[ -n "$CCGW_LIST" ] || fail "case 4: code-ccgw.sh no longer declares a DOTENV_FORCE_KEYS list"
+[ "$SET_MODEL_LIST" = "$CCGW_LIST" ] \
+    || fail "case 4: force-list drift between the two declarations:
+  set-model.sh: $SET_MODEL_LIST
+  code-ccgw.sh: $CCGW_LIST"
 
 echo "PASS: test-set-model-dotenv-force-keys"


### PR DESCRIPTION
## Summary

Follow-up to PR #69. Case 4 of the #68 regression test grepped for a single
key, so dropping any of the other four still passed. It now compares
`set-model.sh`'s force-list against `code-ccgw.sh`'s, closing both that hole
and the drift between the two declarations.

## Background

The same list of model-routing keys is declared twice -- `scripts/code-ccgw.sh`
and `scripts/set-model.sh` -- with only a `# Same list as ...` comment tying
them together. A sixth key added to one and not the other would silently leave
that caller with a stale shell value winning over `.env`: the exact bug class
#63 and #68 addressed.

`set-model.sh` offers no read-only way to observe a resolved routing value --
`--list` keys `litellm-server/config.yaml` by env var NAME, never printing the
value. An execution-level assertion would therefore need the write path and a
`litellm-server` restart, which is too heavy for this layer. Cases 1-3 already
prove the loader honors whatever list it is handed, so a complete, matching
list is the remaining half of the guarantee.

## Changes

Case 4 extracts the `DOTENV_FORCE_KEYS` literal from both scripts and asserts
they are equal, reporting both lists on mismatch.

## Tests

Verified the guard is not false-green: removing one key from `set-model.sh`'s
list makes case 4 fail with the diff, and restoring it passes. The old grep
accepted that same edit.
