### PR TITLE
feat(win-server): add Windows host support, merge in the internal-only companion repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ __pycache__/
 # Local Claude Code / worktree state
 .claude/
 .worktree-backup/
+
+# Runtime-side artifacts that must never reach this repo: binaries live beside the
+# service on the host, certificates outside the checkout, and the timestamped
+# config backups a suffix-only *.bak rule cannot match.
+*.exe
+config.yaml.bak*
+certs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,12 @@ When a `config.yaml` under `llama-swap/` changes, also update the `model-annotat
 
 Adding or renaming a model key requires a matching entry with `role`; changing an entry's flags requires updating its `notes`.
 
+The reverse direction: when a model key leaves `config.yaml`, its annotation may stay only
+while the judgement behind it is still live. Keep it by writing that judgement in `retained:`
+— it has to say what decision the entry will be consulted for. An annotation nobody can write
+a `retained:` line for is deleted with the key. This holds for every host directory, not just
+the one that first needed it.
+
 Host directories are named `<chip>-<memory>` — see [llama-swap/README.md](llama-swap/README.md).
 
 ## Design Docs

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hideaki Nire
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ backends**, plus smaller local models (Devstral, Qwen3-Coder) for lighter tiers.
 
 > This repo holds only the **ops / config / decisions** for using these engines as Claude
 > Code backends. Both the GitHub repo and the local clone are named `cc-local-llm`
-> (`~/git/cc-local-llm` on the Mac, `C:\git\cc-local-llm` on Windows).
+> (`~/git/cc-local-llm` on the Mac, `C:\LLM\cc-local-llm` on Windows).
 > The ds4 engine itself is the public upstream `antirez/ds4`, a separate and unrelated
 > repo, cloned on its own at `~/git/ds4`.
 
@@ -40,7 +40,7 @@ Standard layout (mirrors the agents-repo convention):
 | [scripts/code-ccgw.ps1](scripts/code-ccgw.ps1) | Windows client launcher (pwsh) — loads `.env`, sets ccgw env, isolates the VS Code process, launches VS Code |
 | [scripts/code-ccgw.sh](scripts/code-ccgw.sh) | macOS/Linux client launcher — POSIX counterpart of `code-ccgw.ps1`; lets the backend Mac drive its own backend |
 | [litellm-server/](litellm-server/) | LiteLLM gateway config — model-tier routing and protocol conversion |
-| [install.sh](install.sh) / [install.ps1](install.ps1) | One-time prereq installers — `install.sh [--server\|--client\|--all]` (macOS/Linux), `install.ps1` (Windows) |
+| [install.sh](install.sh) / [install.ps1](install.ps1) | One-time prereq installers — `install.sh [--server\|--client\|--all]` (macOS/Linux), `install.ps1 [-Server\|-Client\|-All]` (Windows) |
 | [.env.example](.env.example) | Template for the gitignored `.env` |
 
 ## Quick start
@@ -57,7 +57,27 @@ git -C ~/git/ds4 pull                            # update the antirez/ds4 build 
 ~/git/cc-local-llm/scripts/serverctl.sh start all    # proxy + llama-swap + litellm; or 'install all' for auto-start at login
 ```
 
-**Windows (client):** one-time install of mkcert and `.env` scaffolding:
+**Windows (server):** one-time registration of the llama-swap backend that serves the
+Haiku/Sonnet tiers, from an **elevated** pwsh:
+```powershell
+.\install.ps1 -Server
+```
+It installs mkcert, NSSM and Caddy (all via winget, all idempotent — re-running is safe),
+creates the certificate directory and the certificate, renders the Caddyfile, and registers and
+starts the two NSSM services `llama-swap` and `llama-swap-caddy`.
+
+Three things it assumes are already in place and does **not** install:
+- `llama-swap.exe` in the runtime directory — an upstream-distributed binary, placed by hand
+- a CUDA-built llama.cpp, plus the `.gguf` weights that `llama-swap/rtx5070ti-128gb/config.yaml` names
+- the Mac's **full** mkcert CA directory — `rootCA.pem` *and* `rootCA-key.pem` — copied here with
+  `$env:CAROOT` pointed at it. Importing `rootCA.pem` into the Windows trust store is not enough:
+  mkcert needs the private key to issue a leaf signed by the same CA the gateway already trusts.
+
+Paths live in [docs/infrastructure.md](docs/infrastructure.md); the procedure, the verification
+checklist, and the blast radius of the Caddy service are in [docs/ops.md](docs/ops.md#server-windows).
+
+**Windows (client):** one-time install of mkcert and `.env` scaffolding (no switch means
+`-Client`, so this is equivalent to `.\install.ps1 -Client`):
 ```powershell
 .\install.ps1
 ```
@@ -96,3 +116,7 @@ See [docs/ops.md](docs/ops.md#client-macos--linux).
 
 See [docs/tuning.md](docs/tuning.md) for the full reference, [docs/infrastructure.md](docs/infrastructure.md)
 for hosts/ports/paths, and [docs/history.md](docs/history.md) for why each value is what it is.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/history.md
+++ b/docs/history.md
@@ -126,3 +126,145 @@ Changes: Added an opt-in DOTENV_FORCE_KEYS (space-separated, NON-exported) to sc
 
 Test gap: no test asserted the model-routing keys take .env over a stale shell value; the loader test's run_dotenv also had an unshifted $@ that made all its cases fail with an empty dump
 
+### FEATURE: [win-server] nirecom/llama-swap merged into this repo, absorbing its optimization history (2026-08-29)
+Background: the Windows llama-swap host had its own private repo (`nirecom/llama-swap`), holding the
+config, the launch tooling and an `optimization-history.md` that nothing else could see. That
+split meant the two halves of one system — the Mac gateway and the Windows backend it routes
+Haiku/Sonnet to — were documented in two places, and the tuning rationale for the backend was
+invisible from the repo an operator actually reads. Merging it here makes one repository the
+whole picture. Because this repo is PUBLIC, everything carried over was redacted first: private
+tokens, keys and machine identifiers were stripped or replaced with placeholders before the
+first commit, and the outbound scan gates each one. The source repo was deliberately kept —
+made private and archived as `nirecom/llama-swap-archived` rather than deleted — because the
+verbatim pre-redaction history is the only record of what the redaction removed, and a deleted
+repo cannot answer a later "was this ever public?" question.
+Changes: merged in six commits, each independently reviewable: (1) `.gitignore` + `LICENSE`,
+(2) `llama-swap/rtx5070ti-128gb/{config.yaml,model-annotations.yaml}`, (3) `CLAUDE.md` +
+`llama-swap/README.md`, (4) the Windows server installer, (5) documentation (this entry), (6)
+close-out.
+
+Decisions taken along the way:
+
+- **Annotation split, 3 removed / 3 retained.** Three model keys were dropped from
+  `config.yaml` (`gemma-3-4b-it-Q4_K_M`, `Mistral-22B-v0.2-Q4_K_S`, `Qwen3-8B-Q4_K_M`) and
+  three annotations were kept for models no longer configured, because the judgement behind
+  them is still live. The result is an 11-model / 14-annotation asymmetry on the Windows side,
+  against the Mac side's 1:1. That asymmetry is intentional, so a new rule was written into
+  `CLAUDE.md` to keep it from reading as rot: an annotation may outlive its key only with a
+  `retained:` line naming the decision it will be consulted for, and an annotation nobody can
+  write that line for is deleted with the key.
+- **`install.ps1` grew a role matrix** (`-Server` / `-Client` / `-All` / `-Uninstall`, plus
+  `-LanIp`), with no switch still meaning `-Client` so the one-word invocation in existing
+  notes keeps working. The server role installs its own dependencies via winget (mkcert, NSSM,
+  Caddy), idempotently.
+- **Certificates moved outside the repo.** They are host state, not source, and the leaf now
+  MUST carry the host's LAN IPv4 in its SAN list — a loopback-only cert terminates TLS happily
+  while every LAN client refuses the connection, which is a failure with no error message on
+  the server side.
+- **Log rotation was added to both NSSM services.** Motivation was concrete: a 125 MB service
+  log found on the host. The threshold is an installer default, not a tuning decision, which is
+  why it is recorded here and not in `tuning.md`.
+- **Native-command exit-code policy was centralised into `Invoke-Native`** (`install/win/lib/native.ps1`).
+  Each call site had been deciding for itself which non-zero codes were survivable (`sc query`'s
+  1060, `taskkill`'s 128); one helper now owns that, so a forgotten check cannot silently pass.
+- **The llama-swap runtime directory was deliberately left outside the checkout** (path in
+  `infrastructure.md`). `llama-swap.exe` is an upstream-distributed binary and the NSSM logs are
+  host state; neither belongs in git. The config, by contrast, is a checked-out file read in
+  place — the old design that kept `config.yaml` beside the exe is dead, and
+  `llama-swap-service.ps1` now takes all three paths as mandatory parameters so no default can
+  quietly resurrect the co-location assumption.
+- **LICENSE**: MIT, attributed to the repository owner, matching the pre-existing public posture
+  of this repo rather than the private source repo's absence of one.
+- **A rehearsal backup copy of the source repo was deleted** once the real cutover completed and
+  the archived remote was confirmed reachable; keeping a third unredacted copy on disk was the
+  larger risk.
+
+Absorbed from the source repo's `optimization-history.md` (all five dated sections), plus
+`legacy-launch-cmd.md` and `legacy-manual-tuning.md`, both now obsolete. That file was the only
+record of these measurements and does not survive the merge, so it is transcribed here in full.
+
+**2026/02/21 — initial optimizer run.**
+
+| model | tok/s | threads | batch | ubatch | ngl | FA |
+|---|---|---|---|---|---|---|
+| (8 model rows) | (not individually recorded — see the 2026/04/05 consolidated table for the superseding measurement) | | | | | |
+
+The per-model figures of this first run were not preserved in the extraction; the run's shape
+(8 models, the seven columns above) is recorded so the later tables can be read as supersessions
+rather than as the first data point.
+
+**2026/02/22 — re-run after adding nemotron.**
+
+| model | tok/s | threads | batch | ubatch | ngl | FA |
+|---|---|---|---|---|---|---|
+| (9 model rows — the 02/21 set plus the newly added nemotron) | (not individually recorded — see the 2026/04/05 consolidated table for the superseding measurement) | | | | | |
+
+`Qwen3-32B-Q4_K_M` is already `(pending)` here.
+
+**2026/04/05 — consolidated table (11 models).** The numbers below are the surviving ones; ✓/✗
+in the FA column mean flash-attention on/off, `—` means not recorded. One further row of the
+original eleven was not preserved in the extraction.
+
+| model | tok/s | FA | notes |
+|---|---|---|---|
+| `Qwen3.5-27B-IQ3_M` | 47.4 | ✓ | the chosen quant |
+| `Qwen3.5-27B-Q4_K_M` | 14.6 | ✗ | rejected — this row is the basis of the 16 GB-VRAM Q4-avoidance decision |
+| `Llama-3-ELYZA-JP-8B` | 146.4 | — | later re-measured at 144.3 |
+| `Lumimaid-v0.2-12B` | 97.6 | — | later re-measured at 96.5 |
+| `Nemotron` | 77.2 | — | later re-measured at 74.4 |
+| `Qwen2.5-7B-Instruct-Q4_K_M` | 149.2 | — | at the optimizer's suggested `-ngl 136` — **deliberately not adopted**, see below |
+| `gemma-3-4b-it-Q4_K_M` | 201.2 | — | key removed from config.yaml in commit 2 of this migration |
+| `Mistral-22B-v0.2-Q4_K_S` | 57.9 | — | key removed in commit 2 |
+| `Qwen3-8B-Q4_K_M` | (pending) | — | never benchmarked; key removed in commit 2 |
+| `Qwen3-32B-Q4_K_M` | (pending) | — | never benchmarked, pending in both this table and the 02/22 one, never resolved; no annotation survives for it either |
+
+The single most important fact in this table is the one the numbers do not show:
+**`Qwen2.5-7B-Instruct-Q4_K_M`'s optimizer suggestion was rejected on purpose.** The optimizer
+proposed `-ngl 136` for 149.2 tok/s; the deployed config runs it `-ngl 0 --device none` instead.
+It is the always-resident judge in the `forever` group, so occupying zero GPU memory outranks its
+own throughput — a faster judge that evicts a working model is a net loss. Anyone reading the
+optimizer output later would otherwise "fix" this config back to a slower system.
+
+`Qwen3-8B-Q4_K_M` was confirmed genuinely unused before removal, by cross-checking the host's
+other stacks: the langchain-stack "judge" role actually runs `Qwen2.5-7B-Instruct-Q4_K_M`, not
+this model; Qwen3-8B had been rejected as unsuitable for RAGAS; and in another internal stack it was
+only a temporary onboarding scaffold.
+
+**2026/08/27 — `Qwen3.8-27B-UD-IQ4_XS`, context scaling.**
+
+| context | tok/s | VRAM spill |
+|---|---|---|
+| 32K | 79–82 | ~211 MiB |
+| 64K | 55.4 | ~873 MiB |
+
+MTP draft acceptance rate 0.845 (125/148 drafts accepted, mean accepted length 2.69). Context
+growth slope ≈ 30.7 KiB/token. Built on llama.cpp b1881-3653e6d6d, running the external
+`froggeric v22.4` chat template. Coding-task accuracy was **not** verified at this point — the
+figures are throughput only.
+
+**2026/08/28 — IQ4_XS replaced by UD-Q3_K_XL.**
+
+| quant / context | tok/s | VRAM spill | VRAM used |
+|---|---|---|---|
+| UD-IQ4_XS @ 32K | 79–82 | ~211 MiB | — |
+| UD-IQ4_XS @ 64K | 55.4 | ~873 MiB | — |
+| UD-Q3_K_XL @ 64K | 90.6 | ~305 MiB | 12,537 MiB |
+
+The same 64K context, a few hundred MiB less spill, and throughput rises from 55.4 to 90.6 tok/s.
+This is the concrete example behind the claim in `tuning.md` that at this VRAM budget a
+hundreds-of-MiB spill difference produces a tens-of-percent throughput difference.
+
+**Absorbed from `legacy-launch-cmd.md`:** before NSSM-based service management, models were
+launched from hand-written command lines. When NSSM was adopted, `--watch-config` was added to
+the launch arguments so a config edit takes effect without a manual restart; that argument is now
+produced by `Get-LlamaSwapNssmSettings` in `install/win/lib/nssm-args.ps1`, and the file
+describing the manual launch has no readers left.
+
+**Absorbed from `legacy-manual-tuning.md`:** before the optimizer tool existed, tuning was done
+by hand through a dedicated cmd/ini file. Some of those hand-tuned settings reportedly beat what
+the automated optimizer later produced. Recorded as a historical observation only — no
+measurement survives to act on, so it is not a claim that hand-tuning is better.
+
+### SECURITY: Windows installer security review: Caddy bind scope and NSSM LocalSystem accepted as known risk (2026-08-29)
+Background: Review-code-security round 1 (session da9ea40f-3775-4662-abc9-7b33bb4df317) surfaced two deployment-scope risks in the Windows server installer: (1) every Caddy site block in install/win/Caddyfile.template binds unauthenticated on all interfaces, some reachable via Cloudflare Tunnel; (2) the llama-swap and llama-swap-caddy NSSM services run as LocalSystem and reference config files inside the git checkout with --watch-config, so write access to the checkout is effectively SYSTEM-level code execution.
+Changes: Both accepted as known risk for the current deployment scope: a private, single-operator home LAN with no untrusted or external clients. Hardening (authentication / bind-scope restriction for Caddy; dedicated service account and checkout/config separation with ACLs for NSSM) is deferred until the threat model changes (e.g. additional users, external exposure).

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -63,6 +63,17 @@ SSOT for hosts, network, ports, and paths. Other docs reference this — do not 
 
 | Item | Value |
 |---|---|
-| Client launcher | `C:\git\cc-local-llm\scripts\code-ccgw.ps1` |
+| Client launcher | `C:\LLM\cc-local-llm\scripts\code-ccgw.ps1` |
 | Client root CA (gateway trust) | `<mkcert -CAROOT>\rootCA.pem` (the Mac's CA, imported here; `CCGW_CA_CERT`) |
-| llama-swap config | `C:\LLM\llama-swap\config.yaml` (not in this repo) |
+| llama-swap config | `C:\LLM\cc-local-llm\llama-swap\rtx5070ti-128gb\config.yaml` — a checked-out file, read in place <!-- synced-from: install.ps1 --> |
+| llama-swap runtime (exe + NSSM logs) | `C:\LLM\llama-swap\` — deliberately not under git: `llama-swap.exe` is an upstream-distributed binary, not a llama.cpp build artifact, so it is not under `C:\LLM\llama.cpp\build\bin\Release\` either <!-- synced-from: install.ps1 --> |
+| llama-swap TLS cert/key | `C:\LLM\certs\llama-swap\cert.pem` / `key.pem` — mkcert-issued; the SAN list must carry this host's LAN IPv4 <!-- synced-from: install.ps1 --> |
+| Caddyfile (generated) | `C:\LLM\llama-swap\Caddyfile`, rendered by the installer from `install/win/Caddyfile.template` in this repo <!-- synced-from: install.ps1 --> |
+| NSSM services | `llama-swap` / `llama-swap-caddy` |
+| llama-swap-optimizer config pointer | the `CONFIG_YAML` variable in the optimizer's own `.env` (its install directory sits beside the runtime directory above) — point it at the llama-swap config row above |
+
+`install.ps1` is where the marked values are defined (`$CertDir`, `$RuntimeDir`, `$ConfigPath`);
+the rows carrying `<!-- synced-from: install.ps1 -->` only mirror them, and no other document
+restates them. Change the installer first, then re-sync this table —
+`tests/feature-86-win-llama-swap-server/test-infrastructure-paths-sync.sh` compares the two and
+fails on drift.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -134,6 +134,14 @@ two commands force a model swap between them; expect a cold start on each switch
 | `401 Unauthorized` from the gateway | `LITELLM_CLIENT_KEY` on the client must equal `LITELLM_MASTER_KEY` on the Mac |
 | `401` from the CCGW Proxy | `LITELLM_CCGW_PROXY_API_KEY` must equal `CCGW_PROXY_AUTH_TOKEN` |
 
+Two properties of the Windows Caddy certificate that a "TLS error" never spells out:
+
+- Its SAN list must include the host's **LAN IPv4 address**, not just `localhost` / `127.0.0.1`.
+  A cert that covers only loopback still terminates TLS, so the service looks healthy from the
+  host — LAN clients simply refuse the connection, with no matching entry in Caddy's log.
+- That assumes the LAN IP is **static or DHCP-reserved**. A roaming address invalidates the
+  certificate the moment the lease changes; re-issue it (`install.ps1 -Server`) after any move.
+
 ## Install llama-swap and Laguna S 2.1 (Mac, one-time)
 
 llama-swap owns the full start/stop lifecycle of both ds4-server and Laguna's
@@ -309,11 +317,78 @@ colored `[service]` prefix (magenta proxy, blue llama-swap, green litellm) so th
 source stays legible regardless of which service is currently the noisiest; piped or
 redirected output gets the same prefix without ANSI.
 
+## Server (Windows)
+
+This host serves the Haiku and Sonnet tiers: llama-swap holds the models, Caddy terminates TLS
+in front of it, and both run as NSSM services. One-time install, from an **elevated** pwsh in
+the checkout:
+
+```powershell
+.\install.ps1 -Server
+```
+
+The installer is the source of truth for the exact commands, so they are not restated here: it
+installs mkcert, NSSM and Caddy, issues the certificate, renders the Caddyfile from
+[install/win/Caddyfile.template](../install/win/Caddyfile.template), and registers and starts
+both services. The three prerequisites it assumes rather than installs — the `llama-swap.exe`
+binary in the runtime directory, a CUDA-built llama.cpp plus the `.gguf` weights the config
+names, and the Mac's *full* mkcert CA directory (`rootCA.pem` **and** `rootCA-key.pem`) copied
+here with `$env:CAROOT` pointed at it — are listed under **Windows (server)** in
+[README.md](../README.md#quick-start). A trust-store import of `rootCA.pem` alone does not cover
+that last one: mkcert signs the leaf with the CA private key, so without `rootCA-key.pem` it
+issues from a *different*, locally generated CA and the gateway rejects the result. Every path is
+in [infrastructure.md](infrastructure.md#paths-windows).
+
+**Reissuing the certificate after this host's LAN IP changes:** the SAN list is fixed when the
+certificate is issued, and [install/win/certs.ps1](../install/win/certs.ps1) leaves an existing
+pair untouched so a re-run never invalidates a certificate LAN clients already trust. Re-running
+the installer alone therefore keeps serving the old address. Delete both PEMs first, then re-run
+from an **elevated** pwsh — `<cert-dir>` is the llama-swap TLS cert/key directory in
+[infrastructure.md](infrastructure.md#paths-windows), the only place that path is written down:
+
+```powershell
+Remove-Item <cert-dir>\cert.pem, <cert-dir>\key.pem
+.\install.ps1 -Server
+```
+
+Deleting only one of the two is refused rather than completed, so remove both. LAN clients keep
+trusting the new certificate without any client-side change: it is issued by the same root CA.
+
+Verification — the installer asserts all of this itself, so a clean run has already proved it;
+re-check it by hand after any manual service surgery:
+
+- `Get-Service llama-swap, llama-swap-caddy` reports **Running** for both.
+- Every port is actually accepting connections within 30 s of the start: llama-swap's internal
+  listen port plus one port per front-end block in the generated Caddyfile. Check with
+  `Get-NetTCPConnection -State Listen`. A service that reports Running while nothing is bound is
+  the failure NSSM hides — the process is crash-looping.
+- A request survives the TLS hop end to end:
+  `curl.exe -sk https://<windows-lan-ip>:8443/v1/models`.
+
+**Blast radius of `llama-swap-caddy`:** it is a single Caddy process serving *every* front-end
+block in the generated Caddyfile, not only llama-swap's `:8443`. Four unrelated local services
+share it — Open WebUI (`:3443`), JudgeClaw (`:18790`), the LangChain API (`:8444`) and Langfuse
+(`:13443`). Stopping or removing this one service therefore drops external reachability for all
+five at once, so "just restart Caddy" is never a llama-swap-local action.
+
+**Native command exit-code policy (`install/win/lib/native.ps1`):** `$ErrorActionPreference =
+'Stop'` does not turn a native executable's non-zero exit into a PowerShell exception, so every
+native call the installer makes (nssm, sc.exe, taskkill, winget, mkcert, certutil) goes through
+`Invoke-Native`, which closes that gap once for the class instead of once per call site. Exit 0
+is the only automatic success; a caller must enumerate any other code it wants treated as benign
+(e.g. "already absent"), since the same code is benign at one call site and a real failure at
+another. When extending an allow list: PowerShell reports the full Win32 exit code, but bash
+observing the same run truncates it to 8 bits — `sc.exe` on a missing service is Win32 `1060`,
+which shows as `36` (`1060 & 0xFF`) from bash. Always write the Win32 value. The file holds only
+function definitions: the Pester suites dot-source it, so a stray top-level statement would make
+the test run itself destructive.
+
 ## Client (Windows)
 
 Run `install.ps1` first (once) to install mkcert and scaffold `.env` — see
-[README.md](../README.md#quick-start). Windows is a client only now; the gateway lives on the
-Mac.
+[README.md](../README.md#quick-start). This host is a client, and also serves as the llama-swap
+backend for the Haiku/Sonnet tier (see "Server (Windows)" above); the gateway itself still runs
+on the Mac.
 
 Then edit the repo-root `.env` (gitignored, so the LAN IP and the key are never committed):
 ```powershell

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -92,6 +92,79 @@ Weights ~67 GB resident. `sliding_window: 512` on 36/48 layers + `num_key_value_
 keeps a single request's KV cost to ~48 KB/token — even a maxed-out 262144-token request costs
 only ~12.9 GB of active KV memory. Full derivation and incident history: [history.md](history.md).
 
+## Windows host (RTX 5070 Ti 16 GB / 128 GB RAM)
+
+The Mac's problem is one huge model against 128 GB of unified memory. The Windows host's is the
+opposite: eleven models against **16 GB of VRAM**, with 128 GB of ordinary system RAM behind it.
+Every decision in [llama-swap/rtx5070ti-128gb/config.yaml](../llama-swap/rtx5070ti-128gb/config.yaml)
+falls out of that. Values live in that file; only the reasoning is here.
+
+**VRAM placement is four distinct patterns, not one.** Classify by what the entry actually does,
+not by parameter count:
+
+- **Full GPU residency** — no offload flag at all, `-ngl` set past the layer count:
+  `NVIDIA-Nemotron-Nano-9B-v2-Japanese-Q8_0`, `Qwen3.5-27B-IQ3_M`, `Qwen3-Coder-Next-Q4_K_M`,
+  `Qwen3.8-27B-UD-Q3_K_XL`. The two 27B-class members only reach this pattern because the quant
+  is pushed down to IQ3_M / UD-Q3_K_XL — at Q4 they would not fit at all.
+- **MoE expert layers pushed to host RAM** — `gpt-oss-120b-MXFP4` and
+  `Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL` via `--n-cpu-moe`, `gpt-oss-20b-MXFP4` via an
+  `--override-tensor` regex that sends the upper block range's `ffn_*_exps` to CPU (the 30B-A3B
+  entry carries both). These three are the reason 128 GB of system RAM matters, and the `128gb`
+  in the host directory's name refers to this class, not to the GPU.
+- **Partial offload** — `Devstral-Small-2-24B-Instruct-2512-IQ4_XS` keeps most layers on the GPU
+  and pays for its 64K context with quantized KV.
+- **Deliberately GPU-free** — `Qwen2.5-7B-Instruct-Q4_K_M` runs `-ngl 0 --device none`. It is the
+  always-resident judge in the `forever` group, so occupying **zero** GPU bytes outranks its own
+  throughput. The optimizer's 2026/04/05 run proposed a full-offload `-ngl` for it and measured a
+  large speedup; that suggestion was rejected outright and never deployed (figures and date in
+  [history.md](history.md)). The gap between what the optimizer suggested and what was deployed is
+  exactly the kind of reasoning this file exists to hold.
+
+`Llama-3-ELYZA-JP-8B-q4_k_m` and `Lumimaid-v0.2-12B.q4_k_m` (and the `Qwen2.5-7B` entry above)
+carry an `--override-tensor` `ffn_*_exps` regex despite being dense models with no `exps` tensors
+for it to match. This is **likely a no-op** left over from the optimizer applying the flag
+uniformly — unconfirmed: verifying it means reading `llama-server`'s startup tensor-allocation
+log and checking whether any tensor is redirected. Do not remove it on the strength of this
+paragraph alone.
+
+**KV quantization splits into three groups, and the split does not follow the group config.**
+Within the seven `heavy` members alone there are two different policies:
+
+- `-ctk q4_0 -ctv q4_0` — `Qwen3.5-27B-IQ3_M`, `Devstral`, `Qwen3-Coder-Next`,
+  `Qwen3-Coder-30B-A3B` and `Qwen3.8-27B` (five models), all running 32K or 64K context. At this
+  VRAM budget it is effectively the only lever that makes that much context fit.
+- `--cache-type-k q8_0 --cache-type-v q8_0` — `gpt-oss-120b-MXFP4` alone. It can afford the
+  larger KV type because its context is the smallest in the file.
+- **No KV quantization** (f16 default) — `gpt-oss-20b`, `Qwen2.5-7B`, `Nemotron`, `ELYZA` and
+  `Lumimaid` (five models), whose context is small or unset, so there is nothing to shrink.
+  `gpt-oss-20b` sits in `heavy` yet quantizes no KV: group membership and KV policy are
+  independent axes.
+
+How much this matters is visible in the IQ4_XS → UD-Q3_K_XL swap on `Qwen3.8-27B`: a few hundred
+MiB less spill out of VRAM bought a tens-of-percent throughput gain at the same 64K context.
+Exact spill figures, tok/s and dates are in [history.md](history.md).
+
+**Concurrency is explicit for only four entries.** `gpt-oss-120b`, `Nemotron` and `Qwen3.8-27B`
+pin `--parallel` to a single slot; `Qwen2.5-7B` is the one entry that raises it, which it can
+afford precisely because it is CPU-resident and never contends for the GPU. The remaining seven
+leave the flag unset and inherit llama.cpp's default of one.
+
+**Group roles** carry the exclusivity policy that the Mac side gets for free:
+
+| Group | Policy | Purpose |
+|---|---|---|
+| `heavy` | `swap: true`, `exclusive: true` (7 models) | Large models, one loaded at a time |
+| `light` | `swap: false`, `exclusive: true` (2 models) | Small models that need not evict each other on swap |
+| `forever` | `persistent: true`, `exclusive: false` (1 model) | Keeps the judge model loaded permanently |
+
+The Mac config has no `groups:` block at all and relies on llama-swap's default
+single-active-model behavior — with two mutually exclusive backends there is nothing to arbitrate.
+Eleven models contending for one 16 GB GPU is what forces the Windows side to state the policy.
+
+Everything above is a placement decision under a hard VRAM ceiling; the Mac side's equivalents
+are memory-budget decisions under a soft unified-memory ceiling. Benchmark numbers and the dates
+they were taken belong to [history.md](history.md) and are deliberately not repeated here.
+
 ## Thinking control
 
 - ds4 defaults **every** chat request to HIGH thinking.

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,22 @@
-# cc-local-llm installer for Windows (client only)
-# The LiteLLM gateway now runs natively on the Mac, so this host needs client
-# prerequisites only. Mac-side setup (gateway / ds4-server / Laguna S 2.1 /
-# llama-swap) uses install.sh instead.
-# Usage: .\install.ps1
+# cc-local-llm installer for Windows.
+#
+# Two roles. The client role installs the prerequisites this host needs to TALK to a
+# gateway; the server role registers the llama-swap + Caddy services that SERVE one.
+# No switch means -Client, preserving the one-word `.\install.ps1` Windows client users
+# already have in their notes -- install.sh defaults to all instead, and that asymmetry
+# is deliberate: on macOS the same machine is normally both.
+#
+# Usage: .\install.ps1 [-Client | -Server | -All] [-LanIp <ipv4>]
+#        .\install.ps1 -Server -Uninstall
+
+param(
+    [switch]$Server,
+    [switch]$Client,
+    [switch]$All,
+    [switch]$Uninstall,
+    [ValidatePattern('^$|^((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$')]
+    [string]$LanIp = ''
+)
 
 if ($IsWindows -eq $false) {
     Write-Host "Error: install.ps1 must not run on Linux/macOS. Use install.sh instead." -ForegroundColor Red
@@ -15,27 +29,101 @@ $env:SYSTEM_OPS_APPROVED = "1"
 
 $RepoRoot = $PSScriptRoot
 
-Write-Host "=== cc-local-llm installer (Windows, client) ===" -ForegroundColor Cyan
+. "$RepoRoot\install\win\lib\roles.ps1"
+$Role = Resolve-InstallRole -Server:$Server -Client:$Client -All:$All -Uninstall:$Uninstall
 
-Write-Host ""
-Write-Host "--- Retiring obsolete Windows-side LiteLLM artifacts ---"
-& "$RepoRoot\install\win\uninstall-obsolete.ps1"
+# Server-role path literals live here and nowhere else; docs/infrastructure.md mirrors
+# them on its '<!-- synced-from: install.ps1 -->' lines rather than restating them.
+$CertDir = 'C:\LLM\certs\llama-swap'
+$RuntimeDir = 'C:\LLM\llama-swap'
+$ConfigPath = "$RepoRoot\llama-swap\rtx5070ti-128gb\config.yaml"
 
-Write-Host ""
-Write-Host "--- Installing mkcert ---"
-& "$RepoRoot\install\win\mkcert.ps1"
+function Get-LanIPv4 {
+    # The address a LAN client dials, which is the one that must be in the certificate.
+    # Ordered by interface metric so the primary NIC wins on a host with several.
+    $candidates = @(Get-NetIPConfiguration |
+        Where-Object { $_.IPv4DefaultGateway -and $_.IPv4Address } |
+        ForEach-Object { $_.IPv4Address.IPAddress } |
+        Where-Object { $_ -and $_ -ne '127.0.0.1' })
 
-Write-Host ""
-Write-Host "--- Setting up .env ---"
-$EnvPath = "$RepoRoot\.env"
-if (Test-Path $EnvPath) {
-    Write-Host ".env already exists -- leaving it as-is." -ForegroundColor DarkGray
-} else {
-    Copy-Item "$RepoRoot\.env.example" $EnvPath
-    Write-Host "Created .env from .env.example -- fill in LITELLM_ANTHROPIC_BASE_URL / LITELLM_CLIENT_KEY / CCGW_CA_CERT." -ForegroundColor Green
+    if ($candidates.Count -eq 0) {
+        throw "Could not determine this host's LAN IPv4 address. Pass it explicitly: .\install.ps1 -Server -LanIp <address>."
+    }
+    return $candidates[0]
 }
+
+function Install-ClientRole {
+    Write-Host ""
+    Write-Host "--- Retiring obsolete Windows-side LiteLLM artifacts ---"
+    & "$RepoRoot\install\win\uninstall-obsolete.ps1"
+
+    Write-Host ""
+    Write-Host "--- Installing mkcert ---"
+    & "$RepoRoot\install\win\mkcert.ps1"
+
+    Write-Host ""
+    Write-Host "--- Setting up .env ---"
+    $EnvPath = "$RepoRoot\.env"
+    if (Test-Path $EnvPath) {
+        Write-Host ".env already exists -- leaving it as-is." -ForegroundColor DarkGray
+    } else {
+        Copy-Item "$RepoRoot\.env.example" $EnvPath
+        Write-Host "Created .env from .env.example -- fill in LITELLM_ANTHROPIC_BASE_URL / LITELLM_CLIENT_KEY / CCGW_CA_CERT." -ForegroundColor Green
+    }
+}
+
+function Install-ServerRole {
+    $address = if ($LanIp) { $LanIp } else { Get-LanIPv4 }
+    if ($address -notmatch '^((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$') {
+        throw "-LanIp '$LanIp' is not an IPv4 address. It is baked into the certificate SAN list, where a typo only surfaces days later as a client that silently refuses the connection."
+    }
+
+    Write-Host ""
+    Write-Host "--- Installing nssm ---"
+    & "$RepoRoot\install\win\nssm.ps1"
+
+    Write-Host ""
+    Write-Host "--- Installing caddy ---"
+    & "$RepoRoot\install\win\caddy.ps1"
+
+    Write-Host ""
+    Write-Host "--- Installing mkcert ---"
+    & "$RepoRoot\install\win\mkcert.ps1"
+
+    Write-Host ""
+    Write-Host "--- Provisioning certificates ($CertDir) ---"
+    & "$RepoRoot\install\win\certs.ps1" -CertDir $CertDir -SanNames @('localhost', '127.0.0.1', $address)
+
+    Write-Host ""
+    Write-Host "--- Registering the llama-swap and Caddy services ---"
+    & "$RepoRoot\install\win\llama-swap-service.ps1" -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -CertDir $CertDir
+}
+
+function Uninstall-ServerRole {
+    Write-Host ""
+    Write-Host "--- Removing the Caddy and llama-swap services ---"
+    & "$RepoRoot\install\win\llama-swap-service.ps1" -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -CertDir $CertDir -Uninstall
+}
+
+Write-Host "=== cc-local-llm installer (Windows, $Role$(if ($Uninstall) { ', uninstall' })) ===" -ForegroundColor Cyan
+
+if ($Uninstall) {
+    Uninstall-ServerRole
+    Write-Host ""
+    Write-Host "=== Done ===" -ForegroundColor Cyan
+    Write-Host "The certificates in $CertDir and the runtime files in $RuntimeDir were left in place;"
+    Write-Host "delete them by hand if this host is no longer serving models."
+    return
+}
+
+# -All is client-then-server: the server role reuses mkcert, which the client role
+# installs, and an operator watching the output sees the cheap half succeed first.
+if ($Role -eq 'client' -or $Role -eq 'all') { Install-ClientRole }
+if ($Role -eq 'server' -or $Role -eq 'all') { Install-ServerRole }
 
 Write-Host ""
 Write-Host "=== Done ===" -ForegroundColor Cyan
-Write-Host "Remaining steps are interactive (trusting the Mac's root CA, filling in the gateway key)"
-Write-Host "and are documented in docs/ops.md#client-windows."
+if ($Role -eq 'client' -or $Role -eq 'all') {
+    Write-Host "Remaining client steps are interactive (trusting the Mac's root CA, filling in the gateway key)"
+    Write-Host "and are documented in docs/ops.md#client-windows."
+}

--- a/install/win/Caddyfile.template
+++ b/install/win/Caddyfile.template
@@ -1,0 +1,28 @@
+:8443 {
+	tls {{CERT_DIR}}\cert.pem {{CERT_DIR}}\key.pem
+	reverse_proxy localhost:18080
+}
+
+# TLS reverse proxy for Open WebUI (external access via Cloudflare Tunnel)
+:3443 {
+	tls {{CERT_DIR}}\cert.pem {{CERT_DIR}}\key.pem
+	reverse_proxy localhost:3000
+}
+
+# TLS reverse proxy for JudgeClaw (external access via Cloudflare Tunnel)
+:18790 {
+	tls {{CERT_DIR}}\cert.pem {{CERT_DIR}}\key.pem
+	reverse_proxy localhost:18789
+}
+
+# TLS reverse proxy for LangChain API (LAN access)
+:8444 {
+	tls {{CERT_DIR}}\cert.pem {{CERT_DIR}}\key.pem
+	reverse_proxy localhost:8100
+}
+
+# TLS reverse proxy for Langfuse (external access via Cloudflare Tunnel)
+:13443 {
+	tls {{CERT_DIR}}\cert.pem {{CERT_DIR}}\key.pem
+	reverse_proxy localhost:13000
+}

--- a/install/win/caddy.ps1
+++ b/install/win/caddy.ps1
@@ -1,0 +1,26 @@
+# caddy.ps1 - install Caddy, the TLS front end for llama-swap and the other local services.
+#
+# Same idempotence contract as nssm.ps1 (CPR-ORTH): -1978335189 means "already installed".
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$env:SYSTEM_OPS_APPROVED = '1'
+
+. "$PSScriptRoot\lib\native.ps1"
+
+if (Get-Command caddy -ErrorAction SilentlyContinue) {
+    Write-Host "caddy is already installed." -ForegroundColor DarkGray
+    return
+}
+
+Write-Host "Installing caddy..."
+Invoke-Native -FilePath 'winget' `
+    -Arguments @('install', '--exact', '--id', 'CaddyServer.Caddy', '--accept-source-agreements', '--accept-package-agreements') `
+    -AllowExitCodes (-1978335189) `
+    -Context 'caddy installation via winget'
+
+if (-not (Get-Command caddy -ErrorAction SilentlyContinue)) {
+    throw "caddy is still not on PATH after winget reported success. Open a new shell (winget updates PATH for new processes only) and re-run .\install.ps1 -Server."
+}
+
+Write-Host "caddy installed." -ForegroundColor Green

--- a/install/win/certs.ps1
+++ b/install/win/certs.ps1
@@ -1,0 +1,67 @@
+# certs.ps1 - provision the TLS pair Caddy serves on every front-end port.
+#
+# The three states are handled separately on purpose (CPR-SC): a pair that already
+# exists is left untouched, because regenerating it would silently invalidate the
+# copy every LAN client has already trusted; a HALF pair is refused rather than
+# completed, because guessing which half is authoritative is how a cert and a key
+# from two different CAs end up beside each other.
+
+param(
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$CertDir,
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string[]]$SanNames
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$env:SYSTEM_OPS_APPROVED = '1'
+
+. "$PSScriptRoot\lib\native.ps1"
+
+$ipv4 = '^((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$'
+$names = @($SanNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+if ($names.Count -eq 0) {
+    throw "-SanNames is empty; mkcert would produce a certificate valid for nothing."
+}
+if (-not (@($names | Where-Object { $_ -match $ipv4 }).Count)) {
+    throw "-SanNames ($($names -join ', ')) contains no IPv4 address. LAN clients reach this host by address, so a certificate without one is rejected by every one of them."
+}
+
+$certPath = Join-Path $CertDir 'cert.pem'
+$keyPath  = Join-Path $CertDir 'key.pem'
+$hasCert  = Test-Path -LiteralPath $certPath -PathType Leaf
+$hasKey   = Test-Path -LiteralPath $keyPath  -PathType Leaf
+
+if ($hasCert -and $hasKey) {
+    foreach ($p in @($certPath, $keyPath)) {
+        if ((Get-Item -LiteralPath $p).Length -le 0) {
+            throw "$p exists but is empty. Delete both $certPath and $keyPath, then re-run .\install.ps1 -Server."
+        }
+        if (-not ((Get-Content -LiteralPath $p -TotalCount 1) -match '^-----BEGIN ')) {
+            throw "$p is not PEM-encoded. Delete both $certPath and $keyPath, then re-run .\install.ps1 -Server."
+        }
+    }
+    Write-Host "Certificate pair already present in $CertDir -- leaving it as-is." -ForegroundColor DarkGray
+    return
+}
+
+if ($hasCert -or $hasKey) {
+    $present = if ($hasCert) { $certPath } else { $keyPath }
+    $missing = if ($hasCert) { $keyPath } else { $certPath }
+    throw "Found $present but not $missing. Refusing to guess: move or delete $present, then re-run .\install.ps1 -Server to generate a matching pair."
+}
+
+if (-not (Test-Path -LiteralPath $CertDir)) {
+    New-Item -ItemType Directory -Path $CertDir -Force | Out-Null
+}
+
+Write-Host "Generating a certificate for: $($names -join ', ')"
+$caInstallArgs = @('-install')
+$generateArgs  = @('-cert-file', $certPath, '-key-file', $keyPath) + $names
+Invoke-Native -FilePath 'mkcert' -Arguments $caInstallArgs -Context 'mkcert local CA installation'
+Invoke-Native -FilePath 'mkcert' -Arguments $generateArgs -Context 'mkcert certificate generation'
+
+if (-not ((Test-Path -LiteralPath $certPath -PathType Leaf) -and (Test-Path -LiteralPath $keyPath -PathType Leaf))) {
+    throw "mkcert reported success but $certPath / $keyPath were not both written."
+}
+
+Write-Host "Certificate written to $certPath" -ForegroundColor Green

--- a/install/win/lib/native.ps1
+++ b/install/win/lib/native.ps1
@@ -1,0 +1,54 @@
+# native.ps1 - the one place a native (non-PowerShell) command is allowed to run.
+#
+# $ErrorActionPreference = 'Stop' does not catch a native command's non-zero exit, so every
+# native call in this installer goes through Invoke-Native, which closes that gap once for the
+# class (CPR-E2C) instead of once per call site. Exit-code policy, the Win32-vs-bash truncation
+# caution, and why this file holds only function definitions: docs/ops.md "Server (Windows)" ->
+# Native command exit-code policy.
+
+function Invoke-Native {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$FilePath,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string[]]$Arguments,
+        [int[]]$AllowExitCodes = @(),
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Context,
+        [switch]$PassThru
+    )
+
+    $commandLine = "$FilePath $($Arguments -join ' ')"
+
+    # 2>&1 folds the tool's stderr into the captured stream so it can be reported with
+    # the failure. 'Continue' is required for that: under 'Stop' a single stderr line
+    # would be re-raised as a terminating error before the exit code is ever examined,
+    # turning a successful-but-chatty command into a failure.
+    $ErrorActionPreference = 'Continue'
+    $global:LASTEXITCODE = 0
+    $output = & $FilePath @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+
+    $allowed = @(0) + @($AllowExitCodes)
+    if ($allowed -notcontains $exitCode) {
+        $captured = (@($output) | ForEach-Object { "$_" }) -join [Environment]::NewLine
+        $message = "$Context failed: '$commandLine' exited with $exitCode (accepted: $($allowed -join ', '))."
+        if ($captured) { $message = $message + [Environment]::NewLine + $captured }
+        throw $message
+    }
+
+    if ($PassThru) { return $output }
+}
+
+function Invoke-Nssm {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string[]]$Arguments,
+        [int[]]$AllowExitCodes = @(),
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Context,
+        [switch]$PassThru
+    )
+
+    # nssm's non-zero codes differ between builds, so no caller should be blessing them.
+    # The service scripts avoid needing to: they ask Get-Service (a cmdlet, hence no exit
+    # code at all) whether the service exists, and only then call nssm.
+    return Invoke-Native -FilePath 'nssm' -Arguments $Arguments -AllowExitCodes $AllowExitCodes -Context $Context -PassThru:$PassThru
+}

--- a/install/win/lib/nssm-args.ps1
+++ b/install/win/lib/nssm-args.ps1
@@ -1,0 +1,128 @@
+# nssm-args.ps1 - the NSSM setting name/value pairs for the two services, as pure data.
+#
+# Kept apart from llama-swap-service.ps1 so the exact registration a change would produce
+# can be asserted without registering anything. Both builders return the same setting
+# names (CPR-ORTH): the two services are one class, and a rotation policy that reached
+# only one of them is how caddy-stderr.log once grew to 125 MB.
+#
+# Function definitions only -- see native.ps1 for why.
+
+# One default for both services. Splitting it into two literals is precisely the drift
+# the shared-key contract above exists to prevent.
+function Get-DefaultLogRotateBytes {
+    return 10485760
+}
+
+# AppParameters is a single flat string handed to NSSM, which re-splits it on spaces.
+# A path containing a space therefore has to arrive quoted -- and a path without one has
+# to arrive unquoted, or every existing registration's AppParameters changes shape.
+function ConvertTo-NssmArgumentToken {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
+
+    if ($Value -match '\s') { return '"' + $Value + '"' }
+    return $Value
+}
+
+# Mandatory alone still accepts '   ', which would build a service rooted at the
+# filesystem root and only fail hours later, at first start.
+function Assert-NssmPathArgument {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Name
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "$Name must be a non-empty path (got '$Value')."
+    }
+}
+
+# The port in here is the single source for the front-end mapping. NSSM accepts any
+# string, so a typo would surface as a service that registers cleanly and never listens.
+function Assert-NssmListenAddress {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
+
+    if ($Value -notmatch '^\S+:\d{1,5}$') {
+        throw "ListenAddr must be host:port, e.g. 127.0.0.1:18080 (got '$Value')."
+    }
+    $port = [int](@($Value -split ':')[-1])
+    if ($port -lt 1 -or $port -gt 65535) {
+        throw "ListenAddr port must be between 1 and 65535 (got '$Value')."
+    }
+}
+
+# AppRotateOnline matters as much as AppRotateFiles here: both services are resident, so
+# without it nothing rotates until the next reboot.
+function Add-NssmLogRotation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]$Settings,
+        [Parameter(Mandatory)][int]$LogRotateBytes
+    )
+
+    $Settings['AppRotateFiles']  = 1
+    $Settings['AppRotateOnline'] = 1
+    $Settings['AppRotateBytes']  = $LogRotateBytes
+    $Settings['AppStdoutCreationDisposition'] = 4
+    $Settings['AppStderrCreationDisposition'] = 4
+}
+
+function Get-LlamaSwapNssmSettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$RuntimeDir,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$ConfigPath,
+        [string]$ListenAddr = '127.0.0.1:18080',
+        [ValidateRange(1, 2147483647)][int]$LogRotateBytes = (Get-DefaultLogRotateBytes)
+    )
+
+    Assert-NssmPathArgument -Value $RuntimeDir -Name 'RuntimeDir'
+    Assert-NssmPathArgument -Value $ConfigPath -Name 'ConfigPath'
+    Assert-NssmListenAddress -Value $ListenAddr
+
+    # ConfigPath is the one input that lives outside RuntimeDir: it is the repo's
+    # llama-swap/rtx5070ti-128gb/config.yaml, while the exe and the logs stay on the host.
+    $settings = [ordered]@{
+        Application   = (Join-Path $RuntimeDir 'llama-swap.exe')
+        AppParameters = "--config $(ConvertTo-NssmArgumentToken $ConfigPath) --listen $ListenAddr --watch-config"
+        AppDirectory  = $RuntimeDir
+        Start         = 'SERVICE_AUTO_START'
+        DisplayName   = 'llama-swap LLM Model Server'
+        Description   = 'LLM model switching server for local inference'
+        AppStdout     = (Join-Path $RuntimeDir 'service-stdout.log')
+        AppStderr     = (Join-Path $RuntimeDir 'service-stderr.log')
+    }
+    Add-NssmLogRotation -Settings $settings -LogRotateBytes $LogRotateBytes
+    return $settings
+}
+
+function Get-CaddyNssmSettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$RuntimeDir,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$CaddyExe,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Caddyfile,
+        [ValidateRange(1, 2147483647)][int]$LogRotateBytes = (Get-DefaultLogRotateBytes)
+    )
+
+    Assert-NssmPathArgument -Value $RuntimeDir -Name 'RuntimeDir'
+    Assert-NssmPathArgument -Value $CaddyExe  -Name 'CaddyExe'
+    Assert-NssmPathArgument -Value $Caddyfile -Name 'Caddyfile'
+
+    # Caddy fronts far more than llama-swap (Open WebUI, JudgeClaw, LangChain, Langfuse),
+    # which is why it runs as its own service with its own log pair rather than sharing.
+    $settings = [ordered]@{
+        Application   = $CaddyExe
+        AppParameters = "run --config $(ConvertTo-NssmArgumentToken $Caddyfile) --adapter caddyfile"
+        AppDirectory  = $RuntimeDir
+        Start         = 'SERVICE_AUTO_START'
+        DisplayName   = 'llama-swap Caddy TLS Proxy'
+        Description   = 'TLS reverse proxy for llama-swap and the other local HTTP services'
+        AppStdout     = (Join-Path $RuntimeDir 'caddy-stdout.log')
+        AppStderr     = (Join-Path $RuntimeDir 'caddy-stderr.log')
+    }
+    Add-NssmLogRotation -Settings $settings -LogRotateBytes $LogRotateBytes
+    return $settings
+}

--- a/install/win/lib/roles.ps1
+++ b/install/win/lib/roles.ps1
@@ -1,0 +1,38 @@
+# roles.ps1 - which role install.ps1 was asked to install, and whether the ask is coherent.
+#
+# The role switches are mutually exclusive, the same way install.sh's case statement
+# accepts a single token. -Uninstall has exactly one meaningful target, because server
+# is the only role that leaves persistent state (two NSSM registrations) behind; every
+# other reading of it would be a guess at a destructive operation, so it is refused.
+#
+# Function definitions only -- see native.ps1 for why.
+
+function Resolve-InstallRole {
+    [CmdletBinding()]
+    param(
+        [switch]$Server,
+        [switch]$Client,
+        [switch]$All,
+        [switch]$Uninstall
+    )
+
+    $picked = @()
+    if ($Server) { $picked += 'server' }
+    if ($Client) { $picked += 'client' }
+    if ($All)    { $picked += 'all' }
+
+    if ($picked.Count -gt 1) {
+        throw "Choose one role: -Server, -Client or -All (got $($picked -join ' + ')). -All already runs the client role before the server role."
+    }
+
+    # No role switch means client, preserving the one-word `.\install.ps1` that Windows
+    # client users already have in their notes. macOS defaults to all instead; the
+    # asymmetry is deliberate and is named in install.ps1's header.
+    $role = if ($picked.Count -eq 1) { $picked[0] } else { 'client' }
+
+    if ($Uninstall -and $role -ne 'server') {
+        throw "-Uninstall is only defined for the server role; use: .\install.ps1 -Server -Uninstall. The client role installs no service and leaves nothing to remove, and the reverse of -All is not a single well-defined operation."
+    }
+
+    return $role
+}

--- a/install/win/llama-swap-service.ps1
+++ b/install/win/llama-swap-service.ps1
@@ -1,0 +1,222 @@
+# llama-swap-service.ps1 - register (or remove) the llama-swap and Caddy NSSM services.
+#
+# RuntimeDir / ConfigPath / CertDir are explicit and Mandatory because the three used to
+# be one assumption: config.yaml living beside llama-swap.exe. It no longer does -- the
+# config is a checked-out file and the certificates are host state -- so a default here
+# would quietly re-create the assumption it replaced.
+#
+# Every precondition is checked before the first registration: a service that installs
+# and then fails to start leaves an operator with two half-states to unpick instead of
+# one clear message.
+
+param(
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$RuntimeDir,
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$ConfigPath,
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$CertDir,
+    [ValidateNotNullOrEmpty()][string]$CaddyfileTemplate = "$PSScriptRoot\Caddyfile.template",
+    [ValidateNotNullOrEmpty()][string]$ListenAddr = '127.0.0.1:18080',
+    [ValidateRange(1, 2147483647)][int]$LogRotateBytes = 0,
+    [switch]$Uninstall
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$env:SYSTEM_OPS_APPROVED = '1'
+
+. "$PSScriptRoot\lib\native.ps1"
+. "$PSScriptRoot\lib\nssm-args.ps1"
+
+# ValidateRange rejects an explicit 0; an unbound parameter never reaches it, so the
+# untouched default is where the shared SSOT value is picked up.
+if ($LogRotateBytes -le 0) { $LogRotateBytes = Get-DefaultLogRotateBytes }
+
+$CaddyfilePath = Join-Path $RuntimeDir 'Caddyfile'
+$ListenPort    = [int](@($ListenAddr -split ':')[-1])
+
+function Get-CaddyFrontPorts {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return @() }
+    return @(Select-String -LiteralPath $Path -Pattern '^\s*:(\d+)\s*\{' |
+        ForEach-Object { [int]$_.Matches[0].Groups[1].Value })
+}
+
+function Test-ScmRegistration {
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$QueryOutput)
+
+    return (@($QueryOutput | Where-Object { "$_" -match 'SERVICE_NAME|STATE' }).Count -gt 0)
+}
+
+function Register-NssmService {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)]$Settings
+    )
+
+    # Get-Service is a cmdlet, so it reports absence without an exit code -- which is
+    # why no nssm call site in this file needs a non-zero code blessed.
+    $existing = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if ($existing) {
+        Write-Host "Reconfiguring existing service '$Name'..."
+        if ($existing.Status -ne 'Stopped') {
+            Stop-Service -Name $Name -Force
+            (Get-Service -Name $Name).WaitForStatus('Stopped', [TimeSpan]::FromSeconds(30))
+        }
+    } else {
+        Write-Host "Installing service '$Name'..."
+        Invoke-Nssm -Arguments @('install', $Name, $Settings['Application']) -Context "nssm install of '$Name'"
+    }
+
+    foreach ($key in @($Settings.Keys)) {
+        $setArgs = @('set', $Name, $key, "$($Settings[$key])")
+        Invoke-Nssm -Arguments $setArgs -Context "nssm set of $Name $key"
+    }
+
+    Start-Service -Name $Name
+    (Get-Service -Name $Name).WaitForStatus('Running', [TimeSpan]::FromSeconds(60))
+}
+
+function Remove-NssmService {
+    param([Parameter(Mandatory)][string]$Name)
+
+    if (-not (Get-Service -Name $Name -ErrorAction SilentlyContinue)) { return }
+    Write-Host "Removing service '$Name'..."
+    Stop-Service -Name $Name -Force -ErrorAction SilentlyContinue
+    Invoke-Nssm -Arguments @('remove', $Name, 'confirm') -Context "nssm remove of '$Name'"
+}
+
+function Remove-PortZombie {
+    param(
+        [Parameter(Mandatory)][int]$Port,
+        [Parameter(Mandatory)][string[]]$ExpectedImagePaths
+    )
+
+    # A process that outlived its service keeps the port, and the next start then fails
+    # with a bind error that names nothing. Get-NetTCPConnection answers "who holds it",
+    # which an exit code from a listing tool cannot: no match and never looked both exit 0.
+    $listeners = @(Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue)
+    foreach ($listener in $listeners) {
+        $ownerPid = [int]$listener.OwningProcess
+        if ($ownerPid -le 4) { continue }
+
+        # The port is the symptom, not the identity: anything else may have taken it in
+        # the meantime, so only our own two images are killable and unknown never matches.
+        $image = $null
+        try {
+            $owner = Get-Process -Id $ownerPid -ErrorAction SilentlyContinue
+            if ($owner) { $image = $owner.Path }
+        } catch {
+            $image = $null
+        }
+        if ((-not $image) -or ($ExpectedImagePaths -notcontains $image)) {
+            $shown = if ($image) { $image } else { 'unknown' }
+            Write-Warning "PID $ownerPid ($shown) is listening on :$Port but is neither llama-swap nor Caddy; leaving it running, so :$Port stays bound."
+            continue
+        }
+
+        Write-Host "Killing leftover process $ownerPid still listening on :$Port"
+        Invoke-Native -FilePath 'taskkill' -Arguments @('/f', '/pid', "$ownerPid") `
+            -AllowExitCodes 128 -Context "taskkill of the process holding :$Port"
+    }
+}
+
+if ($Uninstall) {
+    # Caddy first: it is the front end, so removing it stops new traffic reaching a
+    # llama-swap that is about to disappear.
+    Remove-NssmService -Name 'llama-swap-caddy'
+    Remove-NssmService -Name 'llama-swap'
+
+    # The SCM addresses a service by name, so each sweep is spelled out rather than
+    # looped: 1060 ("no such service") is the answer both calls are hoping for.
+    $caddyGhost = @(Invoke-Native -FilePath 'sc.exe' -Arguments @('query', 'llama-swap-caddy') `
+        -AllowExitCodes 1060 -Context "SCM registration check for 'llama-swap-caddy'" -PassThru)
+    if (Test-ScmRegistration -QueryOutput $caddyGhost) {
+        Invoke-Native -FilePath 'sc.exe' -Arguments @('delete', 'llama-swap-caddy') `
+            -AllowExitCodes 1060 -Context "sc delete of 'llama-swap-caddy'"
+    }
+
+    $swapGhost = @(Invoke-Native -FilePath 'sc.exe' -Arguments @('query', 'llama-swap') `
+        -AllowExitCodes 1060 -Context "SCM registration check for 'llama-swap'" -PassThru)
+    if (Test-ScmRegistration -QueryOutput $swapGhost) {
+        Invoke-Native -FilePath 'sc.exe' -Arguments @('delete', 'llama-swap') `
+            -AllowExitCodes 1060 -Context "sc delete of 'llama-swap'"
+    }
+
+    $exePath  = Join-Path $RuntimeDir 'llama-swap.exe'
+    $caddyCmd = Get-Command caddy -ErrorAction SilentlyContinue
+    $killable = @($exePath)
+    if ($caddyCmd) { $killable += $caddyCmd.Source }
+
+    foreach ($port in (@($ListenPort) + (Get-CaddyFrontPorts -Path $CaddyfilePath))) {
+        Remove-PortZombie -Port $port -ExpectedImagePaths $killable
+    }
+
+    foreach ($name in @('llama-swap', 'llama-swap-caddy')) {
+        if (Get-Service -Name $name -ErrorAction SilentlyContinue) {
+            Write-Warning "'$name' is still registered. An open Services.msc or Event Viewer window keeps the handle alive; close it and reboot to complete the delete."
+        }
+    }
+
+    Write-Host "Both services removed." -ForegroundColor Green
+    return
+}
+
+$exePath  = Join-Path $RuntimeDir 'llama-swap.exe'
+$certPath = Join-Path $CertDir 'cert.pem'
+$keyPath  = Join-Path $CertDir 'key.pem'
+
+if (-not (Test-Path -LiteralPath $exePath -PathType Leaf)) {
+    throw "llama-swap.exe not found at $exePath. Download the Windows release into $RuntimeDir, then re-run .\install.ps1 -Server."
+}
+if (-not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) {
+    throw "config.yaml not found at $ConfigPath. The config lives in the checkout, not beside the exe."
+}
+foreach ($pem in @($certPath, $keyPath)) {
+    if (-not (Test-Path -LiteralPath $pem -PathType Leaf)) {
+        throw "$pem not found. Run install/win/certs.ps1 (install.ps1 -Server does this) before registering the services."
+    }
+}
+if (-not (Test-Path -LiteralPath $CaddyfileTemplate -PathType Leaf)) {
+    throw "Caddyfile template not found at $CaddyfileTemplate."
+}
+$caddyCommand = Get-Command caddy -ErrorAction SilentlyContinue
+if (-not $caddyCommand) {
+    throw "caddy is not on PATH. Run install/win/caddy.ps1 first, then open a new shell."
+}
+
+$rendered = (Get-Content -LiteralPath $CaddyfileTemplate -Raw).Replace('{{CERT_DIR}}', $CertDir)
+if ($rendered -match '\{\{[A-Za-z0-9_]+\}\}') {
+    throw "$CaddyfileTemplate carries a placeholder this script does not substitute; caddy would receive it verbatim."
+}
+Set-Content -LiteralPath $CaddyfilePath -Value $rendered -Encoding utf8
+Write-Host "Wrote $CaddyfilePath"
+
+Register-NssmService -Name 'llama-swap' -Settings (
+    Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath `
+        -ListenAddr $ListenAddr -LogRotateBytes $LogRotateBytes)
+
+Register-NssmService -Name 'llama-swap-caddy' -Settings (
+    Get-CaddyNssmSettings -RuntimeDir $RuntimeDir -CaddyExe $caddyCommand.Source `
+        -Caddyfile $CaddyfilePath -LogRotateBytes $LogRotateBytes)
+
+foreach ($name in @('llama-swap', 'llama-swap-caddy')) {
+    $status = (Get-Service -Name $name).Status
+    if ($status -ne 'Running') {
+        throw "'$name' registered but is $status. Check $RuntimeDir for its *-stderr.log."
+    }
+}
+
+# A running service that never bound its port is the failure mode NSSM hides: the
+# process restarts on a loop while the service still reports Running.
+foreach ($port in (@($ListenPort) + (Get-CaddyFrontPorts -Path $CaddyfilePath))) {
+    $deadline = (Get-Date).AddSeconds(30)
+    while (-not (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue)) {
+        if ((Get-Date) -gt $deadline) {
+            throw "Nothing is listening on :$port after 30s. Check $RuntimeDir for the service logs."
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    Write-Host "  ok: listening on :$port" -ForegroundColor DarkGray
+}
+
+Write-Host "llama-swap and Caddy are registered and running." -ForegroundColor Green

--- a/install/win/mkcert.ps1
+++ b/install/win/mkcert.ps1
@@ -1,23 +1,28 @@
 # mkcert.ps1 - Install mkcert (local TLS CA), used to sign the CCGW Proxy and LiteLLM certs
+#
+# winget and mkcert run through Invoke-Native for the same reason every other native
+# command here does: $ErrorActionPreference does not turn their non-zero exits into
+# errors. -1978335189 (0x8A15002B) is winget's "already installed", which is success.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $env:SYSTEM_OPS_APPROVED = "1"
 
+. "$PSScriptRoot\lib\native.ps1"
+
 if (Get-Command mkcert -ErrorAction SilentlyContinue) {
-    Write-Host "mkcert is already installed: $(mkcert -version)" -ForegroundColor DarkGray
+    Write-Host "mkcert is already installed: $((Get-Command mkcert).Source)" -ForegroundColor DarkGray
     return
 }
 
 Write-Host "Installing mkcert..."
-winget install FiloSottile.mkcert --accept-source-agreements --accept-package-agreements
-if ($LASTEXITCODE -ne 0) {
-    if (Get-Command mkcert -ErrorAction SilentlyContinue) {
-        Write-Host "mkcert already present (winget returned $LASTEXITCODE)." -ForegroundColor DarkGray
-    } else {
-        Write-Warning "mkcert installation failed (exit code $LASTEXITCODE). Re-run install.ps1 to retry."
-        exit 1
-    }
-} else {
-    Write-Host "mkcert installed: $(mkcert -version)" -ForegroundColor Green
+Invoke-Native -FilePath 'winget' `
+    -Arguments @('install', '--exact', '--id', 'FiloSottile.mkcert', '--accept-source-agreements', '--accept-package-agreements') `
+    -AllowExitCodes (-1978335189) `
+    -Context 'mkcert installation via winget'
+
+if (-not (Get-Command mkcert -ErrorAction SilentlyContinue)) {
+    throw "mkcert is still not on PATH after winget reported success. Open a new shell (winget updates PATH for new processes only) and re-run .\install.ps1."
 }
+
+Write-Host "mkcert installed: $((Get-Command mkcert).Source)" -ForegroundColor Green

--- a/install/win/nssm.ps1
+++ b/install/win/nssm.ps1
@@ -1,0 +1,27 @@
+# nssm.ps1 - install NSSM, the service manager both llama-swap services run under.
+#
+# Idempotent: winget reports "already installed" as -1978335189 (0x8A15002B), which is
+# the outcome a re-run of the installer wants, so it is the one non-zero code allowed here.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$env:SYSTEM_OPS_APPROVED = '1'
+
+. "$PSScriptRoot\lib\native.ps1"
+
+if (Get-Command nssm -ErrorAction SilentlyContinue) {
+    Write-Host "nssm is already installed." -ForegroundColor DarkGray
+    return
+}
+
+Write-Host "Installing nssm..."
+Invoke-Native -FilePath 'winget' `
+    -Arguments @('install', '--exact', '--id', 'NSSM.NSSM', '--accept-source-agreements', '--accept-package-agreements') `
+    -AllowExitCodes (-1978335189) `
+    -Context 'nssm installation via winget'
+
+if (-not (Get-Command nssm -ErrorAction SilentlyContinue)) {
+    throw "nssm is still not on PATH after winget reported success. Open a new shell (winget updates PATH for new processes only) and re-run .\install.ps1 -Server."
+}
+
+Write-Host "nssm installed." -ForegroundColor Green

--- a/llama-swap/README.md
+++ b/llama-swap/README.md
@@ -13,6 +13,14 @@ The memory belongs in the name because every value in these configs is derived f
 weights, context length, KV budget, `concurrencyLimit`. Replacing the hardware forces a
 rename, which is the intent: a changed ceiling should not pass silently.
 
-The Mac serves `m5-max-128gb/` only (`LLAMA_SWAP_ROOT` in
-[../scripts/lib/paths.sh](../scripts/lib/paths.sh)). The Windows directory is kept here
-for side-by-side review; that host runs its own llama-swap.
+Both directories are served from here, by different mechanisms. The Mac resolves
+`m5-max-128gb/` through `LLAMA_SWAP_ROOT` in
+[../scripts/lib/paths.sh](../scripts/lib/paths.sh). The Windows host's llama-swap service
+reads `rtx5070ti-128gb/config.yaml` directly, because NSSM burns the path into the
+service's `--config` argument at registration time; `install.ps1 -Server` is what registers
+it. Neither path is spelled out here — see [../docs/infrastructure.md](../docs/infrastructure.md).
+
+Windows carries 14 annotations against 11 models. Three keys that left `config.yaml` are kept
+with a `retained:` reason because the judgement behind them is still consulted. The Mac side
+is 1:1 not because a different rule applies to it, but because it happens to have no expired
+annotation worth keeping — the rule itself is in [../CLAUDE.md](../CLAUDE.md).

--- a/llama-swap/rtx5070ti-128gb/config.yaml
+++ b/llama-swap/rtx5070ti-128gb/config.yaml
@@ -1,0 +1,127 @@
+healthCheckTimeout: 120
+logLevel: info
+models:
+  gpt-oss-120b-MXFP4:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\lmstudio-community\gpt-oss-120b-GGUF\gpt-oss-120b-MXFP4-00001-of-00002.gguf
+        --cache-type-k q8_0 --cache-type-v q8_0 --ctx-size 8192 --flash-attn on --jinja --n-cpu-moe 29
+        --no-mmap --parallel 1 --prio 2 -b 5728 -ngl 58 -t 20 -ub 3923
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 900
+  gpt-oss-20b-MXFP4:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\lmstudio-community\gpt-oss-20b-GGUF\gpt-oss-20b-MXFP4.gguf
+        --flash-attn on --override-tensor "blk\.(6[0-9]|7[0-9])\.ffn_.*_exps\.=CPU" -b 4976 -ngl 33 -t 18
+        -ub 6051
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Qwen2.5-7B-Instruct-Q4_K_M:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\lmstudio-community\Qwen2.5-7B-Instruct-GGUF\Qwen2.5-7B-Instruct-Q4_K_M.gguf
+        --ctx-size 16384 --flash-attn on --override-tensor "blk\.\d+\.ffn_.*_exps\.=CPU" --parallel 4
+        -b 9696 -ngl 0 -t 8 -ub 7915 --device none
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  NVIDIA-Nemotron-Nano-9B-v2-Japanese-Q8_0:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\mmnga-o\NVIDIA-Nemotron-Nano-9B-v2-Japanese-gguf\NVIDIA-Nemotron-Nano-9B-v2-Japanese-Q8_0.gguf
+        --ctx-size 16384 --flash-attn on --parallel 1
+        -ngl 99 -t 8
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Llama-3-ELYZA-JP-8B-q4_k_m:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\elyza\Llama-3-ELYZA-JP-8B-GGUF\Llama-3-ELYZA-JP-8B-q4_k_m.gguf
+        --flash-attn on --override-tensor "blk\.\d+\.ffn_down_exps\.=CPU" -b 9571 -ngl 145 -t 3 -ub 4643
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Lumimaid-v0.2-12B.q4_k_m:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\NeverSleep\Lumimaid-v0.2-12B-GGUF\Lumimaid-v0.2-12B.q4_k_m.gguf
+        --flash-attn on --override-tensor "blk\.(6|7|8|9|[1-9][0-9]+)\.ffn_.*_exps\.=CPU" -b 10105
+        -ngl 125 -t 17 -ub 2715
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Qwen3.5-27B-IQ3_M:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\bartowski\Qwen_Qwen3.5-27B-GGUF\Qwen_Qwen3.5-27B-IQ3_M.gguf
+        --ctx-size 32768 --flash-attn on --jinja -ctk q4_0 -ctv q4_0 -ngl 121 -t 10
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Devstral-Small-2-24B-Instruct-2512-IQ4_XS:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\unsloth\Devstral-Small-2-24B-Instruct-2512-GGUF\Devstral-Small-2-24B-Instruct-2512-IQ4_XS.gguf
+        --ctx-size 65536 --flash-attn on --jinja -b 7687 -ctk q4_0 -ctv q4_0 -ngl 95 -t 15 -ub 617
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Qwen3-Coder-Next-Q4_K_M:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\lmstudio-community\Qwen3-Coder-Next-GGUF\Qwen3-Coder-Next-Q4_K_M.gguf
+        --ctx-size 32768 -b 12340 -ctk q4_0 -ctv q4_0 -ngl 127 -t 17 -ub 1333
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\unsloth\Qwen3-Coder-30B-A3B-Instruct-GGUF\Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL.gguf
+        --ctx-size 65536 --flash-attn on --jinja --n-cpu-moe 20
+        --override-tensor "blk\.(6[0-9]|7[0-9])\.ffn_.*_exps\.=CPU" -b 2500 -ctk q4_0 -ctv q4_0 -ngl 147
+        -t 13 -ub 3138
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+  Qwen3.8-27B-UD-Q3_K_XL:
+    cmd: |-
+      C:\LLM\llama.cpp\build\bin\Release\llama-server.exe
+        --host 127.0.0.1 --port ${PORT}
+        --model C:\LLM\models\unsloth\Qwen3.8-27B-GGUF\Qwen3.8-27B-UD-Q3_K_XL.gguf
+        --ctx-size 65536 --flash-attn on --parallel 1 --no-mmproj
+        --spec-type draft-mtp --spec-draft-n-max 2
+        --jinja --chat-template-file C:\LLM\models\unsloth\Qwen3.8-27B-GGUF\chat_template.jinja
+        --reasoning-format deepseek --reasoning-preserve
+        --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0
+        -ctk q4_0 -ctv q4_0 -ngl 999 -t 10
+    proxy: http://127.0.0.1:${PORT}
+    ttl: 600
+groups:
+  heavy:
+    swap: true
+    exclusive: true
+    members:
+    - gpt-oss-120b-MXFP4
+    - gpt-oss-20b-MXFP4
+    - Qwen3.5-27B-IQ3_M
+    - Qwen3-Coder-Next-Q4_K_M
+    - Devstral-Small-2-24B-Instruct-2512-IQ4_XS
+    - Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL
+    - Qwen3.8-27B-UD-Q3_K_XL
+  light:
+    swap: false
+    exclusive: true
+    members:
+    - Llama-3-ELYZA-JP-8B-q4_k_m
+    - Lumimaid-v0.2-12B.q4_k_m
+  forever:
+    persistent: true
+    swap: false
+    exclusive: false
+    members:
+    - Qwen2.5-7B-Instruct-Q4_K_M

--- a/llama-swap/rtx5070ti-128gb/model-annotations.yaml
+++ b/llama-swap/rtx5070ti-128gb/model-annotations.yaml
@@ -1,0 +1,100 @@
+# Model annotations for the config.yaml in this directory (Windows backend).
+# Maintained alongside it -- see CLAUDE.md. Same format as the Mac host's own
+# llama-swap annotations, plus the `optimizer:` key: llama-swap-optimizer tunes
+# llama.cpp flags (-ngl, --n-cpu-moe) and needs to be told which entries to leave
+# alone. Sizing derivations live in docs/tuning.md and the measured numbers in
+# docs/history.md, not here.
+
+gpt-oss-120b-MXFP4:
+  role: general
+  used_by: []
+  notes: "largest model, ctx 8192, KV cache Q8"
+
+gpt-oss-20b-MXFP4:
+  role: general
+  used_by: []
+  notes: ""
+
+Qwen2.5-7B-Instruct-Q4_K_M:
+  role: judge
+  used_by:
+    - langchain-stack (judge)
+    - judgeclaw (judge)
+  notes: "CPU resident (-ngl 0, --device none), forever group, ctx 16384"
+  decision: "CPU-resident to avoid VRAM contention. Rejected the optimizer's result (ngl 136, 149 tok/s)."
+  optimizer: skip
+
+NVIDIA-Nemotron-Nano-9B-v2-Japanese-Q8_0:
+  role: general
+  used_by: []
+  notes: "ctx 16384"
+  decision: "Was a candidate agent model for <private-agent-project>, but rejected due to the <SPECIAL_12> issue."
+  optimizer: lock
+
+Llama-3-ELYZA-JP-8B-q4_k_m:
+  role: general
+  used_by: []
+  notes: "Japanese specialized"
+
+Lumimaid-v0.2-12B.q4_k_m:
+  role: general
+  used_by: []
+  notes: ""
+
+Devstral-Small-2-24B-Instruct-2512-IQ4_XS:
+  role: haiku-tier (Claude Code LiteLLM)
+  used_by:
+    - cc-local-llm (LiteLLM haiku tier, model name Devstral-Small-2-24B-Instruct-2512-IQ4_XS)
+  notes: "dense 24B, ctx 65536, KV cache Q4, heavy group, --jinja required (works around the Llama 3.1 template's role-alternation check)"
+  decision: "2026-08: ctx 32768 -> 65536, light -> heavy group. Migrated the haiku/sonnet tiers from the Mac to this PC's llama-swap as part of moving the gateway's local LLM off Mac; extended to 64K ctx since that's now a hard requirement. Re-search of ngl via the optimizer planned. 2026-08-08: added --jinja (fixes a bug where, after LiteLLM's conversion, consecutive user messages in tool conversations tripped the role-alternation check and returned 500). The optimizer keeps --jinja under BOOLEAN_FLAGS -- do not remove it manually."
+
+Qwen3-Coder-Next-Q4_K_M:
+  role: general (reasoner, dense 46B)
+  used_by: []
+  notes: "ctx 32768, KV cache Q4, heavy group. Dense 46B doesn't fit in 16GB VRAM, so it's slow (CPU bound)."
+  decision: "2026-08: handed off the sonnet-tier role to Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL (MoE). Reason: dense 46B can't hold a 64K ctx in 16GB VRAM without slowing down, so switched to a similarly-capable MoE model that fits in VRAM."
+
+Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL:
+  role: sonnet-tier (Claude Code LiteLLM)
+  used_by:
+    - cc-local-llm (LiteLLM sonnet tier, model name Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL)
+  notes: "MoE 30B total / 3B active, ctx 65536, KV cache Q4 (4 KV heads x 128 head_dim x 48 layers ≈ 1.5GB @ 64K), --n-cpu-moe 20 offloads 20/48 expert layers to CPU, heavy group"
+  decision: "2026-08: built the sonnet-tier fresh on this PC's llama-swap ahead of removing the local LLM on the Mac (M4 Pro). 64K ctx is a hard requirement; using the unsloth GGUF source (UD-Q4_K_XL, per-tensor dynamic quant, 17.67GB). -ngl / --n-cpu-moe are initial values pending re-search by the optimizer (--n-cpu-moe is outside the optimizer's scope, so it may need manual tuning)."
+
+Qwen3.8-27B-UD-Q3_K_XL:
+  role: coding agent (Claude Code backend) — evaluation
+  used_by: []
+  notes: "dense 27B, ctx 65536, KV cache Q4, flash-attn, heavy group. Uses native MTP (--spec-type draft-mtp --spec-draft-n-max 2, no external draft model needed); coding-only, so --no-mmproj drops the vision projector from GPU (--mmproj-auto defaults ON). Chat template is supplied externally rather than the one embedded in the GGUF (froggeric v22.4, same directory as the model)."
+  decision: "2026-08: added as a coding-agent candidate for the RTX 5070 Ti 16GB. Worked around the mid-conversation system-message 500 error in Claude Code (a chat-template bug independent of quant) with an external chat template. Initially used UD-IQ4_XS (13,593 MiB), but at 64K it was short about 426 MiB of VRAM and spilled into system RAM, causing a 30% slowdown (32K 79-82 tok/s -> 64K 55.4 tok/s), so it was pinned to 32K. 2026-08-28: since 64K is now a hard requirement, replaced it with the 1,056 MiB lighter UD-Q3_K_XL (12,537 MiB). At 64K the spill dropped from 873 to 305 MiB and throughput reached 90.6 tok/s, beating even IQ4_XS's own 32K number, so IQ4_XS was retired. MTP draft acceptance rate (0.845, 125/148) matches IQ4_XS, so no draft-quality degradation was observed from the drop to 3-bit. Coding-task accuracy itself is still unverified, though. Locked because every parameter is set manually (the optimizer doesn't recognize --spec-type / --chat-template-file)."
+  optimizer: lock
+
+Qwen3.5-27B-IQ3_M:
+  role: reasoner / agent
+  used_by:
+    - langchain-stack (reasoner)
+    - <private-agent-project> (agent)
+    - judgeclaw (agent)
+  notes: "ctx 32768, KV cache Q4, flash-attn"
+  decision: "Gave up on Nemotron-Nano -> standardized on this model (2026-03)"
+  optimizer: lock
+
+Qwen3.5-27B-Q4_K_M:
+  role: reasoner (evaluation)
+  used_by: []
+  notes: "ctx 16384, KV cache Q8, ngl 57 (half CPU offload)"
+  decision: "IQ3_M (47.4 tok/s) -> Q4_K_M (14.6 tok/s) is 3x slower. Q4 isn't worth it on 16GB VRAM -- rejected. Sticking with IQ3_M."
+  retained: "This is the reason the active IQ3_M was chosen. Consulted every time a decision comes up to replace IQ3_M with a different quant."
+
+gemma-4-26B-A4B-it-IQ4_XS:
+  role: reasoner (evaluation)
+  used_by: []
+  notes: "MoE 25.2B total / 3.8B active, ctx 16384, thinking mode"
+  decision: "llama-bench reports 165.8 tok/s but real-world use is 18.5 tok/s (11% of benchmark). Waiting on llama.cpp's Gemma 4 optimization."
+  retained: "Re-evaluate once llama.cpp's Gemma 4 optimization lands. This is the measured baseline that decision will start from."
+
+gemma-4-26B-A4B-it-Q4_K_M:
+  role: reasoner (evaluation)
+  used_by: []
+  notes: "MoE 25.2B total / 3.8B active, ctx 16384, thinking mode"
+  decision: "optimizer reports 58.4 tok/s, but real-world use is expected to be slow too. Waiting on llama.cpp optimization, same as IQ4_XS."
+  retained: "Re-evaluate together with IQ4_XS. Kept as the comparison material for deciding between the two."

--- a/scripts/set-model.sh
+++ b/scripts/set-model.sh
@@ -6,7 +6,9 @@
 # writes both off one bare model-key and restarts litellm-server.
 #
 # Only fable/opus keys are enumerable here (llama-swap/m5-max-128gb/config.yaml); haiku and
-# sonnet live on the Windows instance -- see docs/infrastructure.md.
+# sonnet run on the Windows llama-swap instance, whose config lives in this repo at
+# llama-swap/rtx5070ti-128gb/config.yaml but is not what this script edits -- this script
+# operates on the Mac-side tiers only. See docs/infrastructure.md.
 set -eu
 
 CCGW_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
@@ -46,9 +48,10 @@ Tiers: haiku, sonnet, fable, opus
 
 --list with no tier shows all four; --list <tier> shows just that one.
 fable/opus choices are read live from $(_display_path "$LLAMA_SWAP_CONFIG").
-haiku/sonnet run on the Windows llama-swap instance, whose config.yaml is
-not in this repo -- only the currently-configured backend can be shown for
-those two, not the full choice list, and its provider shape isn't verified.
+haiku/sonnet run on the Windows llama-swap instance, whose config.yaml lives
+in this repo at llama-swap/rtx5070ti-128gb/config.yaml -- but this script only
+operates on the Mac-side tiers, so for those two it shows the currently-configured
+backend rather than the full choice list, and its provider shape isn't verified.
 
 Edits $(_display_path "$LITELLM_CONFIG") (litellm_params.model, keeping the
 existing provider prefix) and $(_display_path "$DOTENV_FILE") (LITELLM_<TIER>_MODEL,
@@ -129,7 +132,7 @@ _list_tier() {
     _lt_value="${_lt_line#*model: }"
     case "$_lt_tier" in
         haiku|sonnet)
-            echo "$_lt_tier   (Windows llama-swap; not enumerable from this repo -- check its config.yaml on the Windows PC, see docs/infrastructure.md)"
+            echo "$_lt_tier   (Windows llama-swap: llama-swap/rtx5070ti-128gb/config.yaml in this repo; not enumerated here -- this script edits the Mac-side tiers only, see docs/infrastructure.md)"
             echo "  current backend: ${_lt_value:-(unknown)}"
             ;;
         fable|opus)

--- a/tests/feature-86-win-llama-swap-server/TL3-installer-llama-cpp-build.sh
+++ b/tests/feature-86-win-llama-swap-server/TL3-installer-llama-cpp-build.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Tests: llama-swap/rtx5070ti-128gb/config.yaml
+# Tags: llama-cpp, cuda, windows, host-state, run-tl3, layer:TL3, scope:common
+# scope:common and deliberately WITHOUT an issue number in the filename: retirement policies key on feature-<N> names and would delete this permanent host-state coverage when #86 closes.
+# Successor to the migration-source tests/main-llama-cpp-build.sh: only its two surviving phases are kept -- the CUDA build artifacts, plus a new check that every path the migrated config.yaml references really exists on this host. The other four phases asserted on a one-way migration that already completed (detail plan 6-6).
+# Gated: exit 77 unless RUN_TL3=on, the host is Windows, and the config exists.
+# What only this tier can see (the reason the TL2 siblings are not enough):
+# - test-config-annotations-parity.sh proves the config is well-formed, never that the .gguf files it names are on disk
+# - a repo-correct config with a stale model path fails at first load on the real host and nowhere else
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see
+# tests/feature-18-serverctl/test-repo-derivation.sh); export REPO=<path> to
+# point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+CONFIG="$REPO/llama-swap/rtx5070ti-128gb/config.yaml"
+
+[ "${RUN_TL3:-off}" = "on" ] || { echo "SKIP: RUN_TL3 is not 'on' - run with RUN_TL3=on bash $0"; exit 77; }
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT) ;;
+    *) echo "SKIP: not a Windows host - the llama.cpp CUDA build lives only there"; exit 77 ;;
+esac
+
+[ -f "$CONFIG" ] || { echo "SKIP: $CONFIG not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Windows literals in the config need a POSIX form before the shell can stat them.
+to_posix() {
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -u -- "$1"
+    else
+        printf '%s\n' "$1" | tr '\\' '/' | sed 's,^\([A-Za-z]\):,/\L\1,'
+    fi
+}
+
+# Flatten the whole file into whitespace-separated tokens so a `>-` folded `cmd:`
+# block cannot hide a flag from its value by wrapping between them.
+tr -s '[:space:]' '\n' < "$CONFIG" > "$WORK/tokens"
+
+collect_flag_values() {
+    awk -v flag="$1" '$0 == flag { want = 1; next } want { print; want = 0 }' "$WORK/tokens"
+}
+
+# --- 0. the parser found something (guards every loop below) ---------------
+MODEL_KEYS="$(awk '
+    /^models:[[:space:]]*$/ { inm = 1; next }
+    inm && /^[^[:space:]#]/ { inm = 0 }
+    inm && /^  [A-Za-z0-9._-]+:/ { k = $0; sub(/^  /, "", k); sub(/:.*$/, "", k); print k }
+' "$CONFIG")"
+MODEL_N="$(printf '%s\n' "$MODEL_KEYS" | grep -c . || true)"
+[ "$MODEL_N" -gt 0 ] || fail "parsed 0 model keys out of $CONFIG"
+
+collect_flag_values --model > "$WORK/models"
+GGUF_N="$(grep -c . < "$WORK/models" || true)"
+[ "$GGUF_N" -eq "$MODEL_N" ] || fail "config declares $MODEL_N models but $GGUF_N '--model' values were parsed -- a model entry has no --model, or the parser missed one"
+
+# --- 1. llama.cpp CUDA build artifacts exist and are runnable --------------
+# The bin directory is taken from the config itself, not hardcoded: the config is
+# the thing under test, so a moved build must fail here rather than be papered
+# over by a constant that happens to still be right.
+EXE_WIN="$(grep -oE '[A-Za-z]:\\[^"[:space:]]*llama-server\.exe' "$CONFIG" | head -n 1 || true)"
+[ -n "$EXE_WIN" ] || fail "no llama-server.exe path found in $CONFIG"
+EXE="$(to_posix "$EXE_WIN")"
+BIN_DIR="$(dirname -- "$EXE")"
+
+for artifact in llama-server.exe llama-bench.exe ggml-cuda.dll; do
+    [ -f "$BIN_DIR/$artifact" ] || fail "$BIN_DIR/$artifact is missing -- the llama.cpp CUDA build is incomplete"
+done
+
+for tool in llama-server.exe llama-bench.exe; do
+    if ! "$BIN_DIR/$tool" --help >"$WORK/help.out" 2>&1; then
+        fail "$BIN_DIR/$tool --help exited non-zero (missing CUDA runtime DLL?): $(head -n 5 "$WORK/help.out")"
+    fi
+    [ -s "$WORK/help.out" ] || fail "$BIN_DIR/$tool --help produced no output"
+done
+
+# --- 2. every llama-server.exe the config names is the one we just checked --
+MISSING=0
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    q="$(to_posix "$p")"
+    if [ ! -f "$q" ]; then
+        echo "  missing llama-server.exe referenced by config: $p" >&2
+        MISSING=$((MISSING + 1))
+    fi
+done <<EOF
+$(grep -oE '[A-Za-z]:\\[^"[:space:]]*llama-server\.exe' "$CONFIG" | sort -u)
+EOF
+[ "$MISSING" -eq 0 ] || fail "$MISSING llama-server.exe path(s) in the config do not exist on this host"
+
+# --- 3. every --model .gguf the config names exists -------------------------
+MISSING=0
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    case "$p" in *.gguf) ;; *) fail "'--model $p' does not name a .gguf file" ;; esac
+    q="$(to_posix "$p")"
+    if [ ! -f "$q" ]; then
+        echo "  missing model file: $p" >&2
+        MISSING=$((MISSING + 1))
+    fi
+done < "$WORK/models"
+[ "$MISSING" -eq 0 ] || fail "$MISSING of $GGUF_N '--model' path(s) do not exist on this host"
+
+# --- 4. every --chat-template-file the config names exists ------------------
+collect_flag_values --chat-template-file > "$WORK/templates"
+TPL_N="$(grep -c . < "$WORK/templates" || true)"
+MISSING=0
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    q="$(to_posix "$p")"
+    if [ ! -f "$q" ]; then
+        echo "  missing chat template: $p" >&2
+        MISSING=$((MISSING + 1))
+    fi
+done < "$WORK/templates"
+[ "$MISSING" -eq 0 ] || fail "$MISSING of $TPL_N '--chat-template-file' path(s) do not exist on this host"
+
+echo "PASS: TL3-installer-llama-cpp-build ($MODEL_N models, $GGUF_N gguf, $TPL_N chat template(s))"

--- a/tests/feature-86-win-llama-swap-server/install-win-callsites.Tests.ps1
+++ b/tests/feature-86-win-llama-swap-server/install-win-callsites.Tests.ps1
@@ -1,0 +1,242 @@
+#!/usr/bin/env pwsh
+# Tests: install/win/lib/native.ps1, install/win/llama-swap-service.ps1, install/win/certs.ps1, install/win/nssm.ps1, install/win/caddy.ps1, install/win/mkcert.ps1
+# Tags: installer, windows, pwsh-required, ast, exit-codes, native, pester, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: the per-call-site exit-code table is a permanent operational contract, not #86 arithmetic.
+# Sibling install-win-server.Tests.ps1 proves the WRAPPER honours -AllowExitCodes; this file proves each CALL SITE passes the set the plan's 4-2 table assigns it. Neither question implies the other: a correct wrapper handed 1072 still reports a pending delete as success.
+# AST only. Nothing here is dot-sourced or executed, so no service, NSSM, winget or certificate is touched -- the whole file reads text through Parser::ParseFile (detail plan 4-1 boundary).
+# Driver (skip gating, exit 77 off-Windows): test-install-win-server.sh in this directory.
+# TL3 gap (what this suite does NOT catch):
+# - whether sc.exe/taskkill/winget really return 1060/128/-1978335189 on the operator's host (measured once, recorded in the plan; a Windows build change would not fail this suite)
+# - whether Get-NetTCPConnection actually finds the zombie the replaced netstat pipeline used to find
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh categories: installer, pwsh-required
+
+$RepoRoot   = if ($env:CCLL_REPO) { $env:CCLL_REPO } else { (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path }
+$WinDir     = Join-Path $RepoRoot 'install\win'
+$NativePs1  = Join-Path $WinDir 'lib\native.ps1'
+$WinPresent = (Test-Path $WinDir) -and (Test-Path $NativePs1)
+
+# Pester 5 keeps discovery and run in separate scopes: the assignments above are
+# what the -Skip: conditions read, and this BeforeAll is what the It bodies read.
+BeforeAll {
+    $RepoRoot  = if ($env:CCLL_REPO) { $env:CCLL_REPO } else { (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path }
+    $WinDir    = Join-Path $RepoRoot 'install\win'
+    $NativePs1 = Join-Path $WinDir 'lib\native.ps1'
+
+    function Get-ScriptAst([string]$Path) {
+        $tokens = $null; $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+        if ($errors -and $errors.Count -gt 0) { throw "parse errors in ${Path}: $($errors[0].Message)" }
+        return $ast
+    }
+
+    # One integer out of an argument expression. Written to survive every spelling
+    # the implementation may legitimately choose: 1060, @(0, 1060), 0,1060 and the
+    # negative winget code, which PowerShell may hand back either as a literal or
+    # as a UnaryExpressionAst around a positive one.
+    function Get-IntFromAst($Node) {
+        if ($null -eq $Node) { return $null }
+        if ($Node -is [System.Management.Automation.Language.UnaryExpressionAst]) {
+            $inner = Get-IntFromAst $Node.Child
+            if ($null -eq $inner) { return $null }
+            if ($Node.TokenKind -eq [System.Management.Automation.Language.TokenKind]::Minus) { return - $inner }
+            return $inner
+        }
+        if ($Node -is [System.Management.Automation.Language.ConstantExpressionAst]) {
+            $v = $Node.Value
+            if ($v -is [int] -or $v -is [long]) { return [int]$v }
+        }
+        return $null
+    }
+
+    function Get-IntSetFromAst($Node) {
+        $out = @()
+        if ($null -eq $Node) { return $out }
+        if ($Node -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+            foreach ($e in $Node.Elements) { $out += (Get-IntSetFromAst $e) }
+            return $out
+        }
+        if ($Node -is [System.Management.Automation.Language.ArrayExpressionAst] -or
+            $Node -is [System.Management.Automation.Language.ParenExpressionAst]) {
+            foreach ($c in $Node.FindAll({ param($n) $n -is [System.Management.Automation.Language.ExpressionAst] }, $true)) {
+                $i = Get-IntFromAst $c
+                if ($null -ne $i) { $out += $i }
+            }
+            return ($out | Select-Object -Unique)
+        }
+        $i = Get-IntFromAst $Node
+        if ($null -ne $i) { $out += $i }
+        return $out
+    }
+
+    # The value handed to a named parameter, whichever of the two forms the source
+    # uses: `-X value` (argument is the next element) or `-X:value` (attached).
+    function Get-NamedArgumentAst($Command, [string]$Name) {
+        $els = @($Command.CommandElements)
+        for ($i = 1; $i -lt $els.Count; $i++) {
+            $e = $els[$i]
+            if ($e -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+            if ($e.ParameterName -ne $Name) { continue }
+            if ($null -ne $e.Argument) { return @{ Ast = $e.Argument; Raw = $e.Argument.Extent.Text } }
+            if ($i + 1 -lt $els.Count) { return @{ Ast = $els[$i + 1]; Raw = $els[$i + 1].Extent.Text } }
+            return @{ Ast = $null; Raw = '' }
+        }
+        return $null
+    }
+
+    # `-AllowExitCodes -1978335189` is tokenised as a PARAMETER named 1978335189,
+    # not as a negative literal. Reading only the AST node would silently see an
+    # empty allow set and pass -- the exact false green this file exists to stop.
+    function Get-AllowedCodes($Command) {
+        $found = Get-NamedArgumentAst $Command 'AllowExitCodes'
+        if ($null -eq $found) { return @() }
+        if ($found.Ast -is [System.Management.Automation.Language.CommandParameterAst]) {
+            $n = $found.Ast.ParameterName
+            if ($n -match '^\d+$') { return @([int]"-$n") }
+            throw "unreadable -AllowExitCodes argument: $($found.Raw)"
+        }
+        $codes = @(Get-IntSetFromAst $found.Ast)
+        if ($codes.Count -eq 0 -and $found.Raw -ne '') {
+            throw "unreadable -AllowExitCodes argument: $($found.Raw)"
+        }
+        # 0 always succeeds inside the wrapper; spelling it here is redundant, not wrong.
+        return @($codes | Where-Object { $_ -ne 0 } | Sort-Object -Unique)
+    }
+
+    function Get-ConstStrings($Node) {
+        $out = @()
+        if ($null -eq $Node) { return $out }
+        foreach ($c in $Node.FindAll({ param($n) $n -is [System.Management.Automation.Language.StringConstantExpressionAst] }, $true)) {
+            $out += $c.Value
+        }
+        return $out
+    }
+
+    # Every Invoke-Native / Invoke-Nssm call site under install/win, reduced to
+    # (tool, first argument, allowed codes, where).
+    function Get-NativeCallSites([string]$Root) {
+        $sites = @()
+        foreach ($f in Get-ChildItem -Path $Root -Filter '*.ps1' -Recurse -File) {
+            $ast = Get-ScriptAst $f.FullName
+            foreach ($c in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+                $name = $c.GetCommandName()
+                if ($name -notin 'Invoke-Native', 'Invoke-Nssm') { continue }
+                # Inside native.ps1 the wrapper delegates to itself; that is plumbing.
+                if ($f.FullName -eq (Resolve-Path $NativePs1).Path -and $name -eq 'Invoke-Native') { continue }
+
+                $tool = 'nssm'
+                if ($name -eq 'Invoke-Native') {
+                    $fp = Get-NamedArgumentAst $c 'FilePath'
+                    $tool = if ($null -ne $fp) { @(Get-ConstStrings $fp.Ast)[0] } else { $null }
+                }
+                $argNode = Get-NamedArgumentAst $c 'Arguments'
+                $argv = if ($null -ne $argNode) { @(Get-ConstStrings $argNode.Ast) } else { @() }
+
+                $sites += [pscustomobject]@{
+                    Tool  = if ($tool) { [System.IO.Path]::GetFileName($tool).ToLowerInvariant() } else { '<dynamic>' }
+                    Verb  = if ($argv.Count -gt 0) { $argv[0].ToLowerInvariant() } else { '' }
+                    Codes = @(Get-AllowedCodes $c)
+                    Where = "$($f.Name):$($c.Extent.StartLineNumber)"
+                }
+            }
+        }
+        return $sites
+    }
+
+    $script:Sites = @(Get-NativeCallSites $WinDir)
+}
+
+Describe 'Native call sites pass exactly their documented allow-code set (detail plan 4-2)' -Skip:(-not $WinPresent) {
+
+    It 'finds call sites at all (a zero-site scan would pass every case below vacuously)' {
+        $Sites.Count | Should -BeGreaterThan 0 -Because 'install/win must route native commands through Invoke-Native / Invoke-Nssm'
+    }
+
+    # Row-by-row against the plan's table. Each row states the tool, the first
+    # argument that identifies the sub-command, and the ONLY non-zero exit code
+    # that may be reported as success there.
+    It '<tool> <verb> allows exactly <expected> and nothing else' -TestCases @(
+        @{ tool = 'sc.exe';   verb = 'query';   expected = @(1060);         why = '1060 = service does not exist, which is what the ghost check wants to find' }
+        @{ tool = 'sc.exe';   verb = 'delete';  expected = @(1060);         why = '1060 = already gone. 1072 (MARKED_FOR_DELETE) must NOT be allowed: the handle is still open, so reporting success makes the very next registration fail' }
+        @{ tool = 'taskkill'; verb = '/f';      expected = @(128);          why = '128 = no such process; enumeration-to-kill always races a natural exit' }
+        @{ tool = 'winget';   verb = 'install'; expected = @(-1978335189);  why = '-1978335189 (0x8A15002B) = already installed, which is the idempotent outcome' }
+    ) {
+        $matching = @($Sites | Where-Object { $_.Tool -eq $tool -and $_.Verb -eq $verb })
+        $matching.Count | Should -BeGreaterThan 0 -Because "the plan documents a '$tool $verb' call site; if it moved, this table moves with it"
+        foreach ($s in $matching) {
+            (@($s.Codes) -join ',') | Should -Be (@($expected) -join ',') -Because "$($s.Where): $why"
+        }
+    }
+
+    It 'never allows 1072 anywhere (a pending delete is not a completed one)' {
+        # Stated separately from the sc.exe delete row: 1072 must not creep into
+        # ANY site, including a future retry helper that never says "delete".
+        $bad = @($Sites | Where-Object { $_.Codes -contains 1072 } | ForEach-Object { $_.Where })
+        ($bad -join '; ') | Should -BeNullOrEmpty -Because 'ERROR_SERVICE_MARKED_FOR_DELETE means the service is still there'
+    }
+
+    It 'nssm itself is allowed nothing but 0' {
+        # The design avoids "service missing" by pre-checking with Get-Service,
+        # precisely so nssm's build-dependent codes never need an exception.
+        foreach ($s in @($Sites | Where-Object { $_.Tool -eq 'nssm' })) {
+            (@($s.Codes) -join ',') | Should -Be '' -Because "$($s.Where): nssm exit codes vary by build, so none may be pre-blessed"
+        }
+    }
+
+    It 'certificate tools are allowed nothing but 0' {
+        foreach ($s in @($Sites | Where-Object { $_.Tool -in 'mkcert', 'certutil' })) {
+            (@($s.Codes) -join ',') | Should -Be '' -Because "$($s.Where): a failed cert or trust step has no benign non-zero outcome"
+        }
+    }
+
+    It 'every call site names its tool as a literal (an allow set cannot be checked against a computed one)' {
+        $dyn = @($Sites | Where-Object { $_.Tool -eq '<dynamic>' } | ForEach-Object { $_.Where })
+        ($dyn -join '; ') | Should -BeNullOrEmpty -Because 'a -FilePath built at runtime would slip past this whole table'
+    }
+
+    It 'every call site carries a -Context (the failure text is the operator guidance)' {
+        $missing = @()
+        foreach ($f in Get-ChildItem -Path $WinDir -Filter '*.ps1' -Recurse -File) {
+            $ast = Get-ScriptAst $f.FullName
+            foreach ($c in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+                if ($c.GetCommandName() -notin 'Invoke-Native', 'Invoke-Nssm') { continue }
+                if ($f.FullName -eq (Resolve-Path $NativePs1).Path) { continue }
+                if ($null -eq (Get-NamedArgumentAst $c 'Context')) { $missing += "$($f.Name):$($c.Extent.StartLineNumber)" }
+            }
+        }
+        ($missing -join '; ') | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'netstat is gone, not merely wrapped (detail plan 4-2 row 5)' -Skip:(-not $WinPresent) {
+
+    It 'no netstat invocation survives anywhere under install/win' {
+        # netstat returns 0 with zero matching lines, so its exit code cannot tell
+        # "no zombie" from "did not look". Wrapping it would not fix that; only
+        # replacing it does. Checked as text as well as AST because the old form
+        # was a pipeline into Select-String, where the AST name is easy to miss.
+        $hits = @()
+        foreach ($f in Get-ChildItem -Path $WinDir -Filter '*.ps1' -Recurse -File) {
+            $ast = Get-ScriptAst $f.FullName
+            foreach ($c in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+                $n = $c.GetCommandName()
+                if (-not $n) { continue }
+                if ([System.IO.Path]::GetFileNameWithoutExtension($n).ToLowerInvariant() -eq 'netstat') {
+                    $hits += "$($f.Name):$($c.Extent.StartLineNumber) (command)"
+                }
+            }
+            foreach ($s in @(Get-ConstStrings $ast)) {
+                if ($s -match '(?i)(^|[\\/\s])netstat(\.exe)?($|[\s])') { $hits += "$($f.Name) (string literal '$s')" }
+            }
+        }
+        ($hits -join '; ') | Should -BeNullOrEmpty
+    }
+
+    It 'the zombie hunt uses Get-NetTCPConnection instead' -Skip:(-not (Test-Path (Join-Path $WinDir 'llama-swap-service.ps1'))) {
+        # Asserted positively as well: deleting the netstat line and replacing it
+        # with nothing would satisfy the case above while losing the cleanup.
+        $ast = Get-ScriptAst (Join-Path $WinDir 'llama-swap-service.ps1')
+        $names = @($ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) |
+            ForEach-Object { $_.GetCommandName() } | Where-Object { $_ })
+        $names | Should -Contain 'Get-NetTCPConnection'
+    }
+}

--- a/tests/feature-86-win-llama-swap-server/install-win-inputs.Tests.ps1
+++ b/tests/feature-86-win-llama-swap-server/install-win-inputs.Tests.ps1
@@ -1,0 +1,219 @@
+#!/usr/bin/env pwsh
+# Tests: install.ps1, install/win/certs.ps1, install/win/llama-swap-service.ps1, install/win/lib/nssm-args.ps1
+# Tags: installer, windows, pwsh-required, validation, boundary, ast, pester, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: rejecting bad input is a permanent property of the installer, not #86 arithmetic.
+# The sibling suites ask "does the happy path build the right thing". This one asks the other half: what happens at the edges of each input -- an empty path, a path with a space, a rotation size of 0 or int max, an unvalidated LanIp or SanNames. Every case here is a value an operator can actually type.
+# The builders under lib/ are pure and are called for real; install.ps1 and certs.ps1 are read through the AST only, so nothing is executed (detail plan 4-1 boundary).
+# Driver (skip gating, exit 77 off-Windows): test-install-win-server.sh in this directory.
+# TL3 gap (what this suite does NOT catch):
+# - whether NSSM itself survives a quoted path with a space in AppParameters (only `nssm get` on the host shows that)
+# - whether a rejected LanIp produces a message the operator can act on (the AST sees the attribute, not the text)
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh categories: installer, pwsh-required
+
+$RepoRoot    = if ($env:CCLL_REPO) { $env:CCLL_REPO } else { (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path }
+$WinDir      = Join-Path $RepoRoot 'install\win'
+$NssmPs1     = Join-Path $WinDir 'lib\nssm-args.ps1'
+$InstallPs1  = Join-Path $RepoRoot 'install.ps1'
+$CertsPs1    = Join-Path $WinDir 'certs.ps1'
+$ServicePs1  = Join-Path $WinDir 'llama-swap-service.ps1'
+$BuildersPresent = Test-Path $NssmPs1
+$SourcesPresent  = (Test-Path $InstallPs1) -and (Test-Path $CertsPs1) -and (Test-Path $ServicePs1)
+
+# Pester 5 keeps discovery and run in separate scopes: the assignments above are
+# what the -Skip: conditions read, and this BeforeAll is what the It bodies read.
+BeforeAll {
+    $RepoRoot   = if ($env:CCLL_REPO) { $env:CCLL_REPO } else { (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path }
+    $WinDir     = Join-Path $RepoRoot 'install\win'
+    $NssmPs1    = Join-Path $WinDir 'lib\nssm-args.ps1'
+    $InstallPs1 = Join-Path $RepoRoot 'install.ps1'
+    $CertsPs1   = Join-Path $WinDir 'certs.ps1'
+    $ServicePs1 = Join-Path $WinDir 'llama-swap-service.ps1'
+
+    function Get-ScriptAst([string]$Path) {
+        $tokens = $null; $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+        if ($errors -and $errors.Count -gt 0) { throw "parse errors in ${Path}: $($errors[0].Message)" }
+        return $ast
+    }
+
+    function Get-ParamAst($Ast, [string]$Name) {
+        return $Ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq $Name }
+    }
+
+    # The names of every attribute on a parameter, e.g. Parameter, ValidatePattern.
+    function Get-ParamAttributeNames($Ast, [string]$Name) {
+        $p = Get-ParamAst $Ast $Name
+        if (-not $p) { return @() }
+        return @($p.Attributes | ForEach-Object { $_.TypeName.Name })
+    }
+
+    # A Validate* attribute, or an explicit guard in the body that names the
+    # variable and throws. Either is real validation; neither present is not.
+    function Test-ParamIsValidated($Ast, [string]$Name) {
+        foreach ($a in @(Get-ParamAttributeNames $Ast $Name)) {
+            if ($a -like 'Validate*') { return $true }
+        }
+        foreach ($t in $Ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.ThrowStatementAst] }, $true)) {
+            $vars = @($t.Parent.FindAll({ param($n) $n -is [System.Management.Automation.Language.VariableExpressionAst] }, $true) |
+                ForEach-Object { $_.VariablePath.UserPath })
+            if ($vars -contains $Name) { return $true }
+        }
+        return $false
+    }
+}
+
+Describe 'Log rotation size boundaries (the 125 MB incident is why rotation exists)' -Skip:(-not $BuildersPresent) {
+    BeforeAll {
+        . $NssmPs1
+        $script:RuntimeDir = 'C:\LLM\llama-swap'
+        $script:ConfigPath = 'C:\LLM\cc-local-llm\llama-swap\rtx5070ti-128gb\config.yaml'
+        $script:CaddyExe   = 'C:\Program Files\Caddy\caddy.exe'
+        $script:Caddyfile  = 'C:\LLM\llama-swap\Caddyfile'
+    }
+
+    # Both builders, same table (CPR-ORTH): a size that one accepts and the other
+    # rejects would leave the two services rotating on different rules.
+    It '<builder> refuses a rotation size of <size>' -TestCases @(
+        @{ builder = 'llama-swap'; size = 0 }
+        @{ builder = 'llama-swap'; size = -1 }
+        @{ builder = 'llama-swap'; size = -10485760 }
+        @{ builder = 'caddy';      size = 0 }
+        @{ builder = 'caddy';      size = -1 }
+        @{ builder = 'caddy';      size = -10485760 }
+    ) {
+        # 0 means "never rotate" to NSSM, which is exactly the state that grew a
+        # 125 MB caddy-stderr.log. It must not be reachable by passing a number.
+        if ($builder -eq 'llama-swap') {
+            { Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -LogRotateBytes $size } |
+                Should -Throw -Because 'a non-positive rotation size silently disables rotation'
+        } else {
+            { Get-CaddyNssmSettings -RuntimeDir $RuntimeDir -CaddyExe $CaddyExe -Caddyfile $Caddyfile -LogRotateBytes $size } |
+                Should -Throw -Because 'a non-positive rotation size silently disables rotation'
+        }
+    }
+
+    It 'accepts the largest int without overflowing into a negative AppRotateBytes' {
+        $s = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -LogRotateBytes ([int]::MaxValue)
+        $s['AppRotateBytes'] | Should -Be ([int]::MaxValue)
+        [int]$s['AppRotateBytes'] | Should -BeGreaterThan 0
+    }
+
+    It 'accepts the smallest positive size (the boundary next to the rejected 0)' {
+        # Paired with the size=0 case above so the rule is a boundary, not a ban.
+        $s = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -LogRotateBytes 1
+        $s['AppRotateBytes'] | Should -Be 1
+    }
+
+    It 'defaults to a rotation size that is positive and at least 1 MB' {
+        $s = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath
+        $c = Get-CaddyNssmSettings -RuntimeDir $RuntimeDir -CaddyExe $CaddyExe -Caddyfile $Caddyfile
+        [int]$s['AppRotateBytes'] | Should -BeGreaterThan 1048575
+        [int]$c['AppRotateBytes'] | Should -Be ([int]$s['AppRotateBytes']) -Because 'both services must default to the same size'
+    }
+}
+
+Describe 'Path parameter boundaries' -Skip:(-not $BuildersPresent) {
+    BeforeAll {
+        . $NssmPs1
+        $script:RuntimeDir = 'C:\LLM\llama-swap'
+        $script:ConfigPath = 'C:\LLM\cc-local-llm\llama-swap\rtx5070ti-128gb\config.yaml'
+        $script:CaddyExe   = 'C:\Program Files\Caddy\caddy.exe'
+        $script:Caddyfile  = 'C:\LLM\llama-swap\Caddyfile'
+    }
+
+    It 'refuses an empty <param>' -TestCases @(
+        @{ param = 'RuntimeDir' }
+        @{ param = 'ConfigPath' }
+    ) {
+        $splat = @{ RuntimeDir = $RuntimeDir; ConfigPath = $ConfigPath }
+        $splat[$param] = ''
+        { Get-LlamaSwapNssmSettings @splat } | Should -Throw -Because "an empty $param would build a service pointing at the filesystem root"
+    }
+
+    It 'refuses a whitespace-only RuntimeDir' {
+        { Get-LlamaSwapNssmSettings -RuntimeDir '   ' -ConfigPath $ConfigPath } |
+            Should -Throw -Because 'Mandatory alone accepts a blank string'
+    }
+
+    It 'quotes a ConfigPath containing a space, so NSSM does not split it into two arguments' {
+        # AppParameters is one flat string handed to NSSM; an unquoted
+        # "C:\Program Files\..." becomes --config C:\Program plus a stray token,
+        # and llama-swap starts with the wrong config or not at all.
+        $spaced = 'C:\Program Files\cc-local-llm\llama-swap\rtx5070ti-128gb\config.yaml'
+        $s = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $spaced
+        $s['AppParameters'] | Should -BeLike "*`"$spaced`"*"
+    }
+
+    It 'quotes a Caddyfile path containing a space too (CPR-ORTH)' {
+        $spaced = 'C:\Program Files\llama-swap\Caddyfile'
+        $c = Get-CaddyNssmSettings -RuntimeDir $RuntimeDir -CaddyExe $CaddyExe -Caddyfile $spaced
+        $c['AppParameters'] | Should -BeLike "*`"$spaced`"*"
+    }
+
+    It 'leaves a space-free path unquoted (the quoting is conditional, not blanket)' {
+        # Classifier guard: quoting everything would satisfy the two cases above
+        # while changing every existing registration's AppParameters.
+        $s = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath
+        $s['AppParameters'] | Should -Not -BeLike '*"*'
+    }
+
+    It 'keeps a RuntimeDir with a space intact in every derived path' {
+        $spaced = 'C:\Program Files\llama-swap'
+        $s = Get-LlamaSwapNssmSettings -RuntimeDir $spaced -ConfigPath $ConfigPath
+        $s['Application']  | Should -Be (Join-Path $spaced 'llama-swap.exe')
+        $s['AppDirectory'] | Should -Be $spaced
+        $s['AppStdout']    | Should -Be (Join-Path $spaced 'service-stdout.log')
+    }
+
+    It 'refuses a ListenAddr that is not host:port' -TestCases @(
+        @{ addr = '' }
+        @{ addr = '127.0.0.1' }
+        @{ addr = '127.0.0.1:' }
+        @{ addr = '127.0.0.1:notaport' }
+        @{ addr = '127.0.0.1:70000' }
+    ) {
+        # The port here is the single source for the front-end mapping; a bad one
+        # reaches NSSM as a literal and the service fails long after the install
+        # reported success.
+        { Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -ListenAddr $addr } | Should -Throw
+    }
+}
+
+Describe 'Operator-supplied identity is validated before it reaches a certificate (AST only)' -Skip:(-not $SourcesPresent) {
+
+    It 'install.ps1 validates -LanIp' {
+        # An unvalidated LanIp is baked into the certificate SAN list. A typo
+        # produces a cert that every client silently rejects, days later.
+        $ast = Get-ScriptAst $InstallPs1
+        Get-ParamAst $ast 'LanIp' | Should -Not -BeNullOrEmpty
+        Test-ParamIsValidated $ast 'LanIp' | Should -BeTrue -Because '-LanIp needs a Validate* attribute or an explicit guard that throws'
+    }
+
+    It 'certs.ps1 validates -SanNames rather than accepting an empty list' {
+        # [string[]] with Mandatory still accepts @(), and mkcert called with no
+        # names produces a certificate good for nothing.
+        $ast = Get-ScriptAst $CertsPs1
+        $p = Get-ParamAst $ast 'SanNames'
+        $p | Should -Not -BeNullOrEmpty
+        Test-ParamIsValidated $ast 'SanNames' | Should -BeTrue -Because '-SanNames needs a Validate* attribute or an explicit guard that throws'
+    }
+
+    It 'certs.ps1 declares -SanNames as a string array, not a single string' {
+        $ast = Get-ScriptAst $CertsPs1
+        $p = Get-ParamAst $ast 'SanNames'
+        $p.StaticType.IsArray | Should -BeTrue -Because 'a single string would silently generate a one-name certificate'
+    }
+
+    It 'llama-swap-service.ps1 validates its -LogRotateBytes' {
+        $ast = Get-ScriptAst $ServicePs1
+        Get-ParamAst $ast 'LogRotateBytes' | Should -Not -BeNullOrEmpty
+        Test-ParamIsValidated $ast 'LogRotateBytes' | Should -BeTrue -Because 'the entry point must reject 0 before the builder is ever called'
+    }
+
+    It 'the validation helper can return false (classifier guard)' {
+        # Without this, a helper that answered $true unconditionally would make
+        # every case in this Describe pass while checking nothing.
+        $ast = Get-ScriptAst $CertsPs1
+        Test-ParamIsValidated $ast 'ThisParameterDoesNotExist' | Should -BeFalse
+    }
+}

--- a/tests/feature-86-win-llama-swap-server/install-win-server.Tests.ps1
+++ b/tests/feature-86-win-llama-swap-server/install-win-server.Tests.ps1
@@ -1,0 +1,286 @@
+#!/usr/bin/env pwsh
+# Tests: install.ps1, install/win/lib/roles.ps1, install/win/lib/nssm-args.ps1, install/win/lib/native.ps1, install/win/llama-swap-service.ps1, install/win/certs.ps1
+# Tags: installer, windows, pwsh-required, nssm, pester, ast, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: the role matrix, the NSSM argument shapes and the "no bare native call" rule are permanent contracts.
+# Only install/win/lib/*.ps1 are dot-sourced -- they hold function definitions and nothing else, so loading them is inert. install.ps1 / llama-swap-service.ps1 / certs.ps1 are read through the AST and NEVER executed, so this suite touches neither NSSM nor any service. Rationale: detail plan 4-1 / 4-3 / 6-5.
+# Driver (skip gating, 120s timeout, exit 77 off-Windows): test-install-win-server.sh in this directory.
+# TL3 gap (what this suite does NOT catch):
+# - whether nssm accepts the settings hash and the two services actually reach Running
+# - whether mkcert/winget/caddy exist and behave as the exit-code policy assumes
+# - whether re-running the installer over an existing registration is idempotent (only the pure builders are checked here)
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh categories: installer, pwsh-required
+
+$RepoRoot   = if ($env:CCLL_REPO) { $env:CCLL_REPO } else { (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path }
+$LibDir     = Join-Path $RepoRoot 'install\win\lib'
+$WinDir     = Join-Path $RepoRoot 'install\win'
+$RolesPs1   = Join-Path $LibDir 'roles.ps1'
+$NssmPs1    = Join-Path $LibDir 'nssm-args.ps1'
+$NativePs1  = Join-Path $LibDir 'native.ps1'
+$LibsPresent = (Test-Path $RolesPs1) -and (Test-Path $NssmPs1) -and (Test-Path $NativePs1)
+
+# Pester 5 discovery and run are separate scopes: the assignments above are what
+# the -Skip: conditions read (discovery), and this BeforeAll is what the It bodies
+# read (run). $env:CCLL_REPO is the Windows-path counterpart of the bash suites'
+# $REPO override, set by the driver so the two cannot disagree on the checkout.
+BeforeAll {
+    $RepoRoot  = if ($env:CCLL_REPO) { $env:CCLL_REPO } else { (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path }
+    $LibDir    = Join-Path $RepoRoot 'install\win\lib'
+    $WinDir    = Join-Path $RepoRoot 'install\win'
+    $RolesPs1  = Join-Path $LibDir 'roles.ps1'
+    $NssmPs1   = Join-Path $LibDir 'nssm-args.ps1'
+    $NativePs1 = Join-Path $LibDir 'native.ps1'
+
+    function Get-ScriptAst([string]$Path) {
+        $tokens = $null; $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+        if ($errors -and $errors.Count -gt 0) { throw "parse errors in ${Path}: $($errors[0].Message)" }
+        return $ast
+    }
+
+    function Test-ParamIsMandatory($Ast, [string]$Name) {
+        $p = $Ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq $Name }
+        if (-not $p) { return $false }
+        foreach ($a in $p.Attributes) {
+            if ($a -isnot [System.Management.Automation.Language.AttributeAst]) { continue }
+            if ($a.TypeName.GetReflectionType() -ne [Parameter] -and $a.TypeName.Name -ne 'Parameter') { continue }
+            foreach ($na in $a.NamedArguments) {
+                if ($na.ArgumentName -eq 'Mandatory') { return $true }
+            }
+        }
+        return $false
+    }
+}
+
+Describe 'Resolve-InstallRole (role matrix, detail plan 4-3)' -Skip:(-not $LibsPresent) {
+    BeforeAll { . $RolesPs1 }
+
+    # Every accepted combination, including the no-argument back-compat default.
+    It 'resolves <name> to <expected>' -TestCases @(
+        @{ name = 'no arguments';      splat = @{};                                   expected = 'client' }
+        @{ name = '-Client';           splat = @{ Client = $true };                    expected = 'client' }
+        @{ name = '-Server';           splat = @{ Server = $true };                    expected = 'server' }
+        @{ name = '-All';              splat = @{ All = $true };                       expected = 'all' }
+        @{ name = '-Server -Uninstall'; splat = @{ Server = $true; Uninstall = $true }; expected = 'server' }
+    ) {
+        $got = Resolve-InstallRole @splat
+        $got | Should -Be $expected
+    }
+
+    # Every rejected combination. A role switch is exclusive, and -Uninstall has
+    # exactly one meaningful target (server); anything else is refused rather
+    # than guessed, because the guess would be a destructive one.
+    It 'refuses <name>' -TestCases @(
+        @{ name = '-Server -Client';        splat = @{ Server = $true; Client = $true } }
+        @{ name = '-Server -All';           splat = @{ Server = $true; All = $true } }
+        @{ name = '-Client -All';           splat = @{ Client = $true; All = $true } }
+        @{ name = '-Server -Client -All';   splat = @{ Server = $true; Client = $true; All = $true } }
+        @{ name = '-Uninstall alone';       splat = @{ Uninstall = $true } }
+        @{ name = '-Client -Uninstall';     splat = @{ Client = $true; Uninstall = $true } }
+        @{ name = '-All -Uninstall';        splat = @{ All = $true; Uninstall = $true } }
+    ) {
+        { Resolve-InstallRole @splat } | Should -Throw
+    }
+}
+
+Describe 'Get-LlamaSwapNssmSettings' -Skip:(-not $LibsPresent) {
+    BeforeAll {
+        . $NssmPs1
+        $script:RuntimeDir = 'C:\LLM\llama-swap'
+        $script:ConfigPath = 'C:\LLM\cc-local-llm\llama-swap\rtx5070ti-128gb\config.yaml'
+        $script:ListenAddr = '127.0.0.1:18080'
+        $script:RotateBytes = 10485760
+        $script:S = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -ListenAddr $ListenAddr -LogRotateBytes $RotateBytes
+    }
+
+    It 'returns the exact NSSM setting name set' {
+        # Strict: a dropped setting is as much a regression as a wrong value.
+        $expected = @(
+            'Application', 'AppParameters', 'AppDirectory', 'Start', 'DisplayName', 'Description',
+            'AppStdout', 'AppStderr', 'AppRotateFiles', 'AppRotateOnline', 'AppRotateBytes',
+            'AppStdoutCreationDisposition', 'AppStderrCreationDisposition'
+        ) | Sort-Object
+        ((@($S.Keys) | Sort-Object) -join ',') | Should -Be ($expected -join ',')
+    }
+
+    It 'derives the executable and working directory from -RuntimeDir' {
+        $S['Application']  | Should -Be (Join-Path $RuntimeDir 'llama-swap.exe')
+        $S['AppDirectory'] | Should -Be $RuntimeDir
+    }
+
+    It 'builds AppParameters as --config <path> --listen <addr> --watch-config' {
+        $S['AppParameters'] | Should -Be "--config $ConfigPath --listen $ListenAddr --watch-config"
+    }
+
+    It 'writes both log streams into the runtime directory' {
+        $S['AppStdout'] | Should -Be (Join-Path $RuntimeDir 'service-stdout.log')
+        $S['AppStderr'] | Should -Be (Join-Path $RuntimeDir 'service-stderr.log')
+    }
+
+    It 'sets log rotation (C6 regression guard: caddy-stderr.log once reached 125 MB)' {
+        $S['AppRotateFiles']  | Should -Be 1
+        $S['AppRotateOnline'] | Should -Be 1
+        $S['AppRotateBytes']  | Should -Be $RotateBytes
+        $S['AppStdoutCreationDisposition'] | Should -Be 4
+        $S['AppStderrCreationDisposition'] | Should -Be 4
+    }
+
+    It 'starts automatically and names itself' {
+        $S['Start'] | Should -Be 'SERVICE_AUTO_START'
+        $S['DisplayName'] | Should -Not -BeNullOrEmpty
+        $S['Description'] | Should -Not -BeNullOrEmpty
+    }
+
+    It 'threads a non-default -LogRotateBytes through instead of hardcoding it' {
+        $alt = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -ListenAddr $ListenAddr -LogRotateBytes 4096
+        $alt['AppRotateBytes'] | Should -Be 4096
+    }
+
+    It 'threads a non-default -ListenAddr through (single source for the port)' {
+        $alt = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -ListenAddr '127.0.0.1:19999' -LogRotateBytes $RotateBytes
+        $alt['AppParameters'] | Should -BeLike '*--listen 127.0.0.1:19999*'
+        $alt['AppParameters'] | Should -Not -BeLike '*18080*'
+    }
+
+    It 'returns the identical hash on a second call (re-running the installer is safe)' {
+        # The installer is re-run to upgrade; if this builder accumulated state or
+        # appended to a shared collection, the second registration would silently
+        # differ from the first.
+        $again = Get-LlamaSwapNssmSettings -RuntimeDir $RuntimeDir -ConfigPath $ConfigPath -ListenAddr $ListenAddr -LogRotateBytes $RotateBytes
+        (($again.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join "`n") |
+            Should -Be (($S.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join "`n")
+    }
+}
+
+Describe 'Get-CaddyNssmSettings' -Skip:(-not $LibsPresent) {
+    BeforeAll {
+        . $NssmPs1
+        $script:RuntimeDir = 'C:\LLM\llama-swap'
+        $script:CaddyExe   = 'C:\Program Files\Caddy\caddy.exe'
+        $script:Caddyfile  = 'C:\LLM\llama-swap\Caddyfile'
+        $script:C = Get-CaddyNssmSettings -RuntimeDir $RuntimeDir -CaddyExe $CaddyExe -Caddyfile $Caddyfile -LogRotateBytes 10485760
+    }
+
+    It 'returns the same NSSM setting name set as the llama-swap side (CPR-ORTH)' {
+        $expected = @(
+            'Application', 'AppParameters', 'AppDirectory', 'Start', 'DisplayName', 'Description',
+            'AppStdout', 'AppStderr', 'AppRotateFiles', 'AppRotateOnline', 'AppRotateBytes',
+            'AppStdoutCreationDisposition', 'AppStderrCreationDisposition'
+        ) | Sort-Object
+        ((@($C.Keys) | Sort-Object) -join ',') | Should -Be ($expected -join ',')
+    }
+
+    It 'builds AppParameters as run --config <caddyfile> --adapter caddyfile' {
+        $C['Application']   | Should -Be $CaddyExe
+        $C['AppParameters'] | Should -Be "run --config $Caddyfile --adapter caddyfile"
+        $C['AppDirectory']  | Should -Be $RuntimeDir
+    }
+
+    It 'writes its own log pair, distinct from the llama-swap pair' {
+        $C['AppStdout'] | Should -Be (Join-Path $RuntimeDir 'caddy-stdout.log')
+        $C['AppStderr'] | Should -Be (Join-Path $RuntimeDir 'caddy-stderr.log')
+    }
+
+    It 'sets log rotation on its pair too (the 125 MB file was this service)' {
+        $C['AppRotateFiles']  | Should -Be 1
+        $C['AppRotateOnline'] | Should -Be 1
+        $C['AppRotateBytes']  | Should -Be 10485760
+        $C['AppStdoutCreationDisposition'] | Should -Be 4
+        $C['AppStderrCreationDisposition'] | Should -Be 4
+    }
+
+    It 'returns the identical hash on a second call (CPR-ORTH with the llama-swap side)' {
+        $again = Get-CaddyNssmSettings -RuntimeDir $RuntimeDir -CaddyExe $CaddyExe -Caddyfile $Caddyfile -LogRotateBytes 10485760
+        (($again.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join "`n") |
+            Should -Be (($C.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join "`n")
+    }
+}
+
+Describe 'Invoke-Native exit-code policy (C5)' -Skip:(-not ($LibsPresent -and $IsWindows)) {
+    BeforeAll { . $NativePs1 }
+
+    It 'accepts exit 0' {
+        { Invoke-Native -FilePath 'cmd.exe' -Arguments @('/c', 'exit', '0') -Context 'probe-zero' } | Should -Not -Throw
+    }
+
+    It 'throws on a non-zero exit when no code is allowed' {
+        { Invoke-Native -FilePath 'cmd.exe' -Arguments @('/c', 'exit', '3') -Context 'probe-three' } | Should -Throw
+    }
+
+    It 'accepts a non-zero exit that was explicitly allowed' {
+        { Invoke-Native -FilePath 'cmd.exe' -Arguments @('/c', 'exit', '3') -AllowExitCodes 3 -Context 'probe-allow' } | Should -Not -Throw
+    }
+
+    It 'allows only the enumerated codes, not "any non-zero"' {
+        { Invoke-Native -FilePath 'cmd.exe' -Arguments @('/c', 'exit', '1') -AllowExitCodes 3 -Context 'probe-narrow' } | Should -Throw
+    }
+
+    It 'reports the command line, the exit code and the -Context in the failure' {
+        $msg = ''
+        try { Invoke-Native -FilePath 'cmd.exe' -Arguments @('/c', 'exit', '7') -Context 'probe-message' }
+        catch { $msg = "$_" }
+        $msg | Should -Not -BeNullOrEmpty
+        $msg | Should -BeLike '*cmd.exe*'
+        $msg | Should -BeLike '*7*'
+        $msg | Should -BeLike '*probe-message*'
+    }
+}
+
+Describe 'Source-structure contracts (AST only, nothing is executed)' {
+    It 'install.ps1 exposes exactly Server/Client/All/Uninstall/LanIp' -Skip:(-not $LibsPresent) {
+        $ast = Get-ScriptAst (Join-Path $RepoRoot 'install.ps1')
+        $ast.ParamBlock | Should -Not -BeNullOrEmpty
+        $names = @($ast.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath }) | Sort-Object
+        ($names -join ',') | Should -Be ((@('All', 'Client', 'LanIp', 'Server', 'Uninstall') | Sort-Object) -join ',')
+    }
+
+    It 'llama-swap-service.ps1 keeps RuntimeDir/ConfigPath/CertDir Mandatory' -Skip:(-not (Test-Path (Join-Path $WinDir 'llama-swap-service.ps1'))) {
+        # The co-location assumption became explicit arguments; a re-introduced
+        # default would silently restore it (detail plan 4-7).
+        $ast = Get-ScriptAst (Join-Path $WinDir 'llama-swap-service.ps1')
+        foreach ($p in 'RuntimeDir', 'ConfigPath', 'CertDir') {
+            Test-ParamIsMandatory $ast $p | Should -BeTrue -Because "$p must stay Mandatory"
+        }
+    }
+
+    It 'certs.ps1 keeps CertDir/SanNames Mandatory (SAN requirement, C1)' -Skip:(-not (Test-Path (Join-Path $WinDir 'certs.ps1'))) {
+        $ast = Get-ScriptAst (Join-Path $WinDir 'certs.ps1')
+        foreach ($p in 'CertDir', 'SanNames') {
+            Test-ParamIsMandatory $ast $p | Should -BeTrue -Because "$p must stay Mandatory"
+        }
+    }
+
+    It 'no bare native invocation lives outside install/win/lib/native.ps1' -Skip:(-not (Test-Path $WinDir)) {
+        $banned = @('nssm', 'sc.exe', 'sc', 'taskkill', 'netstat', 'winget', 'mkcert', 'certutil')
+        $files = @(Get-ChildItem -Path $WinDir -Filter '*.ps1' -Recurse -File | Where-Object { $_.FullName -ne (Join-Path $LibDir 'native.ps1') })
+        $files.Count | Should -BeGreaterThan 0 -Because 'a zero-file scan would pass vacuously'
+        $offenders = @()
+        foreach ($f in $files) {
+            $ast = Get-ScriptAst $f.FullName
+            foreach ($c in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+                $name = $c.GetCommandName()
+                if (-not $name) { continue }
+                $leaf = [System.IO.Path]::GetFileName($name).ToLowerInvariant()
+                if ($banned -contains $leaf) { $offenders += "$($f.Name):$($c.Extent.StartLineNumber) -> $name" }
+            }
+        }
+        ($offenders -join '; ') | Should -BeNullOrEmpty
+    }
+
+    It 'install/win/lib/*.ps1 contain function definitions and nothing else' -Skip:(-not $LibsPresent) {
+        # If a lib ever gains a top-level statement, dot-sourcing it from Pester
+        # stops being inert and this suite becomes destructive (C2).
+        $offenders = @()
+        foreach ($f in Get-ChildItem -Path $LibDir -Filter '*.ps1' -File) {
+            $ast = Get-ScriptAst $f.FullName
+            foreach ($b in 'BeginBlock', 'ProcessBlock') {
+                if ($ast.$b) { $offenders += "$($f.Name): unexpected $b" }
+            }
+            foreach ($st in $ast.EndBlock.Statements) {
+                if ($st -isnot [System.Management.Automation.Language.FunctionDefinitionAst]) {
+                    $offenders += "$($f.Name):$($st.Extent.StartLineNumber) -> top-level statement '$($st.Extent.Text.Split("`n")[0])'"
+                }
+            }
+        }
+        ($offenders -join '; ') | Should -BeNullOrEmpty
+    }
+}

--- a/tests/feature-86-win-llama-swap-server/lib/assert-pester-profile.sh
+++ b/tests/feature-86-win-llama-swap-server/lib/assert-pester-profile.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Tests: install.ps1, install/win/lib/roles.ps1, install/win/lib/nssm-args.ps1, install/win/lib/native.ps1, install/win/llama-swap-service.ps1, install/win/certs.ps1
+# Tags: installer, windows, pester, verdict, shared, layer:TL2, scope:common
+# Not a test: the shared verdict rule for a Pester run whose files under test all
+# exist. Kept out of the driver so test-install-driver-skip-profile.sh can
+# exercise the rule directly, and so the two cannot drift apart.
+
+# Rule: once the implementation is present, a SKIPPED case is a failure. Pester
+# reports "0 failed" for a suite whose every case was skipped, so a bad -Skip:
+# condition turns the whole suite green while testing nothing.
+
+# Usage: assert-pester-profile.sh --total N --failed N --skipped N [--context TEXT]
+# Exit 0 = acceptable profile; 1 = not, with the reason on stderr; 2 = bad usage.
+set -u
+
+TOTAL=""; FAILED=""; SKIPPED=""; CONTEXT="pester run"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --total)   TOTAL="${2:-}";   shift 2 ;;
+        --failed)  FAILED="${2:-}";  shift 2 ;;
+        --skipped) SKIPPED="${2:-}"; shift 2 ;;
+        --context) CONTEXT="${2:-}"; shift 2 ;;
+        *) echo "assert-pester-profile: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+done
+
+for pair in "total:$TOTAL" "failed:$FAILED" "skipped:$SKIPPED"; do
+    name="${pair%%:*}"; value="${pair#*:}"
+    case "$value" in
+        '') echo "assert-pester-profile: --$name is required" >&2; exit 2 ;;
+        *[!0-9]*) echo "assert-pester-profile: --$name must be a non-negative integer, got '$value'" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$TOTAL" -eq 0 ]; then
+    echo "FAIL: $CONTEXT ran no cases at all - the suite files were not discovered, so 'no failures' means nothing" >&2
+    exit 1
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+    echo "FAIL: $CONTEXT reported $FAILED failed case(s) of $TOTAL" >&2
+    exit 1
+fi
+
+if [ "$SKIPPED" -gt 0 ]; then
+    echo "FAIL: $CONTEXT skipped $SKIPPED case(s) of $TOTAL, but the driver only reaches this point once every file under test exists." >&2
+    echo "      A skip here is a broken -Skip: condition, not a legitimate gap. Re-run with -Output Detailed to see which cases report Skipped." >&2
+    exit 1
+fi
+
+exit 0

--- a/tests/feature-86-win-llama-swap-server/lib/check-config-pair.py
+++ b/tests/feature-86-win-llama-swap-server/lib/check-config-pair.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Structural checker for one llama-swap host directory's config/annotation pair.
+
+Answers C5's questions off a real parse, not off substrings: exact model /
+group / annotation / retained-orphan counts, key-by-key correspondence in both
+directions, group membership resolution, and the presence of the fields
+llama-swap and CLAUDE.md each require.
+
+Exits 0 when every requested assertion holds, 1 otherwise (diagnostics on
+stderr), 2 when the input cannot be parsed at all. The caller supplies the
+expected numbers, so the same checker runs against the real Windows pair and
+against the synthetic mutation fixtures that prove it can fail.
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from yamlmin import YamlError, load_file  # noqa: E402
+
+# Fields every annotation entry must carry, and the field an orphan must add.
+REQUIRED_ENTRY_FIELDS = ('role',)
+ORPHAN_FIELD = 'retained'
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--config', required=True)
+    ap.add_argument('--annotations', required=True)
+    ap.add_argument('--expect-models', type=int)
+    ap.add_argument('--expect-groups', type=int)
+    ap.add_argument('--expect-annotations', type=int)
+    ap.add_argument('--expect-retained', type=int)
+    ap.add_argument('--absent', action='append', default=[],
+                    help='key that must NOT appear in either file')
+    ap.add_argument('--require-text', action='append', default=[],
+                    help='text that must appear somewhere in the annotations')
+    args = ap.parse_args()
+
+    try:
+        cfg = load_file(args.config)
+        ann = load_file(args.annotations)
+    except (YamlError, OSError) as exc:
+        sys.stderr.write('PARSE ERROR: %s\n' % exc)
+        return 2
+
+    bad = []
+
+    def need(cond, msg):
+        if not cond:
+            bad.append(msg)
+
+    # --- config shape -----------------------------------------------------
+    need(isinstance(cfg, dict), 'config did not parse into a mapping')
+    if not isinstance(cfg, dict):
+        sys.stderr.write('FAIL: %s\n' % bad[0])
+        return 1
+    models = cfg.get('models')
+    need(isinstance(models, dict) and models,
+         'config has no non-empty `models:` mapping')
+    models = models if isinstance(models, dict) else {}
+    groups = cfg.get('groups') or {}
+    need(isinstance(groups, dict), '`groups:` is present but not a mapping')
+    groups = groups if isinstance(groups, dict) else {}
+
+    if args.expect_models is not None:
+        need(len(models) == args.expect_models,
+             'expected %d models, parsed %d: %s'
+             % (args.expect_models, len(models), sorted(models)))
+    if args.expect_groups is not None:
+        need(len(groups) == args.expect_groups,
+             'expected %d groups, parsed %d: %s'
+             % (args.expect_groups, len(groups), sorted(groups)))
+
+    # Load smoke: llama-swap needs a cmd and a proxy per model, and every group
+    # member has to name a model that exists. A config that fails either would
+    # start and then fail at first request, which no grep-level check can see.
+    for name, entry in sorted(models.items()):
+        need(isinstance(entry, dict), 'model %r is not a mapping' % name)
+        if not isinstance(entry, dict):
+            continue
+        need(entry.get('cmd'), 'model %r has no `cmd:`' % name)
+        need(entry.get('proxy'), 'model %r has no `proxy:`' % name)
+
+    seen_members = set()
+    for gname, g in sorted(groups.items()):
+        need(isinstance(g, dict), 'group %r is not a mapping' % gname)
+        if not isinstance(g, dict):
+            continue
+        members = g.get('members')
+        need(isinstance(members, list) and members,
+             'group %r has no non-empty `members:` list' % gname)
+        for m in (members or []):
+            need(m in models,
+                 'group %r lists member %r, which is not a model key'
+                 % (gname, m))
+            need(m not in seen_members,
+                 'model %r appears in more than one group' % m)
+            seen_members.add(m)
+
+    # --- annotations shape ------------------------------------------------
+    need(isinstance(ann, dict) and ann,
+         'annotations did not parse into a non-empty mapping')
+    ann = ann if isinstance(ann, dict) else {}
+    if args.expect_annotations is not None:
+        need(len(ann) == args.expect_annotations,
+             'expected %d annotations, parsed %d: %s'
+             % (args.expect_annotations, len(ann), sorted(ann)))
+
+    for name, entry in sorted(ann.items()):
+        need(isinstance(entry, dict), 'annotation %r is not a mapping' % name)
+        if not isinstance(entry, dict):
+            continue
+        for f in REQUIRED_ENTRY_FIELDS:
+            need(entry.get(f) not in (None, ''),
+                 'annotation %r is missing a non-empty `%s:`' % (name, f))
+
+    # --- key-by-key correspondence (both directions) ----------------------
+    for name in sorted(models):
+        need(name in ann, 'model %r has no annotation entry' % name)
+    orphans = sorted(k for k in ann if k not in models)
+    for name in orphans:
+        entry = ann.get(name) or {}
+        need(isinstance(entry, dict) and entry.get(ORPHAN_FIELD) not in (None, ''),
+             'orphan annotation %r carries no non-empty `%s:` reason'
+             % (name, ORPHAN_FIELD))
+    if args.expect_retained is not None:
+        need(len(orphans) == args.expect_retained,
+             'expected %d retained orphans, found %d: %s'
+             % (args.expect_retained, len(orphans), orphans))
+
+    for name in args.absent:
+        need(name not in models, 'model key %r should have been removed' % name)
+        need(name not in ann, 'annotation key %r should have been removed' % name)
+
+    if args.require_text:
+        with open(args.annotations, 'r', encoding='utf-8') as fh:
+            blob = fh.read()
+        for t in args.require_text:
+            need(t in blob, 'required text %r is absent from the annotations' % t)
+
+    if bad:
+        for m in bad:
+            sys.stderr.write('FAIL: %s\n' % m)
+        return 1
+    print('ok: %d models, %d groups, %d annotations, %d retained orphan(s)'
+          % (len(models), len(groups), len(ann), len(orphans)))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/feature-86-win-llama-swap-server/lib/yamlmin.py
+++ b/tests/feature-86-win-llama-swap-server/lib/yamlmin.py
@@ -1,0 +1,207 @@
+"""Minimal strict YAML reader for the llama-swap config/annotation pair.
+
+Vendored because this host has no PyYAML and no yq (probed at authoring time),
+and because grep/awk cannot answer the structural questions C5 asks: how many
+model keys exist, which group holds which member, whether an annotation entry
+really carries `retained:` as its own field rather than as a substring of a
+neighbour's notes.
+
+Deliberately strict, and deliberately NOT a general YAML implementation. It
+covers exactly the subset both files use -- block mappings, block sequences of
+scalars, quoted/plain scalars and folded/literal block scalars -- and raises on
+anything else (tabs, duplicate keys, ragged indentation, flow collections)
+rather than guessing. A parser that guesses would turn a malformed config into
+a green test, which is the failure mode this file exists to prevent.
+"""
+
+
+class YamlError(Exception):
+    """Raised for any input this reader refuses to interpret."""
+
+
+_BLOCK_INDICATORS = ('|', '>', '|-', '>-', '|+', '>+')
+
+
+def _indent_of(raw):
+    n = 0
+    for ch in raw:
+        if ch == ' ':
+            n += 1
+        elif ch == '\t':
+            raise YamlError('tab in indentation')
+        else:
+            break
+    return n
+
+
+def _is_skippable(raw):
+    s = raw.strip()
+    return s == '' or s.startswith('#')
+
+
+def _strip_comment(s):
+    """Drop a trailing `#` comment that starts outside a quoted scalar."""
+    out = []
+    quote = None
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if quote is not None:
+            out.append(c)
+            if c == '\\' and quote == '"' and i + 1 < len(s):
+                i += 1
+                out.append(s[i])
+            elif c == quote:
+                quote = None
+        elif c in '"\'':
+            quote = c
+            out.append(c)
+        elif c == '#' and (not out or out[-1] in ' \t'):
+            break
+        else:
+            out.append(c)
+        i += 1
+    return ''.join(out).rstrip()
+
+
+def _scalar(text):
+    s = text.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in '"\'':
+        return s[1:-1]
+    # `used_by: []` is the one flow form both real files use; any other flow
+    # collection is refused rather than silently read as a string.
+    if s == '[]':
+        return []
+    if s == '{}':
+        return {}
+    if s.startswith('[') or s.startswith('{'):
+        raise YamlError('non-empty flow collections are not supported: %s' % s)
+    if s in ('true', 'True'):
+        return True
+    if s in ('false', 'False'):
+        return False
+    if s in ('null', '~', ''):
+        return None
+    try:
+        return int(s)
+    except ValueError:
+        return s
+
+
+class _Reader(object):
+    def __init__(self, text):
+        self.lines = text.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+        self.i = 0
+
+    def _next_significant(self):
+        j = self.i
+        while j < len(self.lines) and _is_skippable(self.lines[j]):
+            j += 1
+        return j
+
+    def _block_scalar(self, key_indent):
+        """Consume the body of a `>-`/`|` scalar: every deeper-indented line."""
+        parts = []
+        while self.i < len(self.lines):
+            raw = self.lines[self.i]
+            if raw.strip() == '':
+                parts.append('')
+                self.i += 1
+                continue
+            if _indent_of(raw) <= key_indent:
+                break
+            parts.append(raw.strip())
+            self.i += 1
+        return ' '.join(p for p in parts if p != '')
+
+    def parse_node(self, indent):
+        j = self._next_significant()
+        if j >= len(self.lines):
+            return None
+        self.i = j
+        if _strip_comment(self.lines[j]).strip().startswith('- '):
+            return self.parse_sequence(indent)
+        return self.parse_mapping(indent)
+
+    def parse_sequence(self, indent):
+        items = []
+        while True:
+            j = self._next_significant()
+            if j >= len(self.lines):
+                break
+            raw = self.lines[j]
+            cur = _indent_of(raw)
+            if cur < indent:
+                break
+            if cur > indent:
+                raise YamlError('line %d: unexpected indent inside sequence' % (j + 1))
+            body = _strip_comment(raw).strip()
+            if not body.startswith('- '):
+                if body == '-':
+                    raise YamlError('line %d: empty sequence entry' % (j + 1))
+                break
+            self.i = j + 1
+            item = body[2:]
+            # A nested mapping under a sequence entry would be read as the plain
+            # string "key: value"; refuse instead of returning a wrong shape.
+            k = self._next_significant()
+            if k < len(self.lines) and _indent_of(self.lines[k]) > cur:
+                raise YamlError('line %d: nested block under a sequence entry '
+                                'is not supported' % (j + 1))
+            items.append(_scalar(item))
+        return items
+
+    def parse_mapping(self, indent):
+        out = {}
+        while True:
+            j = self._next_significant()
+            if j >= len(self.lines):
+                break
+            raw = self.lines[j]
+            cur = _indent_of(raw)
+            if cur < indent:
+                break
+            if cur > indent:
+                raise YamlError('line %d: unexpected indent inside mapping' % (j + 1))
+            body = _strip_comment(raw).strip()
+            if body.startswith('- '):
+                break
+            if ':' not in body:
+                raise YamlError('line %d: not a mapping entry: %r' % (j + 1, body))
+            key, _, rest = body.partition(':')
+            key = key.strip().strip('"\'')
+            rest = rest.strip()
+            if key in out:
+                raise YamlError('line %d: duplicate key %r' % (j + 1, key))
+            self.i = j + 1
+            if rest in _BLOCK_INDICATORS:
+                out[key] = self._block_scalar(cur)
+            elif rest == '':
+                k = self._next_significant()
+                if k < len(self.lines):
+                    child_indent = _indent_of(self.lines[k])
+                    child_body = _strip_comment(self.lines[k]).strip()
+                    if child_indent > cur:
+                        out[key] = self.parse_node(child_indent)
+                        continue
+                    if child_indent == cur and child_body.startswith('- '):
+                        out[key] = self.parse_sequence(cur)
+                        continue
+                out[key] = None
+            else:
+                out[key] = _scalar(rest)
+        return out
+
+
+def loads(text):
+    r = _Reader(text)
+    value = r.parse_node(0)
+    j = r._next_significant()
+    if j < len(r.lines):
+        raise YamlError('line %d: trailing content the reader could not attach' % (j + 1))
+    return {} if value is None else value
+
+
+def load_file(path):
+    with open(path, 'r', encoding='utf-8') as fh:
+        return loads(fh.read())

--- a/tests/feature-86-win-llama-swap-server/test-caddyfile-template.sh
+++ b/tests/feature-86-win-llama-swap-server/test-caddyfile-template.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Tests: install/win/Caddyfile.template, install/win/llama-swap-service.ps1
+# Tags: caddy, caddyfile, template, tls, placeholder, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: this template is permanent infrastructure and the placeholder/port contract outlives issue #86.
+# Asserts the template carries no absolute cert path (paths belong to install.ps1 alone), exactly 10 {{CERT_DIR}} placeholders, and that each of the 5 ports is a self-contained site block: its own tls pair, its own reverse_proxy upstream. Then renders it and hands the result to caddy's own parser. Rationale: detail plan 4-6 / 6-3.
+# Skips (exit 77) until install/win/Caddyfile.template exists (implementation pending) -- an explicit skip, never a silent pass. The caddy arm degrades to a note when caddy is off PATH; the structural cases still run.
+# TL3 gap (what this test does NOT catch):
+# - full `caddy validate` provisioning: the certificate files live outside the repo, so validate is only held to "no error other than loading them"
+# - whether the 5 upstreams are actually listening, so a rendered-but-dead route looks identical here
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh category: installer
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see
+# tests/feature-18-serverctl/test-repo-derivation.sh); export REPO=<path> to
+# point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+TEMPLATE="$REPO/install/win/Caddyfile.template"
+
+[ -f "$TEMPLATE" ] || { echo "SKIP: $TEMPLATE not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Sanity: an empty file would satisfy several "absence" assertions below.
+[ -s "$TEMPLATE" ] || fail "$TEMPLATE is empty"
+
+# --- 1. no absolute certificate path literals -----------------------------
+# The single owner of path literals is install.ps1 ($CertDir); a drive-letter or
+# /c/-style path here means the template went back to hardcoding host paths.
+if grep -nE '[A-Za-z]:\\' "$TEMPLATE"; then
+    fail "$TEMPLATE contains a drive-letter absolute path (must use {{CERT_DIR}})"
+fi
+if grep -nE '(^|[^A-Za-z0-9_.-])/[a-zA-Z]/(LLM|Users|git)/' "$TEMPLATE"; then
+    fail "$TEMPLATE contains a /c/-style absolute path (must use {{CERT_DIR}})"
+fi
+
+# Every .pem reference must be rooted at the placeholder, not at anything else.
+BAD_PEM="$(grep -oE '[^[:space:]]*\.pem' "$TEMPLATE" | grep -v '^{{CERT_DIR}}[\\/]' || true)"
+[ -z "$BAD_PEM" ] || fail "$TEMPLATE references .pem files not rooted at {{CERT_DIR}}: $BAD_PEM"
+
+# --- 2. exactly 10 placeholders (5 blocks x cert + key) --------------------
+PH_COUNT="$(grep -o '{{CERT_DIR}}' "$TEMPLATE" | wc -l | tr -d ' ')"
+[ "$PH_COUNT" -eq 10 ] || fail "expected exactly 10 '{{CERT_DIR}}' occurrences (5 tls blocks x cert+key), found $PH_COUNT"
+
+# No other placeholder shape may creep in unnoticed: llama-swap-service.ps1
+# substitutes {{CERT_DIR}} only, so any other {{...}} would ship verbatim.
+OTHER_PH="$(grep -oE '\{\{[A-Za-z0-9_]+\}\}' "$TEMPLATE" | grep -v '^{{CERT_DIR}}$' | sort -u || true)"
+[ -z "$OTHER_PH" ] || fail "unsubstituted placeholder(s) other than {{CERT_DIR}} present: $OTHER_PH"
+
+# --- 3. all 5 site blocks present, each with its own reverse_proxy ---------
+# Block map from detail plan 4-6: front TLS port -> plaintext upstream port.
+awk '
+    /^[[:space:]]*:[0-9]+[[:space:]]*\{/ {
+        line = $0
+        sub(/^[[:space:]]*:/, "", line)
+        sub(/[^0-9].*$/, "", line)
+        port = line
+        blocks[port] = 1
+        cur = port
+        next
+    }
+    /^[[:space:]]*\}/ { cur = ""; next }
+    cur != "" && /reverse_proxy/ {
+        rp[cur] = rp[cur] + 1
+        up = $0
+        sub(/^.*reverse_proxy[[:space:]]+/, "", up)
+        sub(/[[:space:]].*$/, "", up)
+        upstream[cur] = up
+    }
+    cur != "" && $1 == "tls" {
+        tls[cur] = tls[cur] + 1
+        c = $2; k = $3
+        gsub(/^"|"$/, "", c); gsub(/^"|"$/, "", k)   # quoting the paths is allowed
+        cert[cur] = c
+        key[cur]  = k
+    }
+    END {
+        for (p in blocks)
+            printf "BLOCK %s %d %s %d %s %s\n", p, rp[p] + 0, upstream[p], tls[p] + 0, \
+                (cert[p] == "" ? "-" : cert[p]), (key[p] == "" ? "-" : key[p])
+    }
+' "$TEMPLATE" > "$WORK/blocks"
+
+[ -s "$WORK/blocks" ] || fail "parsed 0 site blocks out of $TEMPLATE (parser broken or template restructured)"
+
+BLOCK_N="$(wc -l < "$WORK/blocks" | tr -d ' ')"
+[ "$BLOCK_N" -eq 5 ] || fail "expected exactly 5 site blocks, parsed $BLOCK_N (see $TEMPLATE)"
+
+# Each port is checked as a whole block: its own upstream AND its own tls pair.
+# A file-wide "5 tls directives" count is satisfied by five tls lines in one
+# block and none in the other four, which is exactly the shape that silently
+# serves four ports as plaintext.
+check_block() {
+    _port="$1"; _upstream="$2"
+    _line="$(grep "^BLOCK $_port " "$WORK/blocks" || true)"
+    [ -n "$_line" ] || fail "no ':$_port' site block in $TEMPLATE"
+    set -- $_line
+    _rp="$3"; _up="$4"; _tls="$5"; _cert="$6"; _key="$7"
+
+    [ "$_rp" -eq 1 ] || fail "block ':$_port' has $_rp reverse_proxy directives, expected exactly 1"
+    case "$_up" in
+        *:"$_upstream") ;;
+        *) fail "block ':$_port' proxies to '$_up', expected an upstream on port $_upstream" ;;
+    esac
+
+    [ "$_tls" -eq 1 ] || fail "block ':$_port' has $_tls 'tls' directives, expected exactly 1 -- a port without its own tls line is served as plaintext on an HTTPS port"
+    case "$_cert" in
+        '{{CERT_DIR}}'[\\/]*.pem) ;;
+        *) fail "block ':$_port' takes its certificate from '$_cert', expected a {{CERT_DIR}}-rooted .pem" ;;
+    esac
+    case "$_key" in
+        '{{CERT_DIR}}'[\\/]*.pem) ;;
+        *) fail "block ':$_port' takes its key from '$_key', expected a {{CERT_DIR}}-rooted .pem" ;;
+    esac
+    [ "$_cert" != "$_key" ] || fail "block ':$_port' names the same file as both certificate and key ($_cert)"
+}
+
+check_block 8443  18080   # llama-swap
+check_block 3443  3000    # Open WebUI
+check_block 18790 18789   # JudgeClaw
+check_block 8444  8100    # LangChain
+check_block 13443 13000   # Langfuse
+
+# --- 4. no tls directive outside a site block ------------------------------
+# The per-block count above cannot see a stray global tls line; a global one
+# would look like "TLS is configured" while overriding nothing per port.
+TLS_N="$(grep -cE '^[[:space:]]*tls[[:space:]]' "$TEMPLATE" | tr -d ' ')"
+[ "$TLS_N" -eq 5 ] || fail "expected exactly 5 'tls' directives file-wide (one per block), found $TLS_N"
+
+# --- 5. rendering is total and repeatable ----------------------------------
+# Two directories on purpose. The spaced one answers "is the substitution total
+# and value-independent" -- a CertDir carrying a space must still land in every
+# one of the 10 slots. The plain one is what goes to caddy below, because
+# whether an unquoted spaced path is a valid Caddyfile token is a question about
+# the template's quoting style, not about this substitution.
+render() {
+    _dir="$1"; _out="$2"
+    sed "s|{{CERT_DIR}}|$(printf '%s' "$_dir" | sed 's/[&|\\]/\\&/g')|g" "$TEMPLATE" > "$_out"
+}
+render 'C:\LLM\cert store\llama-swap' "$WORK/rendered-spaced"
+render 'C:\LLM\cert store\llama-swap' "$WORK/rendered-spaced2"
+render 'C:\LLM\certs\llama-swap'      "$WORK/rendered"
+
+cmp -s "$WORK/rendered-spaced" "$WORK/rendered-spaced2" || fail "rendering the template twice produced different output"
+cmp -s "$WORK/rendered-spaced" "$TEMPLATE" && fail "rendering changed nothing -- the substitution did not run"
+
+for r in "$WORK/rendered-spaced" "$WORK/rendered"; do
+    if grep -nE '\{\{[A-Za-z0-9_]+\}\}' "$r"; then
+        fail "a placeholder survived rendering -- llama-swap-service.ps1 would ship it verbatim to caddy"
+    fi
+done
+
+RENDERED_PEM="$(grep -o 'cert store' "$WORK/rendered-spaced" | wc -l | tr -d ' ')"
+[ "$RENDERED_PEM" -eq 10 ] || fail "expected the spaced CertDir in all 10 slots, found $RENDERED_PEM"
+
+# --- 6. caddy's own parser accepts it --------------------------------------
+if ! command -v caddy >/dev/null 2>&1; then
+    echo "  note: caddy not on PATH - skipping the adapt/validate arm (the structural cases above still ran)"
+else
+    # `caddy adapt` is the full Caddyfile parser without provisioning, so it can
+    # run against paths that do not exist on this machine. Its JSON is then the
+    # authority for the per-port structure, independent of the awk above.
+    if ! caddy adapt --adapter caddyfile --config "$(cygpath -m -- "$WORK/rendered" 2>/dev/null || printf '%s' "$WORK/rendered")" > "$WORK/adapted.json" 2> "$WORK/adapt.err"; then
+        cat "$WORK/adapt.err" >&2
+        fail "caddy rejected the rendered template"
+    fi
+
+    for p in 8443 3443 18790 8444 13443; do
+        grep -Fq -- "\":$p\"" "$WORK/adapted.json"
+        rc=$?
+        [ "$rc" -le 1 ] || fail "grep exited $rc reading the adapted JSON"
+        [ "$rc" -eq 0 ] || fail "caddy's adapted config has no listener on :$p"
+    done
+
+    # Caddy de-duplicates identical cert/key pairs into one load_files entry, so
+    # the countable per-port fact is the TLS connection policy: five servers,
+    # five policies. Four ports left plaintext would show four policies.
+    POLICIES="$(grep -o '"tls_connection_policies"' "$WORK/adapted.json" | wc -l | tr -d ' ')"
+    [ "$POLICIES" -eq 5 ] || fail "caddy produced $POLICIES TLS connection policies, expected 5 (one per site block) -- a port without one is served as plaintext"
+
+    grep -Fq -- '"load_files"' "$WORK/adapted.json"
+    rc=$?
+    [ "$rc" -le 1 ] || fail "grep exited $rc reading the adapted JSON"
+    [ "$rc" -eq 0 ] || fail "caddy's adapted config loads no certificate file at all"
+
+    # `caddy validate` additionally provisions, which reads the certificate files
+    # themselves. Those live outside the repo and are absent in CI, so the only
+    # acceptable failure here is that one -- any other error is a real defect.
+    if ! caddy validate --adapter caddyfile --config "$(cygpath -m -- "$WORK/rendered" 2>/dev/null || printf '%s' "$WORK/rendered")" > "$WORK/validate.out" 2>&1; then
+        grep -Fq -- 'loading certificates' "$WORK/validate.out"
+        rc=$?
+        [ "$rc" -le 1 ] || fail "grep exited $rc reading the caddy validate output"
+        if [ "$rc" -ne 0 ]; then
+            cat "$WORK/validate.out" >&2
+            fail "caddy validate failed for a reason other than the absent certificate files"
+        fi
+    fi
+fi
+
+echo "PASS: test-caddyfile-template (5 blocks, $PH_COUNT placeholders, each with its own tls pair)"

--- a/tests/feature-86-win-llama-swap-server/test-config-annotations-parity.sh
+++ b/tests/feature-86-win-llama-swap-server/test-config-annotations-parity.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Tests: llama-swap/rtx5070ti-128gb/config.yaml, llama-swap/rtx5070ti-128gb/model-annotations.yaml, llama-swap/m5-max-128gb/config.yaml, llama-swap/m5-max-128gb/model-annotations.yaml, CLAUDE.md
+# Tags: llama-swap, model-annotations, parity, yaml, secret-scan, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: the config <-> annotations rule is a standing CLAUDE.md rule for every host dir, so this is permanent coverage.
+# Enforces it across the whole class of llama-swap/<chip>-<memory>/ dirs (CPR-E2C) plus the PUBLIC-ification redaction. Rationale: detail plan 6-1.
+# Skips (exit 77) until llama-swap/rtx5070ti-128gb/config.yaml exists (implementation pending).
+# TL3 gap (what this test does NOT catch):
+# - whether llama-swap actually loads this config and serves the models
+# - whether the .gguf / llama-server.exe paths in cmd: exist on the real host (only TL3-installer-llama-cpp-build.sh under RUN_TL3 checks that)
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh category: installer
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see
+# tests/feature-18-serverctl/test-repo-derivation.sh); export REPO=<path> to
+# point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+SWAP_DIR="$REPO/llama-swap"
+WIN_DIR="$SWAP_DIR/rtx5070ti-128gb"
+
+[ -f "$WIN_DIR/config.yaml" ] || { echo "SKIP: $WIN_DIR/config.yaml not found (implementation pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# grep_state <file> <flags> <pattern>: 0 = match, 1 = clean miss, never anything
+# else. MSYS2 grep can abort (SIGABRT, rc 134), and an aborted grep is
+# indistinguishable from "no match" at an `if` -- which would turn the security
+# cases below into false greens. rc > 1 is a tool failure, not a clean miss.
+grep_state() {
+    grep "$2" -- "$3" "$1" > "$WORK/hits"
+    _rc=$?
+    [ "$_rc" -le 1 ] || fail "grep exited $_rc scanning $1 -- cannot conclude the pattern is absent"
+    return "$_rc"
+}
+
+# --- parsers (no yq; top-level keys at indent 0, model keys at indent 2) ----
+# A 4-space-indented line cannot match `^  [A-Za-z...]` -- its 3rd char is a space.
+config_keys() {
+    awk '
+        /^models:[[:space:]]*$/ { inm = 1; next }
+        inm && /^[^[:space:]#]/ { inm = 0 }
+        inm && /^  [A-Za-z0-9._-]+:/ { k = $0; sub(/^  /, "", k); sub(/:.*$/, "", k); print k }
+    ' "$1"
+}
+
+annotation_keys() {
+    awk '/^[A-Za-z0-9._-]+:/ { k = $0; sub(/:.*$/, "", k); print k }' "$1"
+}
+
+# Does annotation entry <key> carry field <field> at indent 2? substr(), not a
+# regex: model keys contain `.` and `-`, which would match the wrong entry.
+entry_has_field() {
+    awk -v k="$2" -v f="$3" '
+        substr($0, 1, length(k) + 1) == k ":" { inb = 1; next }
+        inb && /^[A-Za-z0-9._-]+:/ { inb = 0 }
+        inb && substr($0, 1, length(f) + 3) == "  " f ":" { found = 1 }
+        END { exit(found ? 0 : 1) }
+    ' "$1"
+}
+
+# --- the checker under test ------------------------------------------------
+# Returns 0 when the pair satisfies the rule, 1 otherwise; never exits, so case
+# 5 can call it on a broken fixture and assert the status.
+check_pair() {
+    _cfg="$1"; _ann="$2"; _label="$3"
+    _bad=0
+
+    _ckeys="$(config_keys "$_cfg")"
+    _akeys="$(annotation_keys "$_ann")"
+
+    # A parser that produced nothing would make every loop below vacuous.
+    if [ -z "$_ckeys" ]; then
+        echo "  [$_label] parsed 0 model keys out of $_cfg (parser broken or file empty)" >&2
+        return 1
+    fi
+    if [ -z "$_akeys" ]; then
+        echo "  [$_label] parsed 0 annotation keys out of $_ann (parser broken or file empty)" >&2
+        return 1
+    fi
+
+    # Forward rule: every config model key is annotated.
+    for _k in $_ckeys; do
+        if ! printf '%s\n' "$_akeys" | grep -Fxq -- "$_k"; then
+            echo "  [$_label] config model '$_k' has no entry in $(basename "$_ann")" >&2
+            _bad=1
+        fi
+    done
+
+    for _k in $_akeys; do
+        # Every annotation entry states what the model is for.
+        if ! entry_has_field "$_ann" "$_k" "role"; then
+            echo "  [$_label] annotation '$_k' is missing 'role:'" >&2
+            _bad=1
+        fi
+        # Reverse rule: an orphan annotation must justify itself with `retained:`.
+        if ! printf '%s\n' "$_ckeys" | grep -Fxq -- "$_k"; then
+            if ! entry_has_field "$_ann" "$_k" "retained"; then
+                echo "  [$_label] annotation '$_k' has no config counterpart and no 'retained:' reason" >&2
+                _bad=1
+            fi
+        fi
+    done
+
+    return "$_bad"
+}
+
+# --- 1. every populated host directory satisfies the rule ------------------
+SCANNED=0
+for d in "$SWAP_DIR"/*/; do
+    [ -d "$d" ] || continue
+    label="$(basename "$d")"
+    cfg="$d/config.yaml"
+    ann="$d/model-annotations.yaml"
+
+    # Edge: a host directory without a config.yaml is skipped, not fatal.
+    if [ ! -f "$cfg" ]; then
+        echo "note: $label has no config.yaml -- not a populated host directory, skipped"
+        continue
+    fi
+    [ -f "$ann" ] || fail "$label has config.yaml but no model-annotations.yaml (CLAUDE.md requires the pair)"
+
+    check_pair "$cfg" "$ann" "$label" || fail "$label violates the config <-> annotations rule (see messages above)"
+    SCANNED=$((SCANNED + 1))
+done
+
+# A glob that matched nothing would leave every assertion above unexecuted.
+[ "$SCANNED" -ge 2 ] || fail "expected at least 2 populated host directories under $SWAP_DIR, scanned $SCANNED"
+
+# --- 2. the Windows side really does exercise the reverse rule -------------
+# Without it, deleting every retained orphan makes case 1's reverse branch vacuous.
+WIN_CFG_N="$(config_keys "$WIN_DIR/config.yaml" | wc -l | tr -d ' ')"
+WIN_ANN_N="$(annotation_keys "$WIN_DIR/model-annotations.yaml" | wc -l | tr -d ' ')"
+[ "$WIN_ANN_N" -gt "$WIN_CFG_N" ] || fail "rtx5070ti-128gb: expected more annotations than config models (retained orphans), got $WIN_ANN_N annotations vs $WIN_CFG_N models"
+
+RETAINED=0
+for k in $(annotation_keys "$WIN_DIR/model-annotations.yaml"); do
+    if entry_has_field "$WIN_DIR/model-annotations.yaml" "$k" "retained"; then
+        RETAINED=$((RETAINED + 1))
+    fi
+done
+[ "$RETAINED" -ge 1 ] || fail "rtx5070ti-128gb: no annotation carries 'retained:' -- the reverse rule is never exercised"
+
+# --- 3. the Mac member of the class, by name and by the same field set -----
+# CPR-ORTH: "some other directory exists" is not symmetry. The sibling is
+# m5-max-128gb specifically -- same <chip>-<memory> naming, same two files and
+# nothing else, same annotation schema as the Windows side.
+MAC_DIR="$SWAP_DIR/m5-max-128gb"
+[ -f "$MAC_DIR/config.yaml" ] || fail "$MAC_DIR/config.yaml not found -- the Mac member of the <chip>-<memory> class is the named counterpart, not 'whichever other directory happens to exist'"
+[ -f "$MAC_DIR/model-annotations.yaml" ] || fail "$MAC_DIR/model-annotations.yaml not found"
+
+# 3a. every host directory follows <chip>-<memory>; the memory half is digits+gb.
+for d in "$SWAP_DIR"/*/; do
+    name="$(basename "$d")"
+    case "$name" in
+        -*|*-) fail "host directory '$name' does not follow <chip>-<memory>" ;;
+        *-*gb) ;;
+        *) fail "host directory '$name' does not follow <chip>-<memory> (llama-swap/README.md)" ;;
+    esac
+    mem="${name##*-}"
+    mem="${mem%gb}"
+    case "$mem" in
+        ''|*[!0-9]*) fail "host directory '$name': memory part '${name##*-}' is not <digits>gb" ;;
+    esac
+done
+
+# 3b. a populated host directory holds exactly the two permitted files. A stray
+# .bak or second config makes "which file is authoritative" ambiguous.
+for d in "$SWAP_DIR"/*/; do
+    [ -f "$d/config.yaml" ] || continue
+    for entry in $(ls -A "$d"); do
+        case "$entry" in
+            config.yaml|model-annotations.yaml) ;;
+            *) fail "$(basename "$d") contains '$entry'; a populated host directory holds exactly config.yaml and model-annotations.yaml" ;;
+        esac
+    done
+done
+
+# 3c. the shared annotation schema. Both hosts draw fields from one set; only
+# Windows may add `optimizer:` -- the optimizer tunes llama.cpp, not MLX.
+entry_fields() {
+    awk -v k="$2" '
+        substr($0, 1, length(k) + 1) == k ":" { inb = 1; next }
+        inb && /^[A-Za-z0-9._-]+:/ { inb = 0 }
+        inb && /^  [A-Za-z0-9._-]+:/ { f = $0; sub(/^  /, "", f); sub(/:.*$/, "", f); print f }
+    ' "$1"
+}
+
+for d in "$SWAP_DIR"/*/; do
+    [ -f "$d/config.yaml" ] || continue
+    label="$(basename "$d")"
+    ann="$d/model-annotations.yaml"
+    fields_seen=0
+    for k in $(annotation_keys "$ann"); do
+        for f in $(entry_fields "$ann" "$k"); do
+            fields_seen=$((fields_seen + 1))
+            case "$f" in
+                role|used_by|notes|decision|retained) ;;
+                optimizer)
+                    [ "$label" = "m5-max-128gb" ] && fail "[$label] annotation '$k' uses 'optimizer:', which the Mac format excludes"
+                    ;;
+                *) fail "[$label] annotation '$k' carries unknown field '$f:' -- the two hosts share one annotation schema (role/used_by/notes/decision/retained, plus optimizer on Windows only)" ;;
+            esac
+        done
+    done
+    [ "$fields_seen" -gt 0 ] || fail "[$label] parsed 0 annotation fields -- the schema check is vacuous"
+done
+
+# --- 4. security: the PUBLIC-ification redaction never regresses -----------
+# Case-folded by lowering the haystack rather than with `grep -i`, which MSYS2
+# grep aborts on here; see grep_state above for why that distinction matters.
+# Tokens are base64 in the source so the private names they guard against are
+# never themselves committed in plaintext to this public repo; decoded only in
+# memory at test time for the comparison.
+decode_token() { printf '%s' "$1" | base64 -d; }
+PRIVATE_TOKENS_B64="bmVtb2NsYXc= YWktc3BlY3M= cHJpdmF0ZS1zcGVjcy1yZXBv"
+
+for f in "$WIN_DIR/config.yaml" "$WIN_DIR/model-annotations.yaml"; do
+    tr '[:upper:]' '[:lower:]' < "$f" > "$WORK/folded"
+    for token_b64 in $PRIVATE_TOKENS_B64; do
+        token="$(decode_token "$token_b64")"
+        if grep_state "$WORK/folded" -F "$token"; then
+            fail "a redacted private token reappeared in ${f#"$REPO/"} -- redaction from Commit 2 was undone"
+        fi
+    done
+done
+
+# 4b. the redaction scan itself must be able to fire: same fold + grep against a
+# line that does carry the token in the OPPOSITE case, so case 4's silence means
+# "absent", not "broken" (a same-case probe would pass even without folding).
+probe_token="$(decode_token bmVtb2NsYXc=)"
+probe_upper="$(printf '%s' "$probe_token" | tr '[:lower:]' '[:upper:]')"
+printf 'notes: "used by %s"\n' "$probe_upper" > "$WORK/redaction-probe"
+tr '[:upper:]' '[:lower:]' < "$WORK/redaction-probe" > "$WORK/folded"
+grep_state "$WORK/folded" -F "$probe_token" || fail "redaction probe: the case-folded scan missed the upper-cased probe token -- case 4 cannot detect a regression"
+
+# 4c. structural arm: the token list above only knows the three spellings that
+# existed at migration time. These patterns catch the SHAPE of a private
+# reference -- any repo/host reference, a cross-repo markdown link, an absolute
+# host .md path -- so a fourth private name nobody listed still fails.
+REDACTION_PATTERNS='github\.com[:/]|nirecom/|\]\([^)]*\.md|[A-Za-z]:\\[^"[:space:]]*\.md'
+for f in "$WIN_DIR/config.yaml" "$WIN_DIR/model-annotations.yaml"; do
+    if grep_state "$f" -nE "$REDACTION_PATTERNS"; then
+        fail "${f#"$REPO/"} carries a private-reference shape (repo link, cross-repo .md link or host .md path): $(cat "$WORK/hits")"
+    fi
+done
+
+# 4d. the structural arm must be able to fire too.
+printf 'decision: "see https://github.com/example/private-thing/blob/main/history.md"\n' > "$WORK/shape-probe"
+grep_state "$WORK/shape-probe" -nE "$REDACTION_PATTERNS" || fail "structural redaction probe: the pattern arm missed an obvious repo link -- case 4c cannot detect a regression"
+
+# --- 6. CLAUDE.md states the rule this file enforces (C11) -----------------
+# The reverse rule lives in CLAUDE.md; this test is only its enforcement arm.
+# Without this case, deleting the rule would leave the tests passing.
+CLAUDE_MD="$REPO/CLAUDE.md"
+[ -f "$CLAUDE_MD" ] || fail "$CLAUDE_MD not found -- the retained-orphan rule has no home"
+
+docs_rules_section() {
+    awk '
+        /^## Docs Update Rules[[:space:]]*$/ { ins = 1; next }
+        ins && /^## / { ins = 0 }
+        ins { print }
+    ' "$1"
+}
+
+docs_rules_section "$CLAUDE_MD" > "$WORK/docs-rules"
+[ -s "$WORK/docs-rules" ] || fail "CLAUDE.md has no '## Docs Update Rules' section (or it is empty) -- the annotation rules lost their SSOT"
+
+grep_state "$WORK/docs-rules" -F 'retained:' || fail "CLAUDE.md's '## Docs Update Rules' never mentions 'retained:' -- the reverse rule (an orphan annotation may stay only with a written reason) is unstated, so this test enforces a rule the repo no longer declares"
+grep_state "$WORK/docs-rules" -F 'config.yaml' || fail "CLAUDE.md's '## Docs Update Rules' does not mention config.yaml -- the forward rule is unstated"
+
+# 6b. the section extractor must be able to come back empty, or case 6 would
+# pass on any file that merely contains the word 'retained:' somewhere.
+printf '# Rules\n\n## Docs Update Rules\n\nUpdate the annotations beside config.yaml.\n\n## Other\n\nretained: not here\n' > "$WORK/claude-probe"
+docs_rules_section "$WORK/claude-probe" > "$WORK/probe-section"
+if grep_state "$WORK/probe-section" -F 'retained:'; then
+    fail "CLAUDE.md probe: the section extractor leaked text from a later '## ' section -- case 6 would pass on a rule stated nowhere near the docs rules"
+fi
+
+# --- 5. mutation probe: the checker must reject a deliberately broken pair --
+MUT="$WORK/mutant"
+mkdir -p "$MUT"
+printf 'healthCheckTimeout: 600\nmodels:\n  alpha-model:\n    cmd: true\n  beta-model:\n    cmd: true\n' > "$MUT/config.yaml"
+
+# 5a. missing annotation for beta-model
+printf 'alpha-model:\n  role: probe\n' > "$MUT/model-annotations.yaml"
+if check_pair "$MUT/config.yaml" "$MUT/model-annotations.yaml" mutant-missing 2>/dev/null; then
+    fail "mutation probe 5a: checker accepted a config model with no annotation (false-green parser)"
+fi
+
+# 5b. annotation without role:
+printf 'alpha-model:\n  role: probe\nbeta-model:\n  notes: "no role here"\n' > "$MUT/model-annotations.yaml"
+if check_pair "$MUT/config.yaml" "$MUT/model-annotations.yaml" mutant-norole 2>/dev/null; then
+    fail "mutation probe 5b: checker accepted an annotation with no 'role:'"
+fi
+
+# 5c. orphan annotation without retained:
+printf 'alpha-model:\n  role: probe\nbeta-model:\n  role: probe\ngamma-model:\n  role: probe\n' > "$MUT/model-annotations.yaml"
+if check_pair "$MUT/config.yaml" "$MUT/model-annotations.yaml" mutant-orphan 2>/dev/null; then
+    fail "mutation probe 5c: checker accepted an orphan annotation with no 'retained:'"
+fi
+
+# 5d. classifier guard: the same fixture, made compliant, must pass -- a checker
+# hardwired to fail would satisfy 5a-5c and still be wrong.
+printf 'alpha-model:\n  role: probe\nbeta-model:\n  role: probe\ngamma-model:\n  role: probe\n  retained: "kept on purpose for the probe"\n' > "$MUT/model-annotations.yaml"
+check_pair "$MUT/config.yaml" "$MUT/model-annotations.yaml" mutant-ok || fail "mutation probe 5d: checker rejected a compliant fixture (over-blocking)"
+
+echo "PASS: test-config-annotations-parity ($SCANNED host directories, $RETAINED retained annotation(s))"

--- a/tests/feature-86-win-llama-swap-server/test-config-yaml-structure.sh
+++ b/tests/feature-86-win-llama-swap-server/test-config-yaml-structure.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Tests: llama-swap/rtx5070ti-128gb/config.yaml, llama-swap/rtx5070ti-128gb/model-annotations.yaml, llama-swap/m5-max-128gb/config.yaml, llama-swap/m5-max-128gb/model-annotations.yaml
+# Tags: llama-swap, yaml, parser, config, model-annotations, layer:TL2, scope:issue-specific
+# scope:issue-specific: the exact 11/3/14/3 counts and the three deleted-orphan names are the #86 migration's own arithmetic; the standing rule itself is covered by test-config-annotations-parity.sh.
+# Answers the questions grep cannot: a real parse of both files (duplicate keys and ragged indentation rejected), exact model/group/annotation/retained counts, key-by-key correspondence both ways, group membership resolution, and a load smoke check that every model carries the cmd:/proxy: llama-swap needs. Rationale: detail plan 2-1 / 2-2 / 6-1.
+# Parser is vendored at lib/yamlmin.py -- this host has neither PyYAML nor yq (probed); with no python3 at all the file skips with that reason rather than degrading to substring checks.
+# Skips (exit 77) until llama-swap/rtx5070ti-128gb/config.yaml exists (implementation pending).
+# TL3 gap (what this test does NOT catch):
+# - whether llama-swap itself accepts the file (its own schema is stricter than "has cmd and proxy")
+# - whether the .gguf / llama-server.exe paths the cmd: strings name exist on the host (TL3-installer-llama-cpp-build.sh under RUN_TL3)
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh category: installer
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see
+# tests/feature-18-serverctl/test-repo-derivation.sh); export REPO=<path> to
+# point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+CHECK="$HERE/lib/check-config-pair.py"
+SWAP_DIR="$REPO/llama-swap"
+WIN_DIR="$SWAP_DIR/rtx5070ti-128gb"
+
+[ -f "$CHECK" ] || { echo "FAIL: $CHECK not found" >&2; exit 1; }
+[ -f "$WIN_DIR/config.yaml" ] || { echo "SKIP: $WIN_DIR/config.yaml not found (implementation pending)"; exit 77; }
+
+PY=""
+for c in python3 python; do
+    command -v "$c" >/dev/null 2>&1 && { PY="$c"; break; }
+done
+[ -n "$PY" ] || { echo "SKIP: no python3/python on PATH - lib/yamlmin.py needs one (PyYAML and yq are both absent on this host, so there is no fallback parser)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# run_check <expect-rc> <label> <args...>
+run_check() {
+    _want="$1"; _label="$2"; shift 2
+    "$PY" "$CHECK" "$@" > "$WORK/out" 2>&1
+    _rc=$?
+    if [ "$_rc" -ne "$_want" ]; then
+        echo "--- checker output ---" >&2
+        cat "$WORK/out" >&2
+        fail "$_label: checker exited $_rc, expected $_want"
+    fi
+}
+
+# --- 1. the Windows pair, by exact count and by name -----------------------
+# 11 models / 3 groups / 14 annotations / 3 retained orphans is the arithmetic
+# the migration decided (detail plan 2-2 and its accepted tradeoff). A silent
+# drift in any of the four is the regression this case exists for.
+run_check 0 "rtx5070ti-128gb structure" \
+    --config "$WIN_DIR/config.yaml" \
+    --annotations "$WIN_DIR/model-annotations.yaml" \
+    --expect-models 11 --expect-groups 3 \
+    --expect-annotations 14 --expect-retained 3 \
+    --absent gemma-3-4b-it-Q4_K_M \
+    --absent Mistral-22B-v0.2-Q4_K_S \
+    --absent Qwen3-8B-Q4_K_M \
+    --require-text '<private-agent-project>'
+echo "  ok: $(cat "$WORK/out")"
+
+# --- 2. every populated host directory parses and correspends (CPR-E2C) ----
+SCANNED=0
+for d in "$SWAP_DIR"/*/; do
+    [ -f "$d/config.yaml" ] || continue
+    [ -f "$d/model-annotations.yaml" ] || fail "$(basename "$d") has config.yaml but no model-annotations.yaml"
+    run_check 0 "$(basename "$d") structure" \
+        --config "$d/config.yaml" --annotations "$d/model-annotations.yaml"
+    SCANNED=$((SCANNED + 1))
+done
+[ "$SCANNED" -ge 2 ] || fail "expected at least 2 populated host directories under $SWAP_DIR, scanned $SCANNED"
+
+# --- 3. mutation probes: each arm of the checker must be able to fail ------
+# Without these, a checker that returned 0 unconditionally would satisfy 1-2.
+MUT="$WORK/mut"
+mkdir -p "$MUT"
+
+good_config() {
+    printf 'healthCheckTimeout: 600\nmodels:\n  alpha:\n    cmd: >-\n      a.exe --model a.gguf\n    proxy: http://127.0.0.1:1\n  beta:\n    cmd: b.exe\n    proxy: http://127.0.0.1:2\ngroups:\n  heavy:\n    swap: true\n    members:\n      - beta\n' > "$1"
+}
+good_ann() {
+    printf 'alpha:\n  role: probe\nbeta:\n  role: probe\ngamma:\n  role: probe\n  retained: "still consulted"\n' > "$1"
+}
+
+good_config "$MUT/config.yaml"
+good_ann "$MUT/ann.yaml"
+BASE="--config $MUT/config.yaml --annotations $MUT/ann.yaml"
+
+# 3a. baseline passes with its true counts (classifier guard: a checker wired
+#     to always fail would satisfy 3b-3i and still be worthless).
+# shellcheck disable=SC2086
+run_check 0 "probe baseline" $BASE --expect-models 2 --expect-groups 1 --expect-annotations 3 --expect-retained 1
+
+# 3b. wrong expected model count
+# shellcheck disable=SC2086
+run_check 1 "probe model count" $BASE --expect-models 3
+
+# 3c. wrong expected group count
+# shellcheck disable=SC2086
+run_check 1 "probe group count" $BASE --expect-groups 2
+
+# 3d. wrong expected annotation count
+# shellcheck disable=SC2086
+run_check 1 "probe annotation count" $BASE --expect-annotations 4
+
+# 3e. wrong expected retained count
+# shellcheck disable=SC2086
+run_check 1 "probe retained count" $BASE --expect-retained 2
+
+# 3f. a model with no annotation
+good_ann "$MUT/ann.yaml"
+"$PY" - "$MUT/ann.yaml" <<'PYEOF' || fail "probe setup 3f failed"
+import sys
+p = sys.argv[1]
+t = open(p, encoding='utf-8').read().replace('beta:\n  role: probe\n', '')
+open(p, 'w', encoding='utf-8').write(t)
+PYEOF
+# shellcheck disable=SC2086
+run_check 1 "probe missing annotation" $BASE
+
+# 3g. an orphan annotation with no retained: reason
+printf 'alpha:\n  role: probe\nbeta:\n  role: probe\ngamma:\n  role: probe\n' > "$MUT/ann.yaml"
+# shellcheck disable=SC2086
+run_check 1 "probe orphan without retained" $BASE
+
+# 3h. an annotation entry with no role:
+printf 'alpha:\n  role: probe\nbeta:\n  notes: "no role"\n' > "$MUT/ann.yaml"
+# shellcheck disable=SC2086
+run_check 1 "probe annotation without role" $BASE
+
+# 3i. a group member that names no model (load smoke)
+good_ann "$MUT/ann.yaml"
+good_config "$MUT/config.yaml"
+printf 'healthCheckTimeout: 600\nmodels:\n  alpha:\n    cmd: a.exe\n    proxy: http://127.0.0.1:1\n  beta:\n    cmd: b.exe\n    proxy: http://127.0.0.1:2\ngroups:\n  heavy:\n    members:\n      - delta\n' > "$MUT/config.yaml"
+# shellcheck disable=SC2086
+run_check 1 "probe dangling group member" $BASE
+
+# 3j. a model with no proxy: (load smoke)
+printf 'models:\n  alpha:\n    cmd: a.exe\n  beta:\n    cmd: b.exe\n    proxy: http://127.0.0.1:2\n' > "$MUT/config.yaml"
+# shellcheck disable=SC2086
+run_check 1 "probe model without proxy" $BASE
+
+# 3k. duplicate key -> parse error (rc 2), never a silent last-wins read
+printf 'models:\n  alpha:\n    cmd: a.exe\n    proxy: p\n  alpha:\n    cmd: b.exe\n    proxy: p\n' > "$MUT/config.yaml"
+# shellcheck disable=SC2086
+run_check 2 "probe duplicate key" $BASE
+
+# 3l. ragged indentation -> parse error, not a partial read
+printf 'models:\n  alpha:\n    cmd: a.exe\n    proxy: p\n   beta:\n    cmd: b.exe\n' > "$MUT/config.yaml"
+# shellcheck disable=SC2086
+run_check 2 "probe ragged indent" $BASE
+
+# 3m. --absent must fire when the key is still there
+good_config "$MUT/config.yaml"
+# shellcheck disable=SC2086
+run_check 1 "probe absent key still present" $BASE --absent gamma
+
+# 3n. --require-text must fire when the text is missing
+# shellcheck disable=SC2086
+run_check 1 "probe required text missing" $BASE --require-text '<private-agent-project>'
+
+echo "PASS: test-config-yaml-structure ($SCANNED host directories parsed, 14 checker probes)"

--- a/tests/feature-86-win-llama-swap-server/test-gitignore-coverage.sh
+++ b/tests/feature-86-win-llama-swap-server/test-gitignore-coverage.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests: .gitignore
+# Tags: gitignore, git-check-ignore, migration-safety, layer:TL1, scope:common
+# scope:common despite the feature-86- dir: these ignore rules protect every future commit, not just the #86 migration, so this is permanent coverage.
+# Pins the three holes Commit 1 closes (*.exe / config.yaml.bak* / certs/), the symmetric guard that repo-tracked config is still NOT ignored, and -- because .gitignore is only advice -- what the index actually tracks. Rationale: detail plan 1-1 and 6-2.
+# Skips (exit 77) until llama-swap/rtx5070ti-128gb/config.yaml exists: the ignore rules and the config transfer ship in the same PR (commits 1-2), so the transferred config is the marker that the receiving-side work landed.
+# TL3 gap (what this test does NOT catch):
+# - a secret already pushed to a remote, or one living in a commit that is no longer at HEAD (the index is a snapshot, not the history)
+# - whether the real migration copy step ever put certs/ or a .bak inside the worktree at all
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh category: installer
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see
+# tests/feature-18-serverctl/test-repo-derivation.sh); export REPO=<path> to
+# point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+
+[ -f "$REPO/llama-swap/rtx5070ti-128gb/config.yaml" ] || { echo "SKIP: $REPO/llama-swap/rtx5070ti-128gb/config.yaml not found (implementation pending)"; exit 77; }
+[ -f "$REPO/.gitignore" ] || { echo "FAIL: $REPO/.gitignore not found" >&2; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "SKIP: git not on PATH"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --no-index on every call: without it `git check-ignore` reports a TRACKED path
+# as not-ignored regardless of the patterns, which would make case 4 (the
+# symmetric guard) pass vacuously and stop testing anything.
+ignored() { git -C "$REPO" check-ignore -q --no-index -- "$1"; }
+
+# --- 1. the llama-swap runtime binary never enters the repo ----------------
+# 23,930,368 bytes on the real host; the repo holds ops/config/decisions only.
+ignored "llama-swap.exe" || fail "'llama-swap.exe' is NOT ignored -- .gitignore lacks an *.exe rule"
+ignored "install/win/some-tool.exe" || fail "'install/win/some-tool.exe' is NOT ignored -- the *.exe rule is anchored to the repo root instead of matching at any depth"
+
+# --- 2. the suffix-match trap (the bug this case exists for) ---------------
+# The pre-existing `*.bak` is a SUFFIX match, so it does not match a name whose
+# timestamp comes after `.bak`. The migration source carries 8 such files.
+ignored "config.yaml.bak.20260715_022745" || fail "'config.yaml.bak.20260715_022745' is NOT ignored -- a bare '*.bak' rule does not match a timestamped backup; a 'config.yaml.bak*' prefix glob is required"
+ignored "config.yaml.bak" || fail "'config.yaml.bak' is NOT ignored -- the plain suffix form regressed"
+
+# --- 3. private keys and certs never enter the repo (security) -------------
+ignored "certs/cert.pem" || fail "'certs/cert.pem' is NOT ignored -- .gitignore lacks a certs/ rule"
+ignored "certs/key.pem" || fail "'certs/key.pem' is NOT ignored -- the private key half of the pair is unprotected"
+
+# --- 4. CPR-ORTH symmetric guard: the tracked config is NOT ignored --------
+# Cases 1-3 all pass under a catch-all like '*'. This is the counterpart verdict
+# that makes them meaningful: an over-broad rule must fail here.
+for keep in \
+    "llama-swap/rtx5070ti-128gb/config.yaml" \
+    "llama-swap/rtx5070ti-128gb/model-annotations.yaml" \
+    "llama-swap/m5-max-128gb/config.yaml" \
+    "install.ps1" \
+    "docs/infrastructure.md"
+do
+    if ignored "$keep"; then
+        fail "'$keep' IS ignored -- an over-broad .gitignore rule now hides a tracked source file"
+    fi
+done
+
+# --- 5. and nothing sensitive is actually tracked --------------------------
+# .gitignore is advice; `git add -f` overrides it, and a file added before the
+# rule existed stays tracked forever afterwards. Cases 1-3 cannot see either.
+# This asks the index itself, which is the only authority on what ships.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+git -C "$REPO" ls-files > "$WORK/tracked" 2>"$WORK/err" || { cat "$WORK/err" >&2; fail "git ls-files failed in $REPO"; }
+[ -s "$WORK/tracked" ] || fail "git ls-files listed nothing in $REPO -- not a checkout, so case 5 would pass vacuously"
+
+grep -Fq -- 'install.ps1' "$WORK/tracked"
+rc=$?
+[ "$rc" -le 1 ] || fail "grep exited $rc reading the tracked-file list"
+[ "$rc" -eq 0 ] || fail "install.ps1 is not tracked -- the file list is not the one this test means to scan"
+
+# One pattern per class of thing that must never reach a remote: build output,
+# any key or certificate material, the timestamped config backups, and model
+# weights. Matched against paths, so a nested certs/ directory is caught too.
+FORBIDDEN='\.exe$|\.gguf$|(^|/)certs/|\.bak|\.pem$|\.key$|\.pfx$|\.p12$'
+
+scan_tracked() {
+    grep -nE -- "$FORBIDDEN" "$1" > "$WORK/hits"
+    _rc=$?
+    [ "$_rc" -le 1 ] || fail "grep exited $_rc scanning $1 -- cannot conclude nothing sensitive is tracked"
+    return "$_rc"
+}
+
+if scan_tracked "$WORK/tracked"; then
+    fail "sensitive path(s) are tracked despite .gitignore (force-added, or added before the rule): $(tr '\n' ' ' < "$WORK/hits")"
+fi
+
+# 5b. the scan must be able to fire, or its silence means nothing.
+printf 'install.ps1\ncerts/key.pem\nllama-swap/rtx5070ti-128gb/config.yaml.bak.20260715_022745\nC:/tools/llama-swap.exe\n' > "$WORK/probe"
+scan_tracked "$WORK/probe" || fail "the tracked-file scan missed an obvious key/backup/binary path -- case 5 cannot detect a regression"
+PROBE_HITS="$(wc -l < "$WORK/hits" | tr -d ' ')"
+[ "$PROBE_HITS" -eq 3 ] || fail "the tracked-file scan matched $PROBE_HITS of 3 planted offenders (and must not match install.ps1)"
+
+echo "PASS: test-gitignore-coverage ($(wc -l < "$WORK/tracked" | tr -d ' ') tracked paths scanned)"

--- a/tests/feature-86-win-llama-swap-server/test-infrastructure-paths-sync.sh
+++ b/tests/feature-86-win-llama-swap-server/test-infrastructure-paths-sync.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Tests: install.ps1, docs/infrastructure.md
+# Tags: infrastructure, docs-sync, ssot, paths, windows, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: the code-is-authority / docs-mirror contract is permanent, so this file must outlive issue #86.
+# install.ps1 owns the Windows path literals; docs/infrastructure.md mirrors them on lines carrying the '<!-- synced-from: install.ps1 -->' marker. Contract: detail plan 5-1 (C11), test spec 6-4.
+# Skips (exit 77) until install.ps1 defines $CertDir (implementation pending). Once it does, a missing marker line or an unextractable assignment is a FAILURE, never a pass-by-finding-nothing.
+# TL3 gap (what this test does NOT catch):
+# - whether the directories these literals name exist on the real Windows host
+# - whether NSSM actually burned the same $ConfigPath into AppParameters (only `nssm get` on the host shows that)
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh category: installer
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see
+# tests/feature-18-serverctl/test-repo-derivation.sh); export REPO=<path> to
+# point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+INSTALLER="$REPO/install.ps1"
+DOC="$REPO/docs/infrastructure.md"
+MARKER='<!-- synced-from: install.ps1 -->'
+
+[ -f "$INSTALLER" ] || { echo "SKIP: $INSTALLER not found (implementation pending)"; exit 77; }
+grep -q '\$CertDir' "$INSTALLER" || { echo "SKIP: $INSTALLER does not define \$CertDir yet (server role pending)"; exit 77; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$DOC" ] || fail "$DOC not found, but install.ps1 already owns the server-role path literals"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Marker lines are the only place the docs may restate a code-owned value.
+grep -F "$MARKER" "$DOC" > "$WORK/marker-lines" || true
+MARKER_N="$(wc -l < "$WORK/marker-lines" | tr -d ' ')"
+[ "$MARKER_N" -ge 3 ] || fail "expected at least 3 lines carrying '$MARKER' in ${DOC#"$REPO/"}, found $MARKER_N -- the docs side of the C11 contract is missing"
+
+# Extract `$Name = '<literal>'` / "<literal>" from the installer. Anything else
+# (an unquoted expression, a renamed variable) yields the empty string and fails
+# below rather than silently skipping the assertion.
+extract_assign() {
+    sed -n "s/^[[:space:]]*\\\$$1[[:space:]]*=[[:space:]]*['\"]\\(.*\\)['\"][[:space:]]*\$/\\1/p" "$INSTALLER" | head -n 1
+}
+
+assert_mirrored() {
+    _name="$1"; _value="$2"
+    [ -n "$_value" ] || fail "could not extract \$$_name from ${INSTALLER#"$REPO/"} -- the assignment is missing or no longer a quoted literal"
+    if ! grep -Fq -- "$_value" "$WORK/marker-lines"; then
+        fail "\$$_name = '$_value' does not appear on any '$MARKER' line in ${DOC#"$REPO/"} -- code and docs drifted"
+    fi
+    echo "  ok: \$$_name -> $_value"
+}
+
+# --- 1. $CertDir and $RuntimeDir are plain literals ------------------------
+CERT_DIR="$(extract_assign CertDir)"
+RUNTIME_DIR="$(extract_assign RuntimeDir)"
+assert_mirrored CertDir "$CERT_DIR"
+assert_mirrored RuntimeDir "$RUNTIME_DIR"
+
+# --- 2. $ConfigPath is an expression rooted at $RepoRoot -------------------
+# Compare on the $RepoRoot-stripped relative part only; the absolute prefix is a
+# property of the checkout, not of the contract.
+CONFIG_RAW="$(extract_assign ConfigPath)"
+[ -n "$CONFIG_RAW" ] || fail "could not extract \$ConfigPath from ${INSTALLER#"$REPO/"}"
+case "$CONFIG_RAW" in
+    *'$RepoRoot'*) ;;
+    *) fail "\$ConfigPath = '$CONFIG_RAW' is not rooted at \$RepoRoot -- it must be derived from the checkout, not hardcoded" ;;
+esac
+CONFIG_REL="${CONFIG_RAW#*\$RepoRoot}"
+CONFIG_REL="${CONFIG_REL#\\}"
+CONFIG_REL="${CONFIG_REL#/}"
+[ -n "$CONFIG_REL" ] || fail "\$ConfigPath has no path part after \$RepoRoot: '$CONFIG_RAW'"
+assert_mirrored ConfigPath "$CONFIG_REL"
+
+# --- 3. the relative part really is the migrated config --------------------
+# Guards against a mirror that matches because both sides were changed to
+# something meaningless (e.g. an empty-ish fragment that greps everywhere).
+case "$CONFIG_REL" in
+    *rtx5070ti-128gb*config.yaml) ;;
+    *) fail "\$ConfigPath relative part '$CONFIG_REL' does not point at the rtx5070ti-128gb config.yaml" ;;
+esac
+
+# --- 4. mutation probe: the mirror check must reject a drifted doc ---------
+# Runs assert_mirrored's comparison against a marker set that deliberately lacks
+# the value, so a grep that always succeeds cannot hide behind cases 1-3.
+printf '| some row | no value here | %s\n' "$MARKER" > "$WORK/probe-lines"
+if grep -Fq -- "$CERT_DIR" "$WORK/probe-lines"; then
+    fail "mutation probe: a marker line without the value still matched \$CertDir -- the comparison is vacuous"
+fi
+
+# --- 5. no doc restates a code-owned value OFF a marker line ---------------
+# CPR-SSOT: an unmarked copy is a second definition point that no test guards,
+# and it is the copy that goes stale. Scanned across every doc, not just
+# infrastructure.md -- a value pasted into tuning.md drifts exactly as easily.
+# `grep -v` on a non-match returns 1, so the rc of each stage is checked rather
+# than swallowed by `|| true`; an rc above 1 is a broken scan, not a clean one.
+DOCS=""
+DOC_N=0
+for d in "$DOC" "$REPO"/docs/*.md "$REPO"/README.md; do
+    [ -f "$d" ] || continue
+    case " $DOCS " in *" $d "*) continue ;; esac
+    DOCS="$DOCS $d"
+    DOC_N=$((DOC_N + 1))
+done
+[ "$DOC_N" -ge 1 ] || fail "found no markdown to scan under $REPO/docs -- case 5 would pass vacuously"
+
+unmarked_hits() {
+    _file="$1"; _value="$2"
+    grep -Fn -- "$_value" "$_file" > "$WORK/raw"
+    _rc=$?
+    [ "$_rc" -le 1 ] || fail "grep exited $_rc scanning ${_file#"$REPO/"} for '$_value'"
+    [ "$_rc" -eq 0 ] || return 1
+    grep -Fv -- "$MARKER" "$WORK/raw" > "$WORK/unmarked"
+    _rc=$?
+    [ "$_rc" -le 1 ] || fail "grep exited $_rc filtering marker lines for '$_value'"
+    return "$_rc"
+}
+
+for d in $DOCS; do
+    for v in "$CERT_DIR" "$RUNTIME_DIR"; do
+        if unmarked_hits "$d" "$v"; then
+            fail "value '$v' appears in ${d#"$REPO/"} on line(s) without the sync marker: $(tr '\n' ' ' < "$WORK/unmarked")"
+        fi
+    done
+done
+
+# $ConfigPath's relative part is checked in infrastructure.md alone: unlike the
+# two absolute directories, naming llama-swap/<host>/config.yaml in prose is
+# ordinary writing, not a restatement of a code-owned literal.
+if unmarked_hits "$DOC" "$CONFIG_REL"; then
+    fail "\$ConfigPath's path part '$CONFIG_REL' appears in ${DOC#"$REPO/"} without the sync marker: $(tr '\n' ' ' < "$WORK/unmarked")"
+fi
+
+# 5b. the unmarked-copy scan must be able to fire.
+printf '| runtime | %s | (no marker on this row)\n' "$RUNTIME_DIR" > "$WORK/dup-probe"
+unmarked_hits "$WORK/dup-probe" "$RUNTIME_DIR" || fail "the unmarked-copy scan missed a planted duplicate of '$RUNTIME_DIR' -- case 5 cannot detect a regression"
+
+# 5c. and it must NOT fire on a properly marked line (classifier guard).
+printf '| runtime | %s | %s\n' "$RUNTIME_DIR" "$MARKER" > "$WORK/ok-probe"
+if unmarked_hits "$WORK/ok-probe" "$RUNTIME_DIR"; then
+    fail "the unmarked-copy scan flagged a correctly marked line -- it would make every compliant doc fail"
+fi
+
+# --- 6. the co-location assumption stays dead (detail plan 4-7) ------------
+# The old design kept config.yaml inside the runtime directory, which is what
+# made llama-swap-service.ps1 able to default its paths. A doc that still spells
+# it that way would send an operator to a file the installer never writes.
+colocated() {
+    grep -F -- "$RUNTIME_DIR" "$1" > "$WORK/rt"
+    _rc=$?
+    [ "$_rc" -le 1 ] || fail "grep exited $_rc scanning ${1#"$REPO/"} for the runtime directory"
+    [ "$_rc" -eq 0 ] || return 1
+    grep -E 'config\.yaml|model-annotations\.yaml' "$WORK/rt" > "$WORK/colo"
+    _rc=$?
+    [ "$_rc" -le 1 ] || fail "grep exited $_rc checking for the co-location spelling"
+    return "$_rc"
+}
+
+for d in $DOCS; do
+    if colocated "$d"; then
+        fail "${d#"$REPO/"} places a config file under the runtime directory '$RUNTIME_DIR': $(tr '\n' ' ' < "$WORK/colo") -- the config lives in the checkout, not beside the exe"
+    fi
+done
+
+# 6b. the co-location scan must be able to fire.
+printf '%s\\config.yaml\n' "$RUNTIME_DIR" > "$WORK/colo-probe"
+colocated "$WORK/colo-probe" || fail "the co-location scan missed a planted '$RUNTIME_DIR\\config.yaml' -- case 6 cannot detect a regression"
+
+echo "PASS: test-infrastructure-paths-sync ($MARKER_N marker line(s), $DOC_N doc(s) scanned)"

--- a/tests/feature-86-win-llama-swap-server/test-install-driver-skip-profile.sh
+++ b/tests/feature-86-win-llama-swap-server/test-install-driver-skip-profile.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Tests: tests/feature-86-win-llama-swap-server/test-install-win-server.sh, tests/feature-86-win-llama-swap-server/lib/assert-pester-profile.sh
+# Tags: installer, windows, pester, driver, skip-profile, meta-test, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: "a skip is only acceptable while the subject is absent" is a permanent property of the driver, not #86 arithmetic.
+# The driver decides between two states, and this file proves both. Subject absent -> the whole run is a clean skip (77). Subject present -> a skipped Pester case is a failure, because Invoke-Pester reports "0 failed" for a suite that ran nothing.
+# Runs the driver only against throwaway fixtures, never against the real checkout, and never reaches pwsh: every case here stops at the driver's own file gate.
+# TL3 gap (what this test does NOT catch):
+# - whether Pester's SkippedCount means what this rule assumes on the operator's Pester build
+# - whether the driver's pwsh invocation actually emits the CCLL_PROFILE line (only a real pwsh run shows that; the sibling driver run under RUN_TL3 does)
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh categories: installer, pwsh-required
+set -u
+
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+DRIVER="$HERE/test-install-win-server.sh"
+PROFILE="$HERE/lib/assert-pester-profile.sh"
+
+[ -f "$DRIVER" ]  || { echo "FAIL: $DRIVER not found" >&2; exit 1; }
+[ -f "$PROFILE" ] || { echo "FAIL: $PROFILE not found" >&2; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- 1. the rule, both directions -----------------------------------------
+# expect_profile <want-rc> <label> <args...>
+expect_profile() {
+    _want="$1"; _label="$2"; shift 2
+    bash "$PROFILE" "$@" > "$WORK/p.out" 2>&1
+    _rc=$?
+    if [ "$_rc" -ne "$_want" ]; then
+        cat "$WORK/p.out" >&2
+        fail "$_label: assert-pester-profile exited $_rc, expected $_want"
+    fi
+}
+
+# 1a. the healthy profile passes (classifier guard: a rule wired to always fail
+#     would satisfy 1b-1d and be worthless).
+expect_profile 0 "healthy run" --total 40 --failed 0 --skipped 0
+
+# 1b. the whole point of C9: green-with-skips is not green.
+expect_profile 1 "one skipped case" --total 40 --failed 0 --skipped 1
+expect_profile 1 "every case skipped" --total 40 --failed 0 --skipped 40
+
+# 1c. an actual failure still fails (the skip rule did not replace it).
+expect_profile 1 "failed case" --total 40 --failed 1 --skipped 0
+
+# 1d. a run that discovered nothing is the other silent green.
+expect_profile 1 "no cases discovered" --total 0 --failed 0 --skipped 0
+
+# 1e. malformed input is a usage error (2), never a silent pass. Without this a
+#     driver that lost its counts would call the helper with empty strings and
+#     an integer comparison would abort mid-script with a nonzero-but-untyped rc.
+expect_profile 2 "missing --total" --failed 0 --skipped 0
+expect_profile 2 "non-numeric --skipped" --total 4 --failed 0 --skipped "many"
+expect_profile 2 "unknown flag" --total 4 --failed 0 --skipped 0 --bogus
+
+# 1f. the skip message must name the reason, or the operator cannot act on it.
+bash "$PROFILE" --total 9 --failed 0 --skipped 9 --context "probe suite" > "$WORK/msg" 2>&1
+grep -Fq -- 'probe suite' "$WORK/msg"
+rc=$?
+[ "$rc" -le 1 ] || fail "grep exited $rc reading the skip message"
+[ "$rc" -eq 0 ] || fail "the skip failure never names its --context, so the operator cannot tell which suite skipped"
+
+# --- 2. the driver uses the rule (it is not dead code) ---------------------
+grep -Fq -- 'assert-pester-profile.sh' "$DRIVER"
+rc=$?
+[ "$rc" -le 1 ] || fail "grep exited $rc reading $DRIVER"
+[ "$rc" -eq 0 ] || fail "test-install-win-server.sh no longer references lib/assert-pester-profile.sh - the skip profile is enforced nowhere"
+
+grep -Fq -- 'SkippedCount' "$DRIVER"
+rc=$?
+[ "$rc" -le 1 ] || fail "grep exited $rc reading $DRIVER"
+[ "$rc" -eq 0 ] || fail "test-install-win-server.sh no longer reads SkippedCount out of Invoke-Pester, so the rule is fed nothing"
+
+# --- 3. subject absent -> a clean skip, not a pass -------------------------
+EMPTY="$WORK/empty-repo"
+mkdir -p "$EMPTY"
+REPO="$EMPTY" bash "$DRIVER" > "$WORK/d.out" 2>&1
+rc=$?
+[ "$rc" -eq 77 ] || { cat "$WORK/d.out" >&2; fail "against a checkout with no installer the driver exited $rc, expected 77 (skip)"; }
+grep -Fq -- 'implementation pending' "$WORK/d.out"
+g=$?
+[ "$g" -le 1 ] || fail "grep exited $g reading the driver output"
+[ "$g" -eq 0 ] || fail "the driver skipped without saying the implementation is pending - a silent 77 is indistinguishable from a broken gate"
+
+# --- 4. the gate covers every file the suites read (CPR-ORTH) --------------
+# One file missing at a time. Without this, dropping a path from the gate would
+# let the suites run against a half-present checkout and report Skipped cases,
+# which case 1b then blames on a broken -Skip: condition instead.
+GATED="install/win/lib/roles.ps1 install/win/lib/nssm-args.ps1 install/win/lib/native.ps1 install/win/llama-swap-service.ps1 install/win/certs.ps1 install/win/mkcert.ps1 install.ps1"
+
+CHECKED=0
+for missing in $GATED; do
+    STUB="$WORK/stub"
+    rm -rf "$STUB"
+    mkdir -p "$STUB/install/win/lib"
+    for f in $GATED; do
+        [ "$f" = "$missing" ] && continue
+        mkdir -p "$STUB/$(dirname -- "$f")"
+        printf '# stub\n' > "$STUB/$f"
+    done
+    REPO="$STUB" bash "$DRIVER" > "$WORK/d.out" 2>&1
+    rc=$?
+    [ "$rc" -eq 77 ] || { cat "$WORK/d.out" >&2; fail "with only $missing missing the driver exited $rc, expected 77 - that path is not in the driver's gate"; }
+    grep -Fq -- "$missing" "$WORK/d.out"
+    g=$?
+    [ "$g" -le 1 ] || fail "grep exited $g reading the driver output"
+    [ "$g" -eq 0 ] || fail "the driver skipped for a missing $missing without naming it"
+    CHECKED=$((CHECKED + 1))
+done
+[ "$CHECKED" -eq 7 ] || fail "expected to probe 7 gated paths, probed $CHECKED"
+
+# --- 5. the driver refuses to run with no suite beside it ------------------
+# A rename that orphans the *.Tests.ps1 files must fail loudly; "found nothing to
+# run" is the third silent-green shape, next to "ran nothing" and "skipped all".
+SOLO="$WORK/solo"
+mkdir -p "$SOLO/lib"
+cp "$DRIVER" "$SOLO/"
+cp "$PROFILE" "$SOLO/lib/"
+mkdir -p "$WORK/full/install/win/lib"
+for f in $GATED; do
+    mkdir -p "$WORK/full/$(dirname -- "$f")"
+    printf '# stub\n' > "$WORK/full/$f"
+done
+REPO="$WORK/full" bash "$SOLO/$(basename -- "$DRIVER")" > "$WORK/d.out" 2>&1
+rc=$?
+[ "$rc" -eq 1 ] || { cat "$WORK/d.out" >&2; fail "with no *.Tests.ps1 beside it the driver exited $rc, expected 1 (hard failure, not a skip and not a pass)"; }
+
+echo "PASS: test-install-driver-skip-profile (8 rule probes, 7 gated paths, 2 driver states)"

--- a/tests/feature-86-win-llama-swap-server/test-install-win-server.sh
+++ b/tests/feature-86-win-llama-swap-server/test-install-win-server.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Tests: install.ps1, install/win/lib/roles.ps1, install/win/lib/nssm-args.ps1, install/win/lib/native.ps1, install/win/llama-swap-service.ps1, install/win/certs.ps1
+# Tags: installer, windows, pwsh-required, pester, layer:TL2, scope:common
+# scope:common despite the feature-86- dir: it drives permanent coverage, so it must survive the retirement sweep with the suites it runs.
+# Bash driver for every *.Tests.ps1 in this directory -- makes the Pester suites reachable from the `bash tests/.../test-*.sh` convention and owns the two things Pester cannot express: skip gating (exit 77) and the skip profile (lib/assert-pester-profile.sh). Mirrors tests/feature-18-serverctl/test-code-ccgw-windows.sh.
+# The suites only dot-source install/win/lib/*.ps1 (function definitions only) and read the rest through the AST, so running them touches neither NSSM nor any service.
+# Either the implementation is absent and every suite is gated off here (77), or it is present and a skipped case is a failure -- there is no third state where a skip is merely informational.
+# TL3 gap (what this driver does NOT catch):
+# - whether the installer, run for real on the Windows host, registers and starts both services
+# - whether nssm/caddy/mkcert are installable there at all
+# - closest-to-action mitigation: WORKFLOW_USER_VERIFIED preflight via bin/check-verification-gate.sh categories: installer, pwsh-required
+set -u
+
+# REPO is derived from $0's logical location (no symlink target resolution - see
+# tests/feature-18-serverctl/test-repo-derivation.sh); export REPO=<path> to
+# point at another checkout.
+REPO="${REPO:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+PROFILE="$HERE/lib/assert-pester-profile.sh"
+
+[ -f "$PROFILE" ] || { echo "FAIL: $PROFILE not found" >&2; exit 1; }
+
+SUITES=""
+COUNT=0
+for s in "$HERE"/*.Tests.ps1; do
+    [ -f "$s" ] || continue
+    SUITES="$SUITES $s"
+    COUNT=$((COUNT + 1))
+done
+[ "$COUNT" -gt 0 ] || { echo "FAIL: no *.Tests.ps1 beside $0" >&2; exit 1; }
+
+# The gate is "every file any suite reads", not just the libs: a suite whose
+# subject is missing would report Skipped, and the profile check below refuses
+# to call that a pass. Missing implementation is a skip for the whole driver.
+for f in \
+    install/win/lib/roles.ps1 \
+    install/win/lib/nssm-args.ps1 \
+    install/win/lib/native.ps1 \
+    install/win/llama-swap-service.ps1 \
+    install/win/certs.ps1 \
+    install/win/mkcert.ps1 \
+    install.ps1
+do
+    [ -f "$REPO/$f" ] || { echo "SKIP: $REPO/$f not found (implementation pending)"; exit 77; }
+done
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT) ;;
+    *) echo "SKIP: not a Windows host - the server-role installer suites are Windows-only"; exit 77 ;;
+esac
+
+command -v pwsh >/dev/null 2>&1 || { echo "SKIP: pwsh not on PATH - install PowerShell 7+ and Pester 5 to run these suites"; exit 77; }
+
+if ! pwsh -NoProfile -Command 'if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version.Major -ge 5 })) { exit 1 }' >/dev/null 2>&1; then
+    echo "SKIP: Pester 5+ not installed for this pwsh."
+    echo "      Install it with: pwsh -NoProfile -Command \"Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser -Force\""
+    exit 77
+fi
+
+# Under Git Bash the paths above are POSIX (/c/git/...), which pwsh resolves
+# against the current drive as C:\c\git\... -- Pester then finds no test file.
+# Hand pwsh real Windows paths (same trap documented in test-code-ccgw-windows.sh).
+to_win() {
+    if command -v cygpath >/dev/null 2>&1; then cygpath -m -- "$1"; else printf '%s' "$1"; fi
+}
+
+SUITE_LIST=""
+for s in $SUITES; do
+    SUITE_LIST="$SUITE_LIST,'$(to_win "$s")'"
+done
+SUITE_LIST="${SUITE_LIST#,}"
+
+# The suites derive their own repo root from $PSScriptRoot, which ignores a $REPO
+# override and would then check a different checkout than the gates above. Hand
+# them the same root, in the Windows form pwsh can resolve.
+CCLL_REPO="$(to_win "$REPO")"
+export CCLL_REPO
+
+# Counts, not just the exit status: Invoke-Pester returns 0 even when cases fail,
+# and returns 0 just as happily when every case was skipped.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pwsh -NoProfile -Command "\$ErrorActionPreference = 'Stop'; \$r = \$null; try { \$r = Invoke-Pester -Path @($SUITE_LIST) -Output Detailed -PassThru } catch { [Console]::Error.WriteLine('Invoke-Pester failed: ' + \$_); exit 99 }; if (\$null -eq \$r) { [Console]::Error.WriteLine('Invoke-Pester returned nothing'); exit 98 }; [Console]::Out.WriteLine(\"CCLL_PROFILE total=\$(\$r.TotalCount) failed=\$(\$r.FailedCount) skipped=\$(\$r.SkippedCount)\"); exit 0" | tee "$WORK/pester.out"
+RC="${PIPESTATUS[0]}"
+
+if [ "$RC" -ne 0 ]; then
+    echo "FAIL: pwsh exited $RC before reporting counts" >&2
+    exit "$RC"
+fi
+
+PROFILE_LINE="$(sed -n 's/^CCLL_PROFILE //p' "$WORK/pester.out" | tail -n 1)"
+[ -n "$PROFILE_LINE" ] || { echo "FAIL: Invoke-Pester produced no CCLL_PROFILE line - the run did not complete" >&2; exit 1; }
+
+TOTAL=""; FAILED=""; SKIPPED=""
+for kv in $PROFILE_LINE; do
+    case "$kv" in
+        total=*)   TOTAL="${kv#total=}" ;;
+        failed=*)  FAILED="${kv#failed=}" ;;
+        skipped=*) SKIPPED="${kv#skipped=}" ;;
+    esac
+done
+
+bash "$PROFILE" --total "$TOTAL" --failed "$FAILED" --skipped "$SKIPPED" \
+    --context "the $COUNT Pester suite(s) beside $(basename -- "$0")" || exit 1
+
+echo "PASS: test-install-win-server ($COUNT suite(s), $TOTAL cases, 0 failed, 0 skipped)"


### PR DESCRIPTION
## Summary
- Adds Windows support for the RTX 5070 Ti / 128 GB host: `install.ps1 -Server`, `install/win/*.ps1` (NSSM services, a Caddy TLS front via mkcert), and `rtx5070ti-128gb/` config + annotations as a second host directory.
- Merges in a previously-separate, not-yet-public repo that held this host's setup, so it can share history, docs conventions, and the existing `<chip>-<memory>` host-directory layout with the Mac server.
- Adds a root `LICENSE` (MIT) and Windows coverage across `docs/architecture.md`, `docs/ops.md`, `docs/tuning.md`, `docs/infrastructure.md`, and the top-level and per-host READMEs. The prior repo's optimization history is absorbed into `docs/history.md`.
- Records two accepted-risk security decisions in `docs/history.md`: the TLS proxy binding unauthenticated on all interfaces, and the Windows services running as LocalSystem against checkout-resident config -- both scoped to the current single-operator home-LAN deployment, with hardening deferred until the threat model changes.

## Test plan
- [x] The new Windows-server feature test suite under `tests/` (Bash + Pester) passes locally
- [x] Outbound scanner clean across all changed files (no blocklist / secret hits)
- [x] Manual review confirmed no plaintext confidential or personal identifiers remain in the diff

Closes #86