### PR TITLE
fix(ccgw): stop pinning the startup model so the opus tier is reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ backends**, plus smaller local models (Devstral, Qwen3-Coder) for lighter tiers.
   prompt normalization; see [docs/architecture.md](docs/architecture.md).
 - **LiteLLM gateway (Mac, `:8445`)**: the single endpoint every client talks to, configured in
   `litellm-server/`. It selects the tier by model name — Haiku/Sonnet to the Windows PC's
-  llama-swap, Fable/Opus to the Mac's CCGW Proxy (Fable is ds4, Opus is Laguna S 2.1) — and is
+  llama-swap, Fable/Opus to the Mac's CCGW Proxy (Fable is ds4, Opus is the `.env`-selected
+  `mlx_lm.server` backend) — and is
   the only place the Anthropic wire format is converted.
 - **Clients (Windows, macOS, Linux)**: Claude Code points at the gateway and nothing else.
 
@@ -74,8 +75,8 @@ host on the LAN:
 ```
 On the Mac itself, point `LITELLM_ANTHROPIC_BASE_URL` at `https://127.0.0.1:8445` and leave
 `CCGW_CA_CERT` empty — the launcher derives the CA from `mkcert -CAROOT`. Each tier is its own
-route, so `/model` switches backends: **Fable** is ds4 and **Opus** is Laguna S 2.1 (mutually
-exclusive on the Mac), **Sonnet**/**Haiku** are the Windows PC's smaller models.
+route, so `/model` switches backends: **Fable** is ds4 and **Opus** is the `.env`-selected Mac
+backend (mutually exclusive with ds4), **Sonnet**/**Haiku** are the Windows PC's smaller models.
 See [docs/ops.md](docs/ops.md#client-macos--linux).
 
 ## Configuration at a glance

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,7 @@ backends:
 | Haiku | `devstral-small-2-24b` | Devstral-Small-2-24B-Instruct-2512-IQ4_XS via llama-swap (<windows-host>, Caddy TLS front `:8443/v1`) | Anthropic to OpenAI |
 | Sonnet | `qwen3-coder-30b-a3b` | Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL via llama-swap (<windows-host>, Caddy TLS front `:8443/v1`) | Anthropic to OpenAI |
 | Fable | `deepseek-v4-flash` | CCGW Proxy (<mac-host>, :8443) | None (Anthropic passthrough) |
-| Opus | `laguna-s-2.1` | CCGW Proxy (<mac-host>, :8443) | Anthropic to OpenAI |
+| Opus | `qwen3-next-80b-a3b-thinking` (`.env`-selected) | CCGW Proxy (<mac-host>, :8443) | Anthropic to OpenAI |
 
 ### Why the gateway moved off Windows/Docker
 
@@ -193,7 +193,7 @@ Haiku/Sonnet tiers' existing no-credential design.
 
 ### Why the Opus tier is converted, not passed through
 
-Both Mac tiers reach the same CCGW Proxy, but Laguna is served by `mlx_lm.server`, which
+Both Mac tiers reach the same CCGW Proxy, but the Opus backend is served by `mlx_lm.server`, which
 speaks only the OpenAI shape. LiteLLM converts that tier with the same `openai/` provider
 pattern already used for Haiku/Sonnet, so protocol conversion stays in exactly one component
 (see [Mac backend layer](#mac-backend-layer-llama-swap)). The CCGW Proxy is a path-preserving
@@ -223,6 +223,11 @@ Fable and Opus deliberately land on the same CCGW Proxy but on different tiers. 
 backends cannot be resident together, so putting them on separate tiers makes `/model` the
 switch — no extra routing key, no second base URL. The cost is a cold start on every switch,
 which is inherent to the memory constraint rather than to this arrangement.
+
+Which tier a session *starts* on is not the launcher's to decide. `code-ccgw.sh` / `.ps1` set
+only the four `ANTHROPIC_DEFAULT_*_MODEL` aliases and never `ANTHROPIC_MODEL`, which outranks
+`settings.json`'s `model` and would silently discard the tier chosen there. The startup tier
+comes from `settings.json` or `--model`; `/model` switches it afterwards.
 
 Haiku and Sonnet have no fallback: llama-swap on <windows-host> is the sole backend for
 both tiers. A Mac (M4 Pro) fallback existed briefly during the 2026-08 migration but was

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -400,7 +400,7 @@ values in `.env`, matched against `model_name` entries in
 | Tier | Backend |
 |---|---|
 | Fable | ds4 (`deepseek-v4-flash`), Mac |
-| Opus | Laguna S 2.1 (`laguna-s-2.1`), Mac |
+| Opus | the `.env`-selected Mac backend (`qwen3-next-80b-a3b-thinking`), Mac |
 | Sonnet | Qwen3-Coder-30B-A3B (`qwen3-coder-30b-a3b`), Windows llama-swap |
 | Haiku | Devstral-Small-2-24B (`devstral-small-2-24b`), Windows llama-swap |
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -134,7 +134,7 @@ are set in `.env.example` and resolved at process startup.
 | `LITELLM_HAIKU_MODEL` | `devstral-small-2-24b` | Model routing key for the Haiku tier. Claude Code sends this value as the model name; LiteLLM matches it to the model_name entry in config.yaml, which routes to Devstral-Small-2-24B via llama-swap. |
 | `LITELLM_SONNET_MODEL` | `qwen3-coder-30b-a3b` | Model routing key for the Sonnet tier. LiteLLM routes it to Qwen3-Coder-30B-A3B via llama-swap. |
 | `LITELLM_FABLE_MODEL` | `deepseek-v4-flash` | Model routing key for the Fable tier — ds4 on the Mac. |
-| `LITELLM_OPUS_MODEL` | `laguna-s-2.1` | Model routing key for the Opus tier — Laguna S 2.1 on the Mac. The two Mac backends are mutually exclusive, so they occupy separate tiers and `/model` is what switches between them. |
+| `LITELLM_OPUS_MODEL` | `qwen3-next-80b-a3b-thinking` | Model routing key for the Opus tier — an `mlx_lm.server` backend on the Mac. `scripts/set-model.sh opus <key>` switches it among the Mac llama-swap entries and rewrites `litellm-server/config.yaml` to match, so no backend name is fixed here. The Mac backends are mutually exclusive, so they occupy separate tiers and `/model` is what switches tier. |
 | `LITELLM_ANTHROPIC_BASE_URL` | (required for client) | The gateway endpoint the launcher points `ANTHROPIC_BASE_URL` at. The direct CCGW Proxy route is retired, so the launcher exits when this is unset. |
 | `LITELLM_CLIENT_KEY` | (required for client) | Credential the launcher presents to the gateway. Same value as `LITELLM_MASTER_KEY`. `LITELLM_VIRTUAL_KEY` is accepted for one release as a deprecated alias, with a warning. |
 | `CCGW_SUBAGENT_MODEL` | (empty) | Pins every subagent to one routing key. Empty — the default — lets each agent's frontmatter decide. |
@@ -149,7 +149,7 @@ guess made client-side.
 | Tier | Backend |
 |---|---|
 | Fable | ds4 (`deepseek-v4-flash`), Mac |
-| Opus | Laguna S 2.1 (`laguna-s-2.1`), Mac |
+| Opus | the `.env`-selected Mac backend (`qwen3-next-80b-a3b-thinking`) |
 | Sonnet | Qwen3-Coder-30B-A3B, Windows llama-swap |
 | Haiku | Devstral-Small-2-24B, Windows llama-swap |
 

--- a/litellm-server/config.yaml
+++ b/litellm-server/config.yaml
@@ -44,9 +44,10 @@ model_list:
       drop_params: true
 
   # --- Fable tier: DeepSeek V4 Flash via CCGW Proxy -> Mac swap layer ---
-  # The two Mac backends are mutually exclusive (see llama-swap/config.yaml in this
-  # repo) -- both cannot be resident at once. They sit on separate Claude Code tiers
-  # so /model switches between them: fable -> ds4, opus -> Laguna S 2.1.
+  # The Mac backends are mutually exclusive (see llama-swap/config.yaml in this
+  # repo) -- only one can be resident at once. They sit on separate Claude Code tiers
+  # so /model switches between them: fable -> ds4, opus -> whichever llama-swap entry
+  # .env's LITELLM_OPUS_MODEL currently names.
   #
   # ds4-server accepts the Anthropic shape directly, so this route keeps the
   # anthropic/ provider and reaches the proxy at POST <origin>/v1/messages.
@@ -59,16 +60,16 @@ model_list:
       max_tokens: 8192
       context_window: 393216
 
-  # --- Opus tier: Laguna S 2.1 via CCGW Proxy -> Mac swap layer ---
-  # Laguna is served by mlx_lm.server, which speaks only the OpenAI shape, so
-  # this route uses the same openai/ provider pattern as haiku/sonnet: LiteLLM
-  # performs the Anthropic->OpenAI conversion and reaches the backend at
-  # POST <api_base>/chat/completions. That is why api_base here is the /v1 form
-  # (as LITELLM_LLAMASWAP_URL is) and not the bare origin the fable tier uses:
-  # llama-swap serves /v1/chat/completions, so a bare origin yields the backend's
-  # own "404 page not found" rather than any LiteLLM-level error. The routing key
-  # stays laguna-s-2.1; the body model rewrite that mlx_lm.server needs is
-  # llama-swap's useModelName.
+  # --- Opus tier: the selected mlx_lm.server backend via CCGW Proxy -> Mac swap layer ---
+  # scripts/set-model.sh rewrites the model: line below and .env's LITELLM_OPUS_MODEL
+  # together, so it names whichever llama-swap entry is selected, not a fixed backend.
+  # mlx_lm.server speaks only the OpenAI shape, so this route uses the same openai/
+  # provider pattern as haiku/sonnet: LiteLLM performs the Anthropic->OpenAI conversion
+  # and reaches the backend at POST <api_base>/chat/completions. That is why api_base
+  # here is the /v1 form (as LITELLM_LLAMASWAP_URL is) and not the bare origin the fable
+  # tier uses: llama-swap serves /v1/chat/completions, so a bare origin yields the
+  # backend's own "404 page not found" rather than any LiteLLM-level error. The body
+  # model rewrite mlx_lm.server needs is llama-swap's useModelName.
   - model_name: os.environ/LITELLM_OPUS_MODEL
     litellm_params:
       model: openai/qwen3-next-80b-a3b-thinking

--- a/scripts/code-ccgw.ps1
+++ b/scripts/code-ccgw.ps1
@@ -208,8 +208,8 @@ if ($null -ne $CaCert) {
 # than as a message from here.
 # Absence of a source key means "the child must not have the derived variable at all",
 # never "keep whatever the invoking shell happened to carry": a leftover
-# ANTHROPIC_MODEL from an earlier session would otherwise pin a tier the repo's .env
-# no longer names. Hence every conditional set has an explicit clearing else branch.
+# ANTHROPIC_DEFAULT_OPUS_MODEL would otherwise pin a tier the repo's .env no longer
+# names. Hence every conditional set has an explicit clearing else branch.
 $FableModel = Get-EnvOrNull 'LITELLM_FABLE_MODEL'
 if ($null -ne $FableModel) { Set-ChildEnv 'ANTHROPIC_DEFAULT_FABLE_MODEL' $FableModel }
 else { Set-ChildEnv 'ANTHROPIC_DEFAULT_FABLE_MODEL' '' }
@@ -222,13 +222,15 @@ else { Set-ChildEnv 'ANTHROPIC_DEFAULT_SONNET_MODEL' '' }
 $HaikuModel = Get-EnvOrNull 'LITELLM_HAIKU_MODEL'
 if ($null -ne $HaikuModel) { Set-ChildEnv 'ANTHROPIC_DEFAULT_HAIKU_MODEL' $HaikuModel }
 else { Set-ChildEnv 'ANTHROPIC_DEFAULT_HAIKU_MODEL' '' }
-if ($null -ne $FableModel) {
-    Set-ChildEnv 'ANTHROPIC_MODEL' $FableModel
-    Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION' $FableModel
-} else {
-    Set-ChildEnv 'ANTHROPIC_MODEL' ''
-    Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION' ''
-}
+# ANTHROPIC_MODEL never reaches the child: it outranks the `model` setting in the user's
+# settings.json, so any value here silently discards the tier chosen there -- an opus
+# session would still start on fable, with nothing in the client to say why. Cleared
+# unconditionally, since an inherited value reintroduces the same override.
+Set-ChildEnv 'ANTHROPIC_MODEL' ''
+
+# The picker entry is additive: it offers the fable tier, it does not choose the startup one.
+if ($null -ne $FableModel) { Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION' $FableModel }
+else { Set-ChildEnv 'ANTHROPIC_CUSTOM_MODEL_OPTION' '' }
 
 # Subagent routing is opt-in. LiteLLM multiplexes, so pinning every subagent to one tier
 # is no longer needed -- and an unconditional value silently overrides the model an

--- a/scripts/code-ccgw.sh
+++ b/scripts/code-ccgw.sh
@@ -97,9 +97,9 @@ fi
 # from LiteLLM rather than as a message from here.
 #
 # Absence of a source key means "the child must not have the derived variable at all",
-# never "keep whatever the invoking shell happened to carry": a leftover ANTHROPIC_MODEL
-# from an earlier session would otherwise pin a tier the repo's .env no longer names.
-# Hence every conditional export has an explicit unsetting else branch.
+# never "keep whatever the invoking shell happened to carry": a leftover
+# ANTHROPIC_DEFAULT_OPUS_MODEL would otherwise pin a tier the repo's .env no longer
+# names. Hence every conditional export has an explicit unsetting else branch.
 if [ -n "${LITELLM_FABLE_MODEL:-}" ]; then
     export ANTHROPIC_DEFAULT_FABLE_MODEL="$LITELLM_FABLE_MODEL"
 else
@@ -120,11 +120,16 @@ if [ -n "${LITELLM_HAIKU_MODEL:-}" ]; then
 else
     unset ANTHROPIC_DEFAULT_HAIKU_MODEL
 fi
+# ANTHROPIC_MODEL is never exported: it outranks the `model` setting in the user's
+# settings.json, so any value here silently discards the tier chosen there -- an opus
+# session would still start on fable, with nothing in the client to say why. Cleared
+# unconditionally, since an inherited value reintroduces the same override.
+unset ANTHROPIC_MODEL
+
+# The picker entry is additive: it offers the fable tier, it does not choose the startup one.
 if [ -n "${LITELLM_FABLE_MODEL:-}" ]; then
-    export ANTHROPIC_MODEL="$LITELLM_FABLE_MODEL"
     export ANTHROPIC_CUSTOM_MODEL_OPTION="$LITELLM_FABLE_MODEL"
 else
-    unset ANTHROPIC_MODEL
     unset ANTHROPIC_CUSTOM_MODEL_OPTION
 fi
 

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-01-04-configuration.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-01-04-configuration.ps1
@@ -190,7 +190,7 @@ Context '4. Model selection (unconditional LiteLLM routing keys)' {
         Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models: opus routing key'
         Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_SONNET_MODEL' 'lite-sonnet' 'models: sonnet routing key'
         Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_HAIKU_MODEL' 'lite-haiku' 'models: haiku routing key'
-        Assert-LauncherEnv $r 'ANTHROPIC_MODEL' 'lite-fable' 'models: startup model follows the fable tier'
+        Assert-LauncherEnvUnset $r 'ANTHROPIC_MODEL' "models: the startup tier is settings.json's to choose, not the launcher's"
         Assert-LauncherEnv $r 'ANTHROPIC_CUSTOM_MODEL_OPTION' 'lite-fable' 'models: custom model option follows the fable tier'
         # Stated as an inequality too: a regression that collapses the tiers onto
         # one key would still satisfy each literal individually if all literals
@@ -211,7 +211,7 @@ Context '4. Model selection (unconditional LiteLLM routing keys)' {
 
     It '4c. the retired startup-model variable must change nothing at all' {
         $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ $script:RDefaultModel = 'laguna-s-2.1' }))
-        Assert-LauncherEnv $r 'ANTHROPIC_MODEL' 'lite-fable' 'models/retired-default: the retired startup-model variable must be ignored'
+        Assert-LauncherEnvUnset $r 'ANTHROPIC_MODEL' 'models/retired-default: the retired startup-model variable must configure nothing'
         Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models/retired-default: the tier map must be unaffected'
     }
 
@@ -256,7 +256,7 @@ Context '4. Model selection (unconditional LiteLLM routing keys)' {
         }
     }
 
-    It '4f. partial keys: the fable tier drives the startup vars, so its absence leaves them unset' {
+    It '4f. partial keys: the fable tier drives the picker entry, so its absence leaves it unset' {
         $r = Invoke-Launcher -Environment (New-Env @{
                 LITELLM_OPUS_MODEL   = 'lite-opus'
                 LITELLM_SONNET_MODEL = 'lite-sonnet'
@@ -267,5 +267,18 @@ Context '4. Model selection (unconditional LiteLLM routing keys)' {
         foreach ($v in $script:ActiveVars) {
             Assert-LauncherEnvUnset $r $v 'models/no-fable: the launcher must invent no model name of its own'
         }
+    }
+
+    # 4g. ANTHROPIC_MODEL must never reach the child, whatever the parent carried.
+    # It outranks settings.json's `model`, so any value silently discards the tier the
+    # user chose there. Asserted against a parent that already carries one: an inherited
+    # value takes a different route than a set one, so the launcher has to clear it
+    # rather than merely decline to set it.
+    It '4g. an inherited ANTHROPIC_MODEL is cleared, not passed through' {
+        $r = Invoke-Launcher -Environment (New-Env ($script:AllKeys + @{ ANTHROPIC_MODEL = 'stale-from-parent' }))
+        $r.ExitCode | Should -Be 0 -Because "stderr: $($r.StdErr)"
+        Assert-LauncherEnvUnset $r 'ANTHROPIC_MODEL' 'models/inherited-startup-model: an inherited value must be cleared'
+        Assert-LauncherEnv $r 'ANTHROPIC_DEFAULT_OPUS_MODEL' 'lite-opus' 'models/inherited-startup-model: the tier map must be unaffected'
+        Assert-LauncherEnv $r 'ANTHROPIC_CUSTOM_MODEL_OPTION' 'lite-fable' 'models/inherited-startup-model: the picker entry must be unaffected'
     }
 }

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-08-parent-env.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-08-parent-env.ps1
@@ -28,7 +28,6 @@ Context '8. The invoking shell keeps its own environment (issue #66)' {
             ANTHROPIC_DEFAULT_OPUS_MODEL              = 'ctx8-opus'
             ANTHROPIC_DEFAULT_SONNET_MODEL            = 'ctx8-sonnet'
             ANTHROPIC_DEFAULT_HAIKU_MODEL             = 'ctx8-haiku'
-            ANTHROPIC_MODEL                           = 'ctx8-fable'
             ANTHROPIC_CUSTOM_MODEL_OPTION             = 'ctx8-fable'
             ANTHROPIC_CUSTOM_MODEL_OPTION_NAME        = 'Local model via ccgw'
             ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION = 'Mac backend via the LiteLLM gateway, selected per request'
@@ -39,9 +38,9 @@ Context '8. The invoking shell keeps its own environment (issue #66)' {
             CLAUDE_CODE_AUTO_COMPACT_WINDOW           = '65536'
             CLAUDE_AUTOCOMPACT_PCT_OVERRIDE           = '75'
         }
-        # ANTHROPIC_API_KEY is deliberately NOT in that map: its contract is the
-        # opposite shape ("the child must see no key at all"), so it gets its own
-        # case, 8d.
+        # ANTHROPIC_API_KEY and ANTHROPIC_MODEL are deliberately NOT in that map:
+        # their contract is the opposite shape ("the child must see none of it"),
+        # so each gets its own case -- 8d and 8k.
         $script:MustVars = @($script:Ctx8ExpectedChild.Keys)
 
         # Every routing key set, so each variable above is genuinely computed to
@@ -67,13 +66,17 @@ Context '8. The invoking shell keeps its own environment (issue #66)' {
         )
 
         $script:Ctx8ApiKey = 'cloud-key-must-survive-in-parent'
+        $script:Ctx8StartupModel = 'parent-startup-model-must-survive'
 
         # The shell the developer typed the command into: every variable the
         # launcher touches already holds a value of the user's own. Reused by the
         # failure cases so they police the same names as 8b.
         function New-Ctx8ParentEnv {
             param([hashtable]$Config = @{})
-            $h = @{ ANTHROPIC_API_KEY = $script:Ctx8ApiKey }
+            $h = @{
+                ANTHROPIC_API_KEY = $script:Ctx8ApiKey
+                ANTHROPIC_MODEL   = $script:Ctx8StartupModel
+            }
             foreach ($n in $script:MustVars) { $h[$n] = "PARENT-SENTINEL-$n-KEEP" }
             foreach ($k in $Config.Keys) { $h[$k] = $Config[$k] }
             return $h
@@ -125,6 +128,17 @@ Context '8. The invoking shell keeps its own environment (issue #66)' {
             -Because 'blanking the key for VS Code must not blank it for the shell'
         $got = if ($script:Ctx8.Env.ContainsKey('ANTHROPIC_API_KEY')) { $script:Ctx8.Env['ANTHROPIC_API_KEY'] } else { $null }
         [string]::IsNullOrEmpty($got) | Should -BeTrue -Because "ANTHROPIC_API_KEY reached the child as '$got'"
+    }
+
+    It '8k. an inherited ANTHROPIC_MODEL survives in the shell but never reaches the child' {
+        # Same two-halves shape as 8d. ANTHROPIC_MODEL outranks the `model` setting
+        # in the user's settings.json, so letting one through would silently discard
+        # the tier chosen there -- and clearing it for VS Code must not clear it for
+        # the shell the developer is still working in.
+        $script:Ctx8.AfterEnv['ANTHROPIC_MODEL'] | Should -BeExactly $script:Ctx8StartupModel `
+            -Because 'clearing the startup model for VS Code must not clear it for the shell'
+        $got = if ($script:Ctx8.Env.ContainsKey('ANTHROPIC_MODEL')) { $script:Ctx8.Env['ANTHROPIC_MODEL'] } else { $null }
+        [string]::IsNullOrEmpty($got) | Should -BeTrue -Because "ANTHROPIC_MODEL reached the child as '$got'"
     }
 
     It '8e. the same launch still hands the computed values to the child' {

--- a/tests/feature-18-serverctl/code-ccgw-windows/context-15-config-value-injection.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/context-15-config-value-injection.ps1
@@ -66,7 +66,7 @@ Context '15. Adversarial CONFIG values stay data too (issue #66)' -Skip:(-not $I
                     @{ Var = 'ANTHROPIC_AUTH_TOKEN'; Want = $key }
                     @{ Var = 'NODE_EXTRA_CA_CERTS'; Want = $ca }
                     @{ Var = 'ANTHROPIC_DEFAULT_FABLE_MODEL'; Want = $model }
-                    @{ Var = 'ANTHROPIC_MODEL'; Want = $model }
+                    @{ Var = 'ANTHROPIC_CUSTOM_MODEL_OPTION'; Want = $model }
                 )) {
                 $got = if ($r.Env.ContainsKey($pair.Var)) { $r.Env[$pair.Var] } else { '<absent>' }
                 if ($got -cne $pair.Want) {

--- a/tests/feature-18-serverctl/code-ccgw-windows/setup.ps1
+++ b/tests/feature-18-serverctl/code-ccgw-windows/setup.ps1
@@ -157,10 +157,10 @@ $script:TierVars = @(
     'ANTHROPIC_DEFAULT_SONNET_MODEL'
     'ANTHROPIC_DEFAULT_HAIKU_MODEL'
 )
-# The vars that name the model in play at startup. CLAUDE_CODE_SUBAGENT_MODEL is
-# deliberately NOT here any more: it is now opt-in (section 4d).
+# The var that offers the fable tier as a selectable /model entry. Two names are
+# deliberately NOT here any more: CLAUDE_CODE_SUBAGENT_MODEL, now opt-in (section 4d),
+# and ANTHROPIC_MODEL, which the launcher must never set at all (section 4g).
 $script:ActiveVars = @(
-    'ANTHROPIC_MODEL'
     'ANTHROPIC_CUSTOM_MODEL_OPTION'
 )
-$script:ModelVars = $script:TierVars + $script:ActiveVars + @('CLAUDE_CODE_SUBAGENT_MODEL')
+$script:ModelVars = $script:TierVars + $script:ActiveVars + @('ANTHROPIC_MODEL', 'CLAUDE_CODE_SUBAGENT_MODEL')

--- a/tests/feature-18-serverctl/test-code-ccgw-posix.sh
+++ b/tests/feature-18-serverctl/test-code-ccgw-posix.sh
@@ -130,10 +130,12 @@ assert_no_ca_warning() { # assert_no_ca_warning <context>
 
 # The four /model tiers Claude Code switches between.
 TIER_VARS="ANTHROPIC_DEFAULT_FABLE_MODEL ANTHROPIC_DEFAULT_OPUS_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL ANTHROPIC_DEFAULT_HAIKU_MODEL"
-# The vars that name the model in play at startup. CLAUDE_CODE_SUBAGENT_MODEL
-# is deliberately NOT here any more: it is now opt-in (section 4d).
-ACTIVE_VARS="ANTHROPIC_MODEL ANTHROPIC_CUSTOM_MODEL_OPTION"
-MODEL_VARS="$TIER_VARS $ACTIVE_VARS CLAUDE_CODE_SUBAGENT_MODEL"
+# The var that offers the fable tier as a selectable /model entry. Two names are
+# deliberately NOT here any more: CLAUDE_CODE_SUBAGENT_MODEL, which is now opt-in
+# (section 4d), and ANTHROPIC_MODEL, which the launcher must never export at all
+# (section 4g) -- it outranks the user's own settings.json `model`.
+ACTIVE_VARS="ANTHROPIC_CUSTOM_MODEL_OPTION"
+MODEL_VARS="$TIER_VARS $ACTIVE_VARS ANTHROPIC_MODEL CLAUDE_CODE_SUBAGENT_MODEL"
 
 # --- Retired variable names --------------------------------------------------
 # The cases that prove a retired variable no longer configures anything need
@@ -268,7 +270,7 @@ assert_env ANTHROPIC_DEFAULT_FABLE_MODEL lite-fable "models: fable routing key"
 assert_env ANTHROPIC_DEFAULT_OPUS_MODEL lite-opus "models: opus routing key"
 assert_env ANTHROPIC_DEFAULT_SONNET_MODEL lite-sonnet "models: sonnet routing key"
 assert_env ANTHROPIC_DEFAULT_HAIKU_MODEL lite-haiku "models: haiku routing key"
-assert_env ANTHROPIC_MODEL lite-fable "models: startup model follows the fable tier"
+assert_unset ANTHROPIC_MODEL "models: the startup tier is settings.json's to choose, not the launcher's"
 assert_env ANTHROPIC_CUSTOM_MODEL_OPTION lite-fable "models: custom model option follows the fable tier"
 # Stated as an inequality too: a regression that collapses the tiers onto one
 # key would still satisfy each literal individually if all literals moved.
@@ -290,7 +292,7 @@ run_launcher LITELLM_ANTHROPIC_BASE_URL=https://lite:1 LITELLM_CLIENT_KEY=ck \
     LITELLM_FABLE_MODEL=lite-fable LITELLM_OPUS_MODEL=lite-opus \
     LITELLM_SONNET_MODEL=lite-sonnet LITELLM_HAIKU_MODEL=lite-haiku \
     "$R_DEFAULT_MODEL=laguna-s-2.1"
-assert_env ANTHROPIC_MODEL lite-fable "models/ccgw-default: the retired startup-model variable must be ignored"
+assert_unset ANTHROPIC_MODEL "models/ccgw-default: the retired startup-model variable must configure nothing"
 assert_env ANTHROPIC_DEFAULT_OPUS_MODEL lite-opus "models/ccgw-default: the tier map must be unaffected"
 
 # 4d. Subagent contract (three cases).
@@ -338,8 +340,8 @@ for v in $MODEL_VARS; do
 done
 
 # 4f. Partial keys: each tier is independent, and the fable tier drives the
-# startup vars, so with LITELLM_FABLE_MODEL absent they stay unset rather than
-# borrowing another tier's key.
+# /model picker entry, so with LITELLM_FABLE_MODEL absent it stays unset rather
+# than borrowing another tier's key.
 run_launcher LITELLM_ANTHROPIC_BASE_URL=https://lite:1 LITELLM_CLIENT_KEY=ck \
     LITELLM_OPUS_MODEL=lite-opus LITELLM_SONNET_MODEL=lite-sonnet LITELLM_HAIKU_MODEL=lite-haiku
 assert_env ANTHROPIC_DEFAULT_OPUS_MODEL lite-opus "models/no-fable: opus routing key still applies"
@@ -347,6 +349,20 @@ assert_unset ANTHROPIC_DEFAULT_FABLE_MODEL "models/no-fable: no fable key means 
 for v in $ACTIVE_VARS; do
     assert_unset "$v" "models/no-fable: the launcher must invent no model name of its own"
 done
+
+# 4g. ANTHROPIC_MODEL must never reach the child, whatever the parent carried.
+# It outranks settings.json's `model`, so any value silently discards the tier the
+# user chose there. Asserted against a parent that already carries one: an inherited
+# value takes a different route than an exported one, so the launcher has to clear it
+# rather than merely decline to set it.
+run_launcher LITELLM_ANTHROPIC_BASE_URL=https://lite:1 LITELLM_CLIENT_KEY=ck \
+    LITELLM_FABLE_MODEL=lite-fable LITELLM_OPUS_MODEL=lite-opus \
+    LITELLM_SONNET_MODEL=lite-sonnet LITELLM_HAIKU_MODEL=lite-haiku \
+    ANTHROPIC_MODEL=stale-from-parent
+[ "$RC" -eq 0 ] || fail "models/inherited-startup-model: exited $RC: $(cat "$WORK/err")"
+assert_unset ANTHROPIC_MODEL "models/inherited-startup-model: an inherited value must be cleared, not passed through"
+assert_env ANTHROPIC_DEFAULT_OPUS_MODEL lite-opus "models/inherited-startup-model: the tier map must be unaffected"
+assert_env ANTHROPIC_CUSTOM_MODEL_OPTION lite-fable "models/inherited-startup-model: the picker entry must be unaffected"
 
 # --- 5. VS Code profile isolation and argv passthrough ----------------------
 run_launcher LITELLM_ANTHROPIC_BASE_URL=https://lite:1 LITELLM_CLIENT_KEY=ck -- /some/project --new-window


### PR DESCRIPTION
## Summary
- Both launchers exported `ANTHROPIC_MODEL` pinned to the fable-tier routing key, which outranks `settings.json`'s `model` -- an opus-configured session silently started on fable (observed as deepseek-v4-flash instead of qwen3-next-80b-a3b-thinking).
- Both launchers now clear `ANTHROPIC_MODEL` unconditionally instead of pinning it; the four `ANTHROPIC_DEFAULT_*_MODEL` aliases are untouched so `/model` tier switching is unaffected. `ANTHROPIC_CUSTOM_MODEL_OPTION` stays (confirmed by measurement it does not hijack the startup model).
- Fixed stale "Laguna S 2.1" / `laguna-s-2.1` opus-tier descriptions in 5 docs/config files -- `scripts/set-model.sh` makes that backend selectable via `.env`, so it's no longer a fixed name.

## Test plan
- [x] `test-code-ccgw-posix.sh` PASS
- [x] `pytest tests/` — 372 passed
- [x] Added bash 4g / Pester 4g+8k regression cases (parent-carried `ANTHROPIC_MODEL` never reaches the child)
- [ ] Pester suite (`.ps1` side) — not run; `pwsh` not installed on this host, symmetry verified by static review only